### PR TITLE
fix(fish): remove redundant newline in key bindings

### DIFF
--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -37,7 +37,6 @@ function fish_user_key_bindings
     command find -L \$dir -mindepth 1 \\( -path \$dir'*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
     -o -type f -print \
     -o -type d -print \
-
     -o -type l -print 2> /dev/null | sed 's@^\./@@'"
 
     test -n "$SKIM_TMUX_HEIGHT"; or set SKIM_TMUX_HEIGHT 40%


### PR DESCRIPTION

## [optional body]
Removed an unnecessary newline in the fish_user_key_bindings function. This change improves the function will be fine
## [optional footer(s)]
<!--
フッターにはコミットログの内容に関連するURLを載せましょう。
例えば、チケットのURLやコミットする前に議論を重ねたIssueやチケット、slackのリンクなどが挙げられます。
https://www.praha-inc.com/lab/posts/commit-message
-->
