### PR TITLE
Feature/add hyprland window switcher

### DIFF
--- a/.bin/deploy.sh
+++ b/.bin/deploy.sh
@@ -213,6 +213,11 @@ if [ ! -d ~/.config/mako ]; then
 fi
 ln -snfv ~/dotfiles/.config/mako/config ~/.config/mako/config
 
+echo "eww setting"
+if [ ! -d ~/.config/eww ]; then
+  mkdir -p ~/.config/eww/
+fi
+ln -snfv ~/dotfiles/.config/eww/eww.yuck ~/.config/eww/eww.yuck
 
 echo "finish setup"
 echo "next you call dein script"

--- a/.bin/install.sh
+++ b/.bin/install.sh
@@ -24,6 +24,8 @@ create_dir_if_not_exists "$HOME/.config/nvim"
 create_dir_if_not_exists "$HOME/.config/starship"
 create_dir_if_not_exists "$HOME/.config/fish"
 create_dir_if_not_exists "$HOME/.config/alacritty"
+create_dir_if_not_exists "$HOME/.config/eww"
+create_dir_if_not_exists "$HOME/.config/hypr/scripts"
 
 # Run setup scripts
 # shellcheck disable=SC1091

--- a/.bin/utils/setup_directories.sh
+++ b/.bin/utils/setup_directories.sh
@@ -13,6 +13,8 @@ directories=(
     "$HOME/.config/fish"
     "$HOME/.config/alacritty"
     "$HOME/.config/starship"
+    "$HOME/.config/eww"
+    "$HOME/.config/hypr/scripts"
     "$HOME/.cache/dein"
 )
 

--- a/.bin/utils/setup_symlinks.sh
+++ b/.bin/utils/setup_symlinks.sh
@@ -16,6 +16,8 @@ mkdir -p "${XDG_CONFIG_HOME}/nvim"
 mkdir -p "${XDG_CONFIG_HOME}/fish"
 mkdir -p "${XDG_CONFIG_HOME}/alacritty"
 mkdir -p "${XDG_CONFIG_HOME}/starship"
+mkdir -p "${XDG_CONFIG_HOME}/eww"
+mkdir -p "${XDG_CONFIG_HOME}/hypr/scripts"
 
 # Create symlinks
 ln -snfv "$DOTFILES_DIR/.bashrc" "$HOME/.bashrc"

--- a/.bin/utils/setup_symlinks.sh
+++ b/.bin/utils/setup_symlinks.sh
@@ -28,4 +28,13 @@ ln -snfv "$DOTFILES_DIR/.config/fish/config.fish" "$HOME/.config/fish/config.fis
 
 ln -snfv "$DOTFILES_DIR/.config/alacritty/alacritty.toml" "$HOME/.config/alacritty/alacritty.toml"
 
+
+# eww
+ln -snfv "$DOTFILES_DIR/.config/eww/eww.yuck" "$HOME/.config/eww/eww.yuck"
+ln -snfv "$DOTFILES_DIR/.config/eww/eww.scss" "$HOME/.config/eww/eww.scss"
+
+# hypr
+ln -snfv "$DOTFILES_DIR/.config/hypr/scripts/notifications.sh" "$HOME/.config/hypr/scripts/notifications.sh"
+ln -snfv "$DOTFILES_DIR/.config/hypr/scripts/window-switcher.py" "$HOME/.config/hypr/scripts/window-switcher.py"
+
 echo "Symlinks created."

--- a/.config/eww/eww.scss
+++ b/.config/eww/eww.scss
@@ -1,0 +1,44 @@
+// ~/.config/eww/eww.scss
+
+.window-switcher {
+  background-color: rgba(30, 30, 30, 0.95);
+  border-radius: 10px;
+  padding: 1rem;
+
+  .preview-container {
+    padding: 1rem;
+
+    .window-preview {
+      min-height: 200px;
+      border-radius: 5px;
+      margin-bottom: 0.5rem;
+    }
+
+    .window-title {
+      font-size: 1.2em;
+      font-weight: bold;
+      color: white;
+    }
+
+    .window-class {
+      font-size: 0.9em;
+      color: #888;
+    }
+  }
+
+  .window-list {
+    padding: 0.5rem;
+
+    .window-item {
+      padding: 0.5rem 1rem;
+      background-color: rgba(60, 60, 60, 0.5);
+      border-radius: 5px;
+      color: white;
+
+      &.active {
+        background-color: rgba(100, 100, 100, 0.8);
+        border: 1px solid #888;
+      }
+    }
+  }
+}

