### PR TITLE
Feature/add mini indent scope

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -32,6 +32,7 @@ end
 if vim.call('dein#load_state', dein_dir) == 1 then
   local dein_toml_dir = vim.env.HOME .. '/dotfiles/.config/nvim'
   local status_line_dir = '/status_line'
+  local mini_dir = '/mini'
 
   -- startup
   local dein_toml = dein_toml_dir .. '/dein.toml'
@@ -39,6 +40,7 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   local style_toml = dein_toml_dir .. '/style.toml'
   local copilot_toml = dein_toml_dir .. '/copilot.toml'
   local ddu_toml = dein_toml_dir .. '/ddu_settings.toml'
+  local mini_toml = dein_toml_dir .. mini_dir .. '/mini.toml'
 
 
   -- status line
@@ -66,6 +68,9 @@ if vim.call('dein#load_state', dein_dir) == 1 then
     lualine_toml,
     gitsigns_toml,
 
+    -- mini
+    mini_toml,
+
     -- lazy
     dein_toml_lazy,
     lsp_setting_toml_lazy,
@@ -84,6 +89,9 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   vim.call('dein#load_toml', lualine_toml, {lazy = 0})
   vim.call('dein#load_toml', bufferline_toml, {lazy = 0})
   vim.call('dein#load_toml', gitsigns_toml, {lazy = 0})
+
+  -- mini
+  vim.call('dein#load_toml', mini_toml, {lazy = 0})
 
   -- Lazy load
   vim.call('dein#load_toml', dein_toml_lazy, {lazy = 1})

--- a/.config/nvim/mini/mini.toml
+++ b/.config/nvim/mini/mini.toml
@@ -65,3 +65,23 @@ on_event = 'BufRead'
 # 複数の引数を一発で分割・結合してくれるプラグイン
 [[plugins]]
 repo = 'echasnovski/mini.splitjoin'
+
+
+# Mini.surround: テキストを囲む機能
+[[plugins]]
+repo = 'echasnovski/mini.surround'
+lua_add = '''
+require('mini.surround').setup({
+  -- テキストを囲むためのキーマッピング
+  -- saと打った後に、囲みたいテキストを入力すると、そのテキストを囲むことができる
+  mappings = {
+    add = 'sa',                 -- saで選択範囲を囲む
+    delete = 'sd',              -- sdで選択範囲の囲みを削除
+    find = 'sf',                -- sfで囲みを探す
+    find_left = 'sF',           -- sFで左側の囲みを探す
+    highlight = 'sh',           -- shで囲みをハイライト
+    replace = 'sr',             -- srで囲みを置換
+    update_n_lines = 'sn',      -- snでn行の囲みを更新
+    }
+})
+'''

--- a/.config/nvim/mini/mini.toml
+++ b/.config/nvim/mini/mini.toml
@@ -1,5 +1,5 @@
 [[plugins]]
