### PR TITLE
nvim-colorizer.lua導入 

### DIFF
--- a/.config/nvim/dein.toml
+++ b/.config/nvim/dein.toml
@@ -390,7 +390,13 @@ nnoremap <silent> vs :terminal<cr>
 
 # フロントエンド周り
 [[plugins]]
-repo = 'gko/vim-coloresque'
+repo = 'norcalli/nvim-colorizer.lua'
+hook_add = '''
+lua << EOF
+  require'colorizer'.setup()
+EOF
+'''
+
 # フロントエンド周り
 
 # git関連


### PR DESCRIPTION
# PR の概要
- カラーレスキューのreplace
- 以下を導入することに
- https://github.com/norcalli/nvim-colorizer.lua 

![demo](https://raw.githubusercontent.com/norcalli/github-assets/master/nvim-colorizer.lua-demo-short.gif)

## 補足
- 補足事項があれば入力してください。
- 例): データが0件のときの処理は入れていないなど。