--- a/.config/eww/eww.yuck
+++ b/.config/eww/eww.yuck
@@ -1,0 +1,31 @@
+;; シンボリックリンクを貼る
+;; ln -snfv ~/dotfiles/.config/eww/eww.yuck ~/.config/eww/eww.yuck
+;; ~/.config/eww/eww.yuck
+
+(defwindow window_switcher
+  :monitor 0
+  :geometry (geometry :x "0%"
+                     :y "10%"
+                     :width "50%"
+                     :height "40%"
+                     :anchor "top center")
+  :stacking "overlay"
+  :class "window-switcher"
+  (box :orientation "vertical"
+       :space-evenly false
+       :spacing 10
+    (box :class "preview-container"
+         :orientation "vertical"
+         :spacing 5
+      (image :path {window_data.current.preview}
+             :class "window-preview")
+      (label :text {window_data.current.title}
+             :class "window-title")
+      (label :text {window_data.current.class}
+             :class "window-class"))
+    (box :class "window-list"
+         :orientation "horizontal"
+         :spacing 10
+      (for window in {window_data.windows}
+        (box :class "window-item ${window.active ? 'active' : ''}"
+             (label :text "${window.class}"))))))

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -60,3 +60,5 @@ set -gx VOLTA_HOME "$HOME/.volta"
 set -gx PATH "$VOLTA_HOME/bin" $PATH
 
 ~/.local/bin/mise activate fish | source
+eval (/home/archie/.local/bin/mise activate fish)
+~/.local/bin/mise activate fish | source