-repo = 'echasnovski/mini.nvim'
+repo = 'echasnovski/mini.indentscope'
 
 on_event = 'BufRead'
 lua_add = '''
@@ -9,7 +9,6 @@ require('mini.indentscope').setup({
   options = {
     try_as_border = true, -- インデントの範囲を表示するためのシンボルを枠線として試みる
   },
-  -- 特定のバッファタイプで無効にする
   draw = {
     deley = 100, -- インデントの範囲を表示するためのシンボルを描画するまでの遅延時間
     priority = 2, -- インデントの範囲を表示するためのシンボルを描画する優先度
@@ -26,7 +25,7 @@ vim.api.nvim_set_hl(0, "MiniIndentscopeSymbol", {
   nocombine = true,
 })
 
--- ダッシュボードでindentscopeを無効化
+-- ダッシュボード等でindentscopeを無効化
 vim.api.nvim_create_autocmd("FileType", {
   pattern = {
     "alpha",
@@ -34,10 +33,10 @@ vim.api.nvim_create_autocmd("FileType", {
     "starter",
     "norg",
     "Trouble",
-
     "lazy",
-
     "mason",
+    "ddu",
+    "ddu-filer-file",
   },
   callback = function()
     vim.b.miniindentscope_disable = true

--- a/.config/nvim/mini/mini.toml
+++ b/.config/nvim/mini/mini.toml
@@ -1,6 +1,7 @@
+# インデントの範囲を表示してくれるプラグインです。
+# インデント関係のテキストオブジェクトも提供
 [[plugins]]
 repo = 'echasnovski/mini.indentscope'
-
 on_event = 'BufRead'
 lua_add = '''
 require('mini.indentscope').setup({
@@ -57,8 +58,6 @@ on_event = 'BufRead'
 # ビジュアルモードで、選択範囲をコメントアウトする。
 # comment_visual = 'gc',
 
-# インデントの範囲を表示してくれるプラグインです。
-# インデント関係のテキストオブジェクトも提供
 
 
 

--- a/.config/nvim/mini/mini.toml
+++ b/.config/nvim/mini/mini.toml
@@ -1,0 +1,68 @@
+[[plugins]]
+repo = 'echasnovski/mini.nvim'
+
+on_event = 'BufRead'
+lua_add = '''
+require('mini.indentscope').setup({
+  -- インデントの範囲を表示するためのシンボル
+  symbol = '│',
+  options = {
+    try_as_border = true, -- インデントの範囲を表示するためのシンボルを枠線として試みる
+  },
+  -- 特定のバッファタイプで無効にする
+  draw = {
+    deley = 100, -- インデントの範囲を表示するためのシンボルを描画するまでの遅延時間
+    priority = 2, -- インデントの範囲を表示するためのシンボルを描画する優先度
+  },
+})
+
+-- ハイライトグループのカスタマイズ（オプション）
+vim.cmd([[
+  highlight MiniIndentscopeSymbol guifg=#4B5563 gui=nocombine
+]])
+-- ハイライトグループのカスタマイズ（API）
+vim.api.nvim_set_hl(0, "MiniIndentscopeSymbol", {
+  fg = "#404955",
+  nocombine = true,
+})
+
+-- ダッシュボードでindentscopeを無効化
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = {
+    "alpha",
+    "dashboard",
+    "starter",
+    "norg",
+    "Trouble",
+
+    "lazy",
+
+    "mason",
+  },
+  callback = function()
+    vim.b.miniindentscope_disable = true
+  end,
+})
+'''
+
+# ファイルタイプに合わせて、いい感じにコメントアウトしてくれるプラグイン
+[[plugins]]
+repo = 'echasnovski/mini.comment'
+on_event = 'BufRead'
+## キーマッピング
+# -- 通常モードとビジュアルモードの両方で、コメント (`gcip` - コメント内段落のようなもの) をトグルする。
+# comment = 'gc',
+# -- 通常モードで、コメント (`gcc` - 行コメント) をトグルする。
+# comment_line = 'gcc',
+
+# ビジュアルモードで、選択範囲をコメントアウトする。
+# comment_visual = 'gc',
+
+# インデントの範囲を表示してくれるプラグインです。
+# インデント関係のテキストオブジェクトも提供
+
+
+
+# 複数の引数を一発で分割・結合してくれるプラグイン
+[[plugins]]
+repo = 'echasnovski/mini.splitjoin'


### PR DESCRIPTION
## [optional body]
This pull request enhances the Neovim configuration by adding support for the `mini` plugin suite. The most important changes include defining the `mini` directory and loading the `mini.toml` file, as well as adding configurations for various `mini` plugins.

### Enhancements to Neovim configuration:

* [`.config/nvim/init.lua`](diffhunk://#diff-63d8bcd646a1e22231af249afbeadca374e8ae4f2757d0d9c56dae22b74ae294R35-R43): Defined the `mini` directory and added `mini.toml` to the list of configuration files to be loaded. [[1]](diffhunk://#diff-63d8bcd646a1e22231af249afbeadca374e8ae4f2757d0d9c56dae22b74ae294R35-R43) [[2]](diffhunk://#diff-63d8bcd646a1e22231af249afbeadca374e8ae4f2757d0d9c56dae22b74ae294R71-R73) [[3]](diffhunk://#diff-63d8bcd646a1e22231af249afbeadca374e8ae4f2757d0d9c56dae22b74ae294R93-R95)

### Addition of `mini` plugin suite:

* `.config/nvim/mini/mini.toml`: Added configurations for the following `mini` plugins:
  * [`mini.indentscope`](diffhunk://#diff-83ddc57dd9b9b8fc2466976a6a9195ef8e514a20e96a087b6a3774833eacacb5R1-R86): Displays the scope of indentation levels with customizable symbols and highlights.
  * [`mini.comment`](diffhunk://#diff-83ddc57dd9b9b8fc2466976a6a9195ef8e514a20e96a087b6a3774833eacacb5R1-R86): Provides enhanced commenting functionality with key mappings for toggling comments.
  * [`mini.splitjoin`](diffhunk://#diff-83ddc57dd9b9b8fc2466976a6a9195ef8e514a20e96a087b6a3774833eacacb5R1-R86): Allows splitting and joining of arguments in a single command.
  * [`mini.surround`](diffhunk://#diff-83ddc57dd9b9b8fc2466976a6a9195ef8e514a20e96a087b6a3774833eacacb5R1-R86): Adds functionality for surrounding text with customizable key mappings.
## [optional footer(s)]

