### PR TITLE
Fix/ddc lsp setting

### DIFF
--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -84,8 +84,18 @@ function CopilotChatBuffer()
   end
 end
 -- 既存のキーマッピング
-vim.keymap.set('n', '<leader>ct', '<cmd>CopilotChatToggle<cr>', { noremap = true, silent = true, desc = "Toggle Copilot Chat" })
+-- CopilotChatToggleのキーマッピングを変更
+vim.keymap.set('n', '<leader>cT', '<cmd>CopilotChatToggle<cr>', { noremap = true, silent = true, desc = "Toggle Copilot Chat" })
+
+-- Copilot Chat Commitのキーマッピング
 vim.keymap.set('n', '<leader>cm', '<cmd>CopilotChatCommit<cr>', { noremap = true, silent = true, desc = "Copilot Chat Commit" })
+
+-- テストを提案するコマンドのキーマッピング
+vim.keymap.set('n', '<leader>ct', function() require('CopilotChat').ask(config.prompts.Tests.prompt) end, { noremap = true, silent = true, desc = "Copilot Suggest Tests" })
+vim.keymap.set('v', '<leader>ct', function() require('CopilotChat').ask(config.prompts.Tests.prompt) end, { noremap = true, silent = true, desc = "Copilot Suggest Tests" })
+
+-- その他のキーマッピング
+vim.keymap.set('v', '<leader>ce', function() require('CopilotChat').ask(config.prompts.Tests.prompt) end, { noremap = true, silent = true, desc = "Copilot Explain (Tests)" })
 vim.keymap.set('v', '<leader>ce', function() require('CopilotChat').ask(config.prompts.Explain.prompt) end, { noremap = true, silent = true, desc = "Copilot Explain (Visual)" })
 vim.keymap.set('n', '<leader>ce', function() require('CopilotChat').ask(config.prompts.Explain.prompt) end, { noremap = true, silent = true, desc = "Copilot Explain (Normal)" })
 vim.keymap.set('n', '<leader>cr', function() require('CopilotChat').ask(config.prompts.Review.prompt) end, { noremap = true, silent = true, desc = "Copilot Review" })

--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -85,7 +85,7 @@ function CopilotChatBuffer()
 end
 -- 既存のキーマッピング
 -- CopilotChatToggleのキーマッピングを変更
-vim.keymap.set('n', '<leader>cT', '<cmd>CopilotChatToggle<cr>', { noremap = true, silent = true, desc = "Toggle Copilot Chat" })
+vim.keymap.set('n', ',ct', '<cmd>CopilotChatToggle<cr>', { noremap = true, silent = true, desc = "Toggle Copilot Chat" })
 
 -- Copilot Chat Commitのキーマッピング
 vim.keymap.set('n', '<leader>cm', '<cmd>CopilotChatCommit<cr>', { noremap = true, silent = true, desc = "Copilot Chat Commit" })

--- a/.config/nvim/ddc_settings.toml
+++ b/.config/nvim/ddc_settings.toml
@@ -77,10 +77,6 @@ inoremap <expr><S-TAB> pumvisible() ? '<C-p>' : '<C-h>'
 '''
 
 [[plugins]]
-repo = 'Shougo/ddc-source-nvim-lsp'
-on_source = 'ddc.vim'
-
-[[plugins]]
 repo = 'Shougo/ddc-around'
 on_source = 'ddc.vim'
 

--- a/.config/nvim/ddc_settings.toml
+++ b/.config/nvim/ddc_settings.toml
@@ -67,14 +67,12 @@ call ddc#custom#patch_filetype('markdown', 'sourceParams', #{
 " Mappings
 " <TAB>: completion.
 inoremap <silent><expr> <TAB>
-\ pumvisible() ? pum#map#insert_relative(+1) :
-\ (col('.') <= 1 <Bar><Bar> getline('.')[col('.') - 2] =~# '\s') ?
+\ pumvisible() ? '<C-n>' :
+\ (col('.') <= 1 || getline('.')[col('.') - 2] =~# '\s') ?
 \ '<TAB>' : ddc#map#manual_complete()
 
-inoremap <silent><expr> <S-TAB>
-\ pumvisible() ? pum#map#insert_relative(-1) : '<C-n>'
-  " <S-TAB>: completion back.
-  inoremap <expr><S-TAB>  pumvisible() ? '<C-p>' : '<C-n>'
+" <S-TAB>: completion back.
+inoremap <expr><S-TAB> pumvisible() ? '<C-p>' : '<C-h>'
   call ddc#enable()
 '''
 
@@ -99,7 +97,7 @@ repo = 'LumaKernel/ddc-file'
 on_source = 'ddc.vim'
 
 [[plugins]]
-repo = 'Shougo/ddc-nvim-lsp'
+repo = 'Shougo/ddc-source-lsp'
 on_source = 'ddc.vim'
 
 [[plugins]]

--- a/.config/nvim/treesitter_settings.toml
+++ b/.config/nvim/treesitter_settings.toml
@@ -6,13 +6,12 @@ lua_source = '''
 require'nvim-treesitter.configs'.setup {
   ensure_installed = {
     "lua",
-
     "rust",
-
     "python",
     "fish",
     "bash",
     "typescript",
+    "svelte",
     "json",
     "go",
     "dockerfile",
@@ -44,19 +43,15 @@ require'nvim-treesitter.configs'.setup {
   },
 
   autotag = {
-
     enable = true,
   },
 
 
   incremental_selection = {
-
     enable = true,
     keymaps = {
-
       init_selection = "gnn",
       node_incremental = "grn",
-
       scope_incremental = "grc",
       node_decremental = "grm",
     },


### PR DESCRIPTION
## [optional body]
This pull request includes multiple changes to the Neovim configuration files to improve key mappings, plugin settings, and Treesitter configurations. The most important changes include modifying key mappings for Copilot Chat, updating DDC plugin settings, and enhancing Treesitter configurations.

### Key Mapping Updates:
* [`.config/nvim/copilot.toml`](diffhunk://#diff-f04922053842de2458379f6df241f2e77f615af8acfa165bcf45adc126860411L87-R98): Changed the key mapping for `CopilotChatToggle` and added new key mappings for `Copilot Chat Commit`, suggesting tests, and explaining code.

### DDC Plugin Settings:
* [`.config/nvim/ddc_settings.toml`](diffhunk://#diff-11cde3c931dc21ad480151db9f1e4ea281bff3d5ddd77ef65ecf23da768775a1L70-L84): Updated key mappings for completion with `<TAB>` and `<S-TAB>`, and replaced the `ddc-nvim-lsp` plugin with `ddc-source-lsp`. [[1]](diffhunk://#diff-11cde3c931dc21ad480151db9f1e4ea281bff3d5ddd77ef65ecf23da768775a1L70-L84) [[2]](diffhunk://#diff-11cde3c931dc21ad480151db9f1e4ea281bff3d5ddd77ef65ecf23da768775a1L102-R96)

### Treesitter Configurations:
* [`.config/nvim/treesitter_settings.toml`](diffhunk://#diff-54f53d7cc5e19cab0b9be9e9d8430c43af776a09784094300335a1a15e3fc09bL9-R14): Added support for the `svelte` language and cleaned up configuration settings for `autotag` and `incremental_selection`. [[1]](diffhunk://#diff-54f53d7cc5e19cab0b9be9e9d8430c43af776a09784094300335a1a15e3fc09bL9-R14) [[2]](diffhunk://#diff-54f53d7cc5e19cab0b9be9e9d8430c43af776a09784094300335a1a15e3fc09bL47-L59)
## [optional footer(s)]
