### PR TITLE
feat(fish): add mise activation to fish config

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -85,3 +85,4 @@ starship init fish | source
 set -gx VOLTA_HOME "$HOME/.volta"
 set -gx PATH "$VOLTA_HOME/bin" $PATH
 
+~/.local/bin/mise activate fish | source


### PR DESCRIPTION
## [optional body]
Added a command to activate mise in the fish shell configuration. This ensures that mise is properly initialized whenever a new fish shell session is started.
## [optional footer(s)]