### PR TITLE
Feat/starship eks arn shortening

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -326,7 +326,7 @@ format = "[[](bg:#4063D8 fg:#464347)$symbol$version[](bg:#464347 fg:#4063D
 
 [kubernetes]
 disabled = false
-symbol = "☸︎"
+symbol = "☸︎  "
 style = "bg:#3371E3 fg:#EEEEEE"
 format = '[[](bg:#3371E3 fg:#464347)$symbol$context(\($namespace\))[](bg:#464347 fg:#3371E3)]($style)'
 # ARNからクラスター名だけを抽出

--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -329,6 +329,10 @@ disabled = false
 symbol = "☸︎"
 style = "bg:#3371E3 fg:#EEEEEE"
 format = '[[](bg:#3371E3 fg:#464347)$symbol$context(\($namespace\))[](bg:#464347 fg:#3371E3)]($style)'
+# ARNからクラスター名だけを抽出
+[[kubernetes.contexts]]
+context_pattern = "arn:aws:eks:[^:]+:[^:]+:cluster/(?P<cluster>[\\w-]+)"
+context_alias = "$cluster"
 
 [memory_usage]
 # disabled = false


### PR DESCRIPTION
## [optional body]
This pull request updates the Kubernetes context display in the Starship prompt configuration to extract and show only the cluster name from an AWS EKS ARN, making the prompt cleaner and more readable.

Prompt display improvements:

* Updated the Kubernetes context configuration in `.config/starship/starship.toml` to extract the cluster name from an EKS ARN using a regular expression and display only the cluster name in the prompt.
## [optional footer(s)]
<!--
フッターにはコミットログの内容に関連するURLを載せましょう。
例えば、チケットのURLやコミットする前に議論を重ねたIssueやチケット、slackのリンクなどが挙げられます。
https://www.praha-inc.com/lab/posts/commit-message
-->
