### PR TITLE
fix(hypr): enable workspace swipe forever option

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -152,7 +152,7 @@ input {
 
 # https://wiki.hyprland.org/Configuring/Variables/#gestures
 gestures {
-    workspace_swipe = false
+    workspace_swipe_forever = true
 }
 
 # Example per-device config


### PR DESCRIPTION
## [optional body]
- Change workspace_swipe to workspace_swipe_forever
- Allows continuous workspace switching with gestures
- Improves touchpad navigation experience
## [optional footer(s)]
<!--
フッターにはコミットログの内容に関連するURLを載せましょう。
例えば、チケットのURLやコミットする前に議論を重ねたIssueやチケット、slackのリンクなどが挙げられます。
https://www.praha-inc.com/lab/posts/commit-message
-->
