### PR TITLE
feat(fish): add new key bindings and functions

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -49,32 +49,6 @@ export TERM=xterm-256color
 set -x PATH ~/.skim/bin $PATH
 set -x SKIM_DEFAULT_COMMAND 'rg --files --hidden --follow --glob "!.git/*"'
 
-function skim-checkout-branch
-    set -l branchname (
-        env SKIM_DEFAULT_COMMAND='git --no-pager branch -a | grep -v HEAD | sed -e "s/^.* //g"' \
-            sk --height 70% --prompt "BRANCH NAME>" \
-                --preview "git --no-pager log -20 --color=always {}"
-    )
-
-    if test -n "$branchname"
-        git checkout (echo "$branchname"| sed "s#remotes/[^/]*/##")
-    end
-end
-
-
-function skim-docker-container-name-select
-    commandline -i (env SKIM_DEFAULT_COMMAND="docker ps -a --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}}\t{{.Ports}}\t{{.Networks}}'" \
-        sk --no-sort --height 80% --bind='p:toggle-preview' --preview-window=down:70% \
-            --preview '
-                set -l containername (echo {} | awk -F " " \'{print $2}\');
-                if test "$containername" != "ID"
-
-                    docker logs --tail 300 $containername
-                end
-            ' | \
-
-        awk -F " " '{print $2}')
-end
 
 function reload
   exec fish

--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -3,14 +3,20 @@ function fish_user_key_bindings
   # 貼り付け。ctrl+wなどで一気に削除された部分を貼り付けられる。
   # マウスやtmuxのコピーモードで代用できるので潰す優先度は高い。
   # skim-checkout-branchのバインド
+  # gitのブランチをskimで選択してチェックアウトする
+  # Ctrl + y でブランチを選択する
   bind \cy skim-checkout-branch
 
   # skim-docker-container-name-selectのバインド
+  # ,d でdockerコンテナ名をskimで選択してログを表示する
   bind ,d skim-docker-container-name-select
 
+  # Ctrl + t でファイルを検索する
   bind \ct skim-file-widget
+  # Ctrl + r で履歴を検索する
   bind \cr skim-history-widget
-  bind \ec skim-cd-widget
+  # Alt + e でディレクトリを検索する
+  bind \ed skim-cd-widget
 
     #!/bin/fish
   # completion.fish


### PR DESCRIPTION
## [optional body]
- Added key bindings for skim-checkout-branch and skim-docker-container-name-select.
- Moved skim-checkout-branch and skim-docker-container-name-select functions to fish_user_key_bindings.fish.
- Updated key bindings for skim-file-widget, skim-history-widget, and skim-cd-widget.

## [optional footer(s)]
