### PR TITLE
refactor: migrate Node.js version manager from Volta to mise

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -33,6 +33,6 @@ else
   exit 1
 fi
 
-. "$HOME/.cargo/env"
+# . "$HOME/.cargo/env"
 
 source /home/archie/.config/broot/launcher/bash/br

--- a/.bashrc
+++ b/.bashrc
@@ -40,5 +40,3 @@ if [ -f ~/.bash_aliases ]; then
 fi
 
 source /home/archie/.config/broot/launcher/bash/br
-export VOLTA_HOME="$HOME/.volta"
-export PATH="$VOLTA_HOME/bin:$PATH"

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -56,8 +56,8 @@ end
 
 # set startship
 starship init fish | source
-set -gx VOLTA_HOME "$HOME/.volta"
-set -gx PATH "$VOLTA_HOME/bin" $PATH
+# set -gx VOLTA_HOME "$HOME/.volta"
+# set -gx PATH "$VOLTA_HOME/bin" $PATH
 
 ~/.local/bin/mise activate fish | source
 eval (/home/archie/.local/bin/mise activate fish)

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 poetry = "latest"
+node = "22.15.1"
 
 [env]
 _.file = ".env"


### PR DESCRIPTION
## [optional body]
- Remove Volta environment settings from .bashrc
- Comment out Volta paths in .config/fish/config.fish
- Comment out Cargo environment in .bash_profile
- Add Node.js version 22.15.1 to mise configuration
## [optional footer(s)]