### PR TITLE
feat(nvim): use Claude Sonnet 4 for commit message generation

### DIFF
--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -222,7 +222,11 @@ vim.keymap.set('n', '<leader>cm', function()
     local git_status = vim.fn.system('git status')
     -- プロンプトをフォーマット
     local formatted_prompt = string.format(extended_prompts.Commit.prompt, git_context, git_status)
-    require('CopilotChat').ask(formatted_prompt)
+    
+    -- コミットメッセージ生成時のみsonnet4を使用
+    require('CopilotChat').ask(formatted_prompt, {
+        model = 'claude-sonnet-4'  -- このaskだけsonnet4を使用
+    })
 end, { desc = "Generate Commit Message" })
 
 -- 全バッファの内容を取得する関数


### PR DESCRIPTION
## [optional body]
Upgrade the commit message generation command to specifically use Claude Sonnet 4 model while keeping the default model for other CopilotChat interactions.

- Add model parameter to CopilotChat.ask() call in commit message keymap
- Configure 'claude-sonnet-4' model specifically for commit generation
- Maintain backward compatibility with existing CopilotChat configuration

This change improves commit message quality by leveraging the more advanced language model capabilities of Claude Sonnet 4 for commit message generation tasks while preserving the existing model configuration for other chat interactions.

## [optional footer(s)]
<!--
フッターにはコミットログの内容に関連するURLを載せましょう。
例えば、チケットのURLやコミットする前に議論を重ねたIssueやチケット、slackのリンクなどが挙げられます。
https://www.praha-inc.com/lab/posts/commit-message
-->
