### PR TITLE
fzfの挙動変更、fish設定追加

### DIFF
--- a/.bin/deploy.sh
+++ b/.bin/deploy.sh
@@ -124,6 +124,7 @@ fi
 
 # fish settings
 ln -snfv ~/dotfiles/.config/fish/config.fish ~/.config/fish/config.fish
+ln -snfv ~/dotfiles/.config/fish/functions/fish_user_key_bindings.fish ~/.config/fish/functions/fish_user_key_bindings.fish
 
 echo "alacritty setting"
 if [ ! -d ~/.config/alacritty ]; then

--- a/.bin/deploy.sh
+++ b/.bin/deploy.sh
@@ -119,6 +119,7 @@ fi
 if [ ! -d ~/.config/fish ]; then
   mkdir -p ~/.config/fish/
   touch ~/.config/fish/config.fish
+  touch ~/.config/fish/functions/fish_user_key_bindings.fish
   fish fish_plugin_setup.fish
 fi
 

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -11,11 +11,20 @@ set -x PATH $PYENV_ROOT/bin $PATH
 set -x PATH $HOME/.cargo/bin $PATH
 
 # set exa alias
-alias ls='exa --icons'
+if type -q test exa
+  alias ls='exa --icons'
+end
 
 # set bat alias
-alias cat='bat'
-alias ps='procs'
+if type -q bat 
+  alias cat='bat'
+end
+
+# set procs alias
+if type -q procs
+  alias ps='procs'
+end
+
 # set poetry path
 # set -U PATH $HOME/.poetry/env $PATH
 

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -50,6 +50,17 @@ export TERM=xterm-256color
 # set startship
 #starship init fish | source
 
+function fzf-checkout-branch
+    set -l branchname (
+        env FZF_DEFAULT_COMMAND='git --no-pager branch -a | grep -v HEAD | sed -e "s/^.* //g"' \
+            fzf --height 70% --prompt "BRANCH NAME>" \
+                --preview "git --no-pager log -20 --color=always {}"
+    )
+    if test -n "$branchname"
+        git checkout (echo "$branchname"| sed "s#remotes/[^/]*/##")
+    end
+end
+
 function reload
   exec fish
 end

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -61,6 +61,18 @@ function fzf-checkout-branch
     end
 end
 
+function fzf-docker-continer-name-select
+    commandline -i (env FZF_DEFAULT_COMMAND="docker ps -a --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}}\t{{.Ports}}\t{{.Networks}}'" \
+        fzf --no-sort --height 80% --bind='p:toggle-preview' --preview-window=down:70% \
+            --preview '
+                set -l containername (echo {} | awk -F " " \'{print $2}\');
+                if test "$containername" != "ID"
+                    docker logs --tail 300 $containername
+                end
+            ' | \
+        awk -F " " '{print $2}')
+end
+
 function reload
   exec fish
 end

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -39,6 +39,7 @@ set __fish_git_prompt_color_branch yellow
 set -x PATH ~/.fzf/bin $PATH
 set -x FZF_LEGACY_KEYBINDINGS 0
 set -x FZF_REVERSE_ISEARCH_OPTS "--height=50%"
+set -x FZF_DEFAULT_COMMAND 'rg --files --hidden --follow --glob "!.git/*"'
 
 # set GO PATH
 set -x GOPATH $HOME/go

--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -1,0 +1,4 @@
+function fish_user_key_bindings
+  bind \cd fzf-docker-continer-name-select
+  fzf_key_bindings
+end

--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -1,4 +1,7 @@
 function fish_user_key_bindings
-  bind \cd fzf-docker-continer-name-select
+  # Ctrl + y を潰す理由 
+  # 貼り付け。ctrl+wなどで一気に削除された部分を貼り付けられる。
+  # マウスやtmuxのコピーモードで代用できるので潰す優先度は高い。
+  bind \cy fzf-docker-continer-name-select
   fzf_key_bindings
 end

--- a/.gitconfig
+++ b/.gitconfig
@@ -7,6 +7,9 @@
   autocrlf = false
   safecrlf = true
 
+[alias]
+  preview = !fish -c "fzf-checkout-branch"
+
 [merge]
   ff = false
 


### PR DESCRIPTION
# PR の概要
- Close #67 
- Close #68 

- Ctrl + yでdockerのlogsのpreviewを確認しながら行えるコマンドの追加
- `git preview` でgitのブランチのコミットログを見つつチェックアウト出来るエイリアスの追加

## 補足
- 補足事項があれば入力してください。
- 例): データが0件のときの処理は入れていないなど。