--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -77,11 +77,12 @@ decoration {
     # Change transparency of focused and unfocused windows
     active_opacity = 1.0
     inactive_opacity = 1.0
-
-    drop_shadow = true
-    shadow_range = 4
-    shadow_render_power = 3
-    col.shadow = rgba(1a1a1aee)
+    shadow {
+      enabled = true
+      range = 4
+      render_power = 3
+      color = rgba(1a1a1aee)
+    }
 
     # https://wiki.hyprland.org/Configuring/Variables/#blur
     blur {

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -40,6 +40,9 @@ bind = $mainMod, P, pseudo
 # タイリングの分割方向を切り替え
 bind = $mainMod, J, togglesplit
 
+## ウィンドウの最大化
+bind = SUPER, F, fullscreen, 0
+
 # windowの切り替え
 ## ワークスペース内のウィンドウ切り替え
 bind = ALT, Tab, exec, ~/.config/hypr/scripts/window-switcher.py

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -40,6 +40,12 @@ bind = $mainMod, P, pseudo
 # タイリングの分割方向を切り替え
 bind = $mainMod, J, togglesplit
 
+# windowの切り替え
+## ワークスペース内のウィンドウ切り替え
+bind = ALT, Tab, exec, ~/.config/hypr/scripts/window-switcher.py
+## すべてのワークスペースを横断してウィンドウ切り替え
+bind = ALT SHIFT, Tab, exec, ~/.config/hypr/scripts/window-switcher.py reverse
+
 ### フォーカス移動 ###
 bind = $mainMod, left, movefocus, l
 bind = $mainMod, right, movefocus, r

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -23,6 +23,7 @@ bind = $mainMod, I, exec, vivaldi-stable
 bind = $mainMod, E, exec, nautilus
 # アプリケーションランチャー（Wofi）
 bind = $mainMod, D, exec, wofi --show drun
+bind = $mainMod, Space, exec, wofi --show drun
 # スクリーンロック（Hyprlock）
 bind = $mainMod, L, exec, hyprlock
 # ログアウトメニュー（Wlogout）
@@ -42,6 +43,28 @@ bind = $mainMod, J, togglesplit
 
 ## ウィンドウの最大化
 bind = SUPER, F, fullscreen, 0
+
+
+# リサイズモードのサブマップを定義
+bind = $mainMod, R, submap, resize
+
+# リサイズモードのキーバインド
+submap = resize
+
+# 矢印キー
+binde = , left, resizeactive, -10 0
+binde = , down, resizeactive, 0 10
+binde = , up, resizeactive, 0 -10
+binde = , right, resizeactive, 10 0
+
+# デフォルトモードに戻る
+bind = , Return, submap, reset
+bind = , Escape, submap, reset
+bind = $mainMod, R, submap, reset
+
+# サブマップをリセット
+submap = reset
+### ウィンドウ管理 ###
 
 # windowの切り替え
 ## ワークスペース内のウィンドウ切り替え

--- a/.config/hypr/scripts/window-switcher.py
+++ b/.config/hypr/scripts/window-switcher.py
@@ -3,7 +3,39 @@
 import json
 import subprocess
 import sys
+import os
+import tempfile
 from typing import List, Dict
+
+class WindowPreview:
+    def __init__(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.preview_file = os.path.join(self.temp_dir, "window_preview.png")
+        
+    def capture_window(self, window_address: str) -> str:
+        """Capture window preview using grimblast"""
+        try:
+            subprocess.run([
+                'hyprctl', 'dispatch', 'focuswindow', f"address:{window_address}"
+            ])
+            # Give the window a moment to focus
+            subprocess.run(['sleep', '0.1'])
+            # Capture the window
+            subprocess.run([
+                'grimblast', 'save', 'active', self.preview_file
+            ])
+            return self.preview_file
+        except subprocess.SubprocessError as e:
+            print(f"Error capturing window: {e}", file=sys.stderr)
+            return ""
+
+    def cleanup(self):
+        """Clean up temporary files"""
+        try:
+            os.remove(self.preview_file)
+            os.rmdir(self.temp_dir)
+        except OSError:
+            pass
 
 def get_windows() -> List[Dict]:
     """Get list of all windows"""
@@ -14,7 +46,6 @@ def get_windows() -> List[Dict]:
             text=True
         )
         windows = json.loads(result.stdout)
-        # マップされているウィンドウのみをフィルタリング
         return [w for w in windows if w.get('mapped', False)]
     except (subprocess.SubprocessError, json.JSONDecodeError) as e:
         print(f"Error getting windows: {e}", file=sys.stderr)
@@ -39,6 +70,49 @@ def focus_window(address: str):
         subprocess.run(['hyprctl', 'dispatch', 'focuswindow', f"address:{address}"])
     except subprocess.SubprocessError as e:
         print(f"Error focusing window: {e}", file=sys.stderr)
+
+def show_preview_window(windows: List[Dict], current_index: int):
+    """Show preview window using eww"""
+    current_window = windows[current_index]
+    
+    # Generate preview image
+    preview = WindowPreview()
+    preview_path = preview.capture_window(current_window['address'])
+    
+    # Create eww widget content
+    window_data = {
+        "windows": [
+            {
+                "title": w['title'],
+                "class": w['class'],
+                "active": i == current_index,
+                "workspace": w.get('workspace', {}).get('id', 1)
+            } for i, w in enumerate(windows)
+        ],
+        "current": {
+            "title": current_window['title'],
+            "class": current_window['class'],
+            "preview": preview_path
+        }
+    }
+    
+    # Save window data to temporary file
+    data_file = os.path.join(preview.temp_dir, "window_data.json")
+    with open(data_file, 'w') as f:
+        json.dump(window_data, f)
+    
+    # Update eww variables
+    subprocess.run(['eww', 'update', f"window_data={data_file}"])
+    
+    # Show eww window
+    subprocess.run(['eww', 'open', 'window_switcher'])
+    
+    return preview
+
+def close_preview_window(preview: WindowPreview):
+    """Close preview window and clean up"""
+    subprocess.run(['eww', 'close', 'window_switcher'])
+    preview.cleanup()
 
 def main():
     # Get all windows
@@ -65,9 +139,16 @@ def main():
     else:
         next_index = (current_index + 1) % len(windows)
 
+    # Show preview window
+    preview = show_preview_window(windows, next_index)
+    
     # Focus next window
     next_window = windows[next_index]
     focus_window(next_window['address'])
+
+    # Wait a moment before closing preview
+    subprocess.run(['sleep', '0.5'])
+    close_preview_window(preview)
     
     return 0
 

--- a/.config/hypr/scripts/window-switcher.py
+++ b/.config/hypr/scripts/window-switcher.py
@@ -3,120 +3,73 @@
 import json
 import subprocess
 import sys
-import os
-import socket
-import selectors
-import struct
-import time
-from typing import List, Dict, Optional, Set
+from typing import List, Dict
 
-class HyprlandWindow:
-    def __init__(self, window_data: Dict):
-        self.id = window_data.get('address')
-        self.workspace = window_data.get('workspace', {}).get('id', 0)
-        self.title = window_data.get('title', 'Unknown')
-        self.class_name = window_data.get('class', 'Unknown')
-        self.is_focused = window_data.get('focused', False)
+def get_windows() -> List[Dict]:
+    """Get list of all windows"""
+    try:
+        result = subprocess.run(
+            ['hyprctl', 'clients', '-j'],
+            capture_output=True,
+            text=True
+        )
+        windows = json.loads(result.stdout)
+        # マップされているウィンドウのみをフィルタリング
+        return [w for w in windows if w.get('mapped', False)]
+    except (subprocess.SubprocessError, json.JSONDecodeError) as e:
+        print(f"Error getting windows: {e}", file=sys.stderr)
+        return []
 
-class HyprlandEventHandler:
-    def __init__(self):
-        self.sock_path = f"/tmp/hypr/{os.environ.get('HYPRLAND_INSTANCE_SIGNATURE')}/.socket2.sock"
-        self.sel = selectors.DefaultSelector()
-        self._setup_socket()
-        self.alt_pressed = True
-        self.tab_pressed = False
+def get_active_window_address() -> str:
+    """Get the address of the currently active window"""
+    try:
+        result = subprocess.run(
+            ['hyprctl', 'activewindow', '-j'],
+            capture_output=True,
+            text=True
+        )
+        active = json.loads(result.stdout)
+        return active.get('address', '')
+    except (subprocess.SubprocessError, json.JSONDecodeError):
+        return ''
 
-    def _setup_socket(self):
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.connect(self.sock_path)
-        self.sock.setblocking(False)
-        self.sel.register(self.sock, selectors.EVENT_READ)
-
-    def read_event(self, timeout: float = 0.1) -> Optional[str]:
-        events = self.sel.select(timeout)
-        for key, _ in events:
-            try:
-                data = key.fileobj.recv(4096).decode()
-                if data:
-                    return data.strip()
-            except (socket.error, UnicodeDecodeError):
-                return None
-        return None
-
-    def wait_for_alt_release(self) -> bool:
-        while True:
-            event = self.read_event()
-            if event:
-                event_parts = event.split(">>")
-                if len(event_parts) >= 2:
-                    event_type = event_parts[0]
-                    event_data = event_parts[1]
-
-                    if event_type == "keyrelease":
-                        # Alt_L のキーコードは 64
-                        if "64" in event_data:
-                            return False
-                    elif event_type == "keypress":
-                        # Tab のキーコードは 23
-                        if "23" in event_data:
-                            return True
-            time.sleep(0.01)
-
-class WindowManager:
-    def __init__(self):
-        self.windows: List[HyprlandWindow] = []
-        self.load_windows()
-        self.current_index = self.get_focused_window_index()
-
-    def load_windows(self):
-        try:
-            result = subprocess.run(
-                ['hyprctl', 'clients', '-j'],
-                capture_output=True,
-                text=True
-            )
-            windows_data = json.loads(result.stdout)
-            # マップされているウィンドウのみを対象にする
-            self.windows = [HyprlandWindow(w) for w in windows_data if w.get('mapped', False)]
-        except (subprocess.SubprocessError, json.JSONDecodeError) as e:
-            print(f"Error loading windows: {e}", file=sys.stderr)
-            self.windows = []
-
-    def get_focused_window_index(self) -> int:
-        for i, window in enumerate(self.windows):
-            if window.is_focused:
-                return i
-        return 0
-
-    def focus_next_window(self, reverse: bool = False):
-        if not self.windows:
-            return
-
-        if reverse:
-            self.current_index = (self.current_index - 1) % len(self.windows)
-        else:
-            self.current_index = (self.current_index + 1) % len(self.windows)
-
-        window = self.windows[self.current_index]
-        self.focus_window(window.id)
-
-    def focus_window(self, window_id: str):
-        try:
-            subprocess.run(['hyprctl', 'dispatch', 'focuswindow', f"address:{window_id}"])
-        except subprocess.SubprocessError as e:
-            print(f"Error focusing window: {e}", file=sys.stderr)
+def focus_window(address: str):
+    """Focus the window with the given address"""
+    try:
+        subprocess.run(['hyprctl', 'dispatch', 'focuswindow', f"address:{address}"])
+    except subprocess.SubprocessError as e:
+        print(f"Error focusing window: {e}", file=sys.stderr)
 
 def main():
-    wm = WindowManager()
-    event_handler = HyprlandEventHandler()
+    # Get all windows
+    windows = get_windows()
+    if not windows:
+        return 1
+
+    # Get current active window
+    current = get_active_window_address()
+    
+    # Find current window index
+    current_index = 0
+    for i, window in enumerate(windows):
+        if window.get('address') == current:
+            current_index = i
+            break
+
+    # Determine direction
     reverse = len(sys.argv) > 1 and sys.argv[1] == "reverse"
+    
+    # Calculate next window index
+    if reverse:
+        next_index = (current_index - 1) % len(windows)
+    else:
+        next_index = (current_index + 1) % len(windows)
 
-    # 最初のウィンドウ切り替え
-    wm.focus_next_window(reverse)
-
-    # Altキーが離されるまでTabキーの入力を監視
-    while event_handler.wait_for_alt_release():
-        wm.focus_next_window(reverse)
+    # Focus next window
+    next_window = windows[next_index]
+    focus_window(next_window['address'])
+    
+    return 0
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/.config/hypr/scripts/window-switcher.py
+++ b/.config/hypr/scripts/window-switcher.py
@@ -122,7 +122,7 @@ def main():
 
     # Get current active window
     current = get_active_window_address()
-    
+
     # Find current window index
     current_index = 0
     for i, window in enumerate(windows):
@@ -132,7 +132,7 @@ def main():
 
     # Determine direction
     reverse = len(sys.argv) > 1 and sys.argv[1] == "reverse"
-    
+
     # Calculate next window index
     if reverse:
         next_index = (current_index - 1) % len(windows)

--- a/.config/hypr/scripts/window-switcher.py
+++ b/.config/hypr/scripts/window-switcher.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import os
+import socket
+import selectors
+import struct
+import time
+from typing import List, Dict, Optional, Set
+
+class HyprlandWindow:
+    def __init__(self, window_data: Dict):
+        self.id = window_data.get('address')
+        self.workspace = window_data.get('workspace', {}).get('id', 0)
+        self.title = window_data.get('title', 'Unknown')
+        self.class_name = window_data.get('class', 'Unknown')
+        self.is_focused = window_data.get('focused', False)
+
+class HyprlandEventHandler:
+    def __init__(self):
+        self.sock_path = f"/tmp/hypr/{os.environ.get('HYPRLAND_INSTANCE_SIGNATURE')}/.socket2.sock"
+        self.sel = selectors.DefaultSelector()
+        self._setup_socket()
+        self.alt_pressed = True
+        self.tab_pressed = False
+
+    def _setup_socket(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.sock_path)
+        self.sock.setblocking(False)
+        self.sel.register(self.sock, selectors.EVENT_READ)
+
+    def read_event(self, timeout: float = 0.1) -> Optional[str]:
+        events = self.sel.select(timeout)
+        for key, _ in events:
+            try:
+                data = key.fileobj.recv(4096).decode()
+                if data:
+                    return data.strip()
+            except (socket.error, UnicodeDecodeError):
+                return None
+        return None
+
+    def wait_for_alt_release(self) -> bool:
+        while True:
+            event = self.read_event()
+            if event:
+                event_parts = event.split(">>")
+                if len(event_parts) >= 2:
+                    event_type = event_parts[0]
+                    event_data = event_parts[1]
+
+                    if event_type == "keyrelease":
+                        # Alt_L のキーコードは 64
+                        if "64" in event_data:
+                            return False
+                    elif event_type == "keypress":
+                        # Tab のキーコードは 23
+                        if "23" in event_data:
+                            return True
+            time.sleep(0.01)
+
+class WindowManager:
+    def __init__(self):
+        self.windows: List[HyprlandWindow] = []
+        self.load_windows()
+        self.current_index = self.get_focused_window_index()
+
+    def load_windows(self):
+        try:
+            result = subprocess.run(
+                ['hyprctl', 'clients', '-j'],
+                capture_output=True,
+                text=True
+            )
+            windows_data = json.loads(result.stdout)
+            # マップされているウィンドウのみを対象にする
+            self.windows = [HyprlandWindow(w) for w in windows_data if w.get('mapped', False)]
+        except (subprocess.SubprocessError, json.JSONDecodeError) as e:
+            print(f"Error loading windows: {e}", file=sys.stderr)
+            self.windows = []
+
+    def get_focused_window_index(self) -> int:
+        for i, window in enumerate(self.windows):
+            if window.is_focused:
+                return i
+        return 0
+
+    def focus_next_window(self, reverse: bool = False):
+        if not self.windows:
+            return
+
+        if reverse:
+            self.current_index = (self.current_index - 1) % len(self.windows)
+        else:
+            self.current_index = (self.current_index + 1) % len(self.windows)
+
+        window = self.windows[self.current_index]
+        self.focus_window(window.id)
+
+    def focus_window(self, window_id: str):
+        try:
+            subprocess.run(['hyprctl', 'dispatch', 'focuswindow', f"address:{window_id}"])
+        except subprocess.SubprocessError as e:
+            print(f"Error focusing window: {e}", file=sys.stderr)
+
+def main():
+    wm = WindowManager()
+    event_handler = HyprlandEventHandler()
+    reverse = len(sys.argv) > 1 and sys.argv[1] == "reverse"
+
+    # 最初のウィンドウ切り替え
+    wm.focus_next_window(reverse)
+
+    # Altキーが離されるまでTabキーの入力を監視
+    while event_handler.wait_for_alt_release():
+        wm.focus_next_window(reverse)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.config/hypr/window-rules.conf
+++ b/.config/hypr/window-rules.conf
@@ -53,6 +53,8 @@ windowrulev2 = workspace 3 silent, class:^(kitty)$
 # フォーカス制御
 windowrulev2 = immediate, class:^(steam_app)$
 windowrulev2 = nofocus, class:^(steam_app)$,title:^(Steam Input Keyboard)$
+windowrulev2 = immediate, class:^(Vivaldi-stable)$
+windowrulev2 = nofocus, class:^(Vivaldi-stable)$,title:^()$
 
 # IDEとエディタの設定
 windowrulev2 = opacity 0.95 0.95, class:^(Emacs)$

--- a/.config/hypr/window-rules.conf
+++ b/.config/hypr/window-rules.conf
@@ -37,6 +37,9 @@ windowrulev2 = opacity 0.95 0.95, class:^(firefox)$
 windowrulev2 = opacity 0.9 0.9, class:^(slack)$
 windowrulev2 = opacity 0.9 0.9, class:^(spotify)$
 
+# 透過を無効にする（完全に不透明にする）アプリケーション
+windowrulev2 = opaque, class:^(Vivaldi-stable)$
+
 # アニメーション設定
 windowrulev2 = animation slide left, class:^(wofi)$
 windowrulev2 = animation slide up, class:^(pavucontrol)$
@@ -52,7 +55,6 @@ windowrulev2 = immediate, class:^(steam_app)$
 windowrulev2 = nofocus, class:^(steam_app)$,title:^(Steam Input Keyboard)$
 
 # IDEとエディタの設定
-windowrulev2 = opacity 0.95 0.95, class:^(jetbrains-.*)$
 windowrulev2 = opacity 0.95 0.95, class:^(Emacs)$
 windowrulev2 = opacity 0.95 0.95, class:^(neovide)$
 


### PR DESCRIPTION


## [optional body]
このプルリクエストは `eww` と `hypr` ツールの設定とセットアップスクリプトに対するいくつかの変更を含んでいる。 最も重要な変更は、これらのツールをサポートするための新しい設定ファイルの追加と既存のスクリプトの更新である。

### Configuration and Setup for `eww` and `hypr`:

* [`.bin/deploy.sh`](diffhunk://#diff-66740242d0c3c04931e9ed2c1e8d39c8c786707d404461ed3787ffe59813d187R216-R220): Added setup commands for `eww` configuration directory and symbolic link creation for `eww.yuck` file.
* [`.bin/install.sh`](diffhunk://#diff-56ae64e08286600cfc518562b267357777c3174b113d76c4136498d3c54abfbbR27-R28): Added commands to create directories for `eww` and `hypr` scripts.
* [`.bin/utils/setup_directories.sh`](diffhunk://#diff-b56e6436792c455dde4cc3d15c5bbffc2e2c14be75b5cac2b894c353a54dc121R16-R17): Included `eww` and `hypr/scripts` directories in the list of directories to be created.
* [`.bin/utils/setup_symlinks.sh`](diffhunk://#diff-8c8cd399c1311e79019c462f8bf846e3ab630a5297c9197a083f11274ab51023R31-R39): Added symbolic links for `eww` and `hypr` configuration files.

### New Configuration Files:

* [`.config/eww/eww.scss`](diffhunk://#diff-c93406bf65dce1243a7ec432c3579cf2f5a132a9d88f165402b3905f5042a5b1R1-R44): Added a new SCSS file for `eww` styling, defining styles for the window switcher interface.
* [`.config/eww/eww.yuck`](diffhunk://#diff-8ad3f5b8ba98246b4981a6039c4b060749a0135610c62e751d71dce675342a6dR1-R31): Added a new `yuck` configuration file for `eww`, defining the window switcher interface.
* [`.config/hypr/scripts/window-switcher.py`](diffhunk://#diff-dea92b419cfd154292cd9462e5f0d3e4af0717e97887fc8d046f2d19fd591d0fR1-R156): Added a new Python script to handle window switching with previews using `eww`.

### Updates to Existing Configuration Files:

* [`.config/hypr/hyprland.conf`](diffhunk://#diff-2b98313b43e1e8fa33e555b9716f9726e520bb4350e597642e4602bf3a7edb42L80-R85): Updated shadow settings to use a new format.
* [`.config/hypr/keybinds.conf`](diffhunk://#diff-c324aa79df0652cb7a102003e7c46dc87d557c077909f574889d3c4daccb8953R44-R74): Added new keybindings for window management, including a fullscreen toggle and resize mode.
* [`.config/hypr/window-rules.conf`](diffhunk://#diff-9d8a9c749930db4f8c1ccfa27ac265e5dc233094fc751816877d02e05606bb9bR56-L55): Added rules for handling `Vivaldi-stable` windows, including making them opaque and setting focus rules.
## [optional footer(s)]

