### PR TITLE
fix(alacritty): update deprecated config structure

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,4 +1,3 @@
-live_config_reload = true
 
 [colors.bright]
 black = "0x5c6370"
@@ -87,7 +86,7 @@ action = "CreateNewWindow"
 key = "N"
 mods = "Control|Shift"
 
-[shell]
+[terminal.shell]
 args = ["--login", "--command", "tmux attach || tmux"]
 program = "/usr/bin/fish"
 
@@ -98,3 +97,8 @@ title = "Alacritty"
 [window.class]
 general = "Alacritty"
 instance = "Alacritty"
+
+[general]
+live_config_reload = true
+
+[terminal]


### PR DESCRIPTION
## [optional body]
- Moved `live_config_reload` to `[general]` section
- Changed `[shell]` to `[terminal.shell]`
- Enabled `live_config_reload` in the new `[general]` section

## [optional footer(s)]
<!--
フッターにはコミットログの内容に関連するURLを載せましょう。
例えば、チケットのURLやコミットする前に議論を重ねたIssueやチケット、slackのリンクなどが挙げられます。
https://www.praha-inc.com/lab/posts/commit-message
-->
