### PR TITLE
feat(nvim): adapt to nvim-treesitter 2025 rewrite

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -52,7 +52,8 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   local dein_toml_lazy = dein_toml_dir .. '/dein_lazy.toml'
   local lsp_setting_toml_lazy = dein_toml_dir .. '/lsp_settings.toml'
   local ddc_toml_lazy = dein_toml_dir .. '/ddc_settings.toml'
-  local treesitter_settings_lazy = dein_toml_dir .. '/treesitter_settings.toml'
+  -- Treesitter (no longer supports lazy loading since 2025 rewrite)
+  local treesitter_settings = dein_toml_dir .. '/treesitter_settings.toml'
 
   vim.call('dein#begin', dein_dir, {
     vim.fn.expand('<sfile>'),
@@ -71,11 +72,13 @@ if vim.call('dein#load_state', dein_dir) == 1 then
     -- mini
     mini_toml,
 
+    -- treesitter (not lazy)
+    treesitter_settings,
+
     -- lazy
     dein_toml_lazy,
     lsp_setting_toml_lazy,
     ddc_toml_lazy,
-    treesitter_settings_lazy
   })
 
   -- startup
@@ -93,11 +96,13 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   -- mini
   vim.call('dein#load_toml', mini_toml, {lazy = 0})
 
+  -- Treesitter (not lazy - required by nvim-treesitter 2025 rewrite)
+  vim.call('dein#load_toml', treesitter_settings, {lazy = 0})
+
   -- Lazy load
   vim.call('dein#load_toml', dein_toml_lazy, {lazy = 1})
   vim.call('dein#load_toml', lsp_setting_toml_lazy, {lazy = 1})
   vim.call('dein#load_toml', ddc_toml_lazy, {lazy = 1})
-  vim.call('dein#load_toml', treesitter_settings_lazy, {lazy = 1})
 
   vim.call('dein#end')
   vim.call('dein#save_state')

--- a/.config/nvim/treesitter_settings.toml
+++ b/.config/nvim/treesitter_settings.toml
@@ -1,69 +1,92 @@
 [[plugins]]
 repo = 'nvim-treesitter/nvim-treesitter'
 merged = 0
-on_event = 'BufReadPost'
+# Note: nvim-treesitter does not support lazy-loading since the 2025 rewrite
 lua_source = '''
-require'nvim-treesitter.configs'.setup {
-  ensure_installed = {
-    "lua",
-    "rust",
-    "python",
-    "fish",
-    "bash",
-    "typescript",
-    "svelte",
-    "json",
-    "go",
-    "dockerfile",
-    "html",
-    "markdown",
-    "toml",
-    "make",
-    "yaml",
-    "jsonnet",
-    "hurl",
-    "vim",
-    "regex",
-    "css",
-  },
+local ts = require('nvim-treesitter')
 
-  sync_install = false,
+-- Setup (optional, default values work fine)
+ts.setup {}
 
-  ignore_install = { "javascript" },
-
-  highlight = {
-    enable = true,
-    disable = { "vue" },
-    additional_vim_regex_highlighting = false,
-    use_languagetree = true,
-  },
-
-  indent = {
-    enable = true,
-  },
-
-  autotag = {
-    enable = true,
-  },
-
-
-  incremental_selection = {
-    enable = true,
-    keymaps = {
-      init_selection = "gnn",
-      node_incremental = "grn",
-      scope_incremental = "grc",
-      node_decremental = "grm",
-    },
-  },
+-- Install parsers
+-- Using pcall to avoid errors if parsers are already installed
+local parsers = {
+  "lua",
+  "rust",
+  "python",
+  "fish",
+  "bash",
+  "typescript",
+  "svelte",
+  "json",
+  "go",
+  "dockerfile",
+  "html",
+  "markdown",
+  "markdown_inline",
+  "toml",
+  "make",
+  "yaml",
+  "jsonnet",
+  "hurl",
+  "vim",
+  "vimdoc",
+  "query",
+  "regex",
+  "css",
 }
 
--- Treesitter folding
+-- Install parsers asynchronously (non-blocking)
+ts.install(parsers, { summary = false })
+
+-- Filetypes to disable treesitter highlighting
+local disabled_filetypes = { "vue" }
+
+-- Enable treesitter features via FileType autocmd
+vim.api.nvim_create_autocmd('FileType', {
+  group = vim.api.nvim_create_augroup('TreesitterSetup', { clear = true }),
+  pattern = '*',
+  callback = function(event)
+    local ft = event.match
+    -- Skip disabled filetypes
+    for _, disabled in ipairs(disabled_filetypes) do
+      if ft == disabled then return end
+    end
+
+    -- Enable treesitter highlighting
+    pcall(vim.treesitter.start, event.buf)
+  end,
+})
+
+-- Treesitter folding (new API)
 vim.opt.foldmethod = "expr"
-vim.opt.foldexpr = "nvim_treesitter#foldexpr()"
+vim.opt.foldexpr = "v:lua.vim.treesitter.foldexpr()"
 -- Unfold all blocks when opening a file
 vim.opt.foldlevel = 99
 
--- Optional: Enable Treesitter based indentation
-vim.opt.indentexpr = "nvim_treesitter#indent()"
+-- Treesitter based indentation (experimental)
+vim.api.nvim_create_autocmd('FileType', {
+  group = vim.api.nvim_create_augroup('TreesitterIndent', { clear = true }),
+  pattern = '*',
+  callback = function()
+    vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+  end,
+})
+
+-- Incremental selection keymaps
+vim.keymap.set('n', 'gnn', function()
+  require('nvim-treesitter.incremental_selection').init_selection()
+end, { desc = 'Treesitter: Init selection' })
+
+vim.keymap.set('x', 'grn', function()
+  require('nvim-treesitter.incremental_selection').node_incremental()
+end, { desc = 'Treesitter: Node incremental' })
+
+vim.keymap.set('x', 'grc', function()
+  require('nvim-treesitter.incremental_selection').scope_incremental()
+end, { desc = 'Treesitter: Scope incremental' })
+
+vim.keymap.set('x', 'grm', function()
+  require('nvim-treesitter.incremental_selection').node_decremental()
+end, { desc = 'Treesitter: Node decremental' })
 '''


### PR DESCRIPTION
## [optional body]
- Remove lazy loading support (no longer supported in 2025 rewrite)
- Update to new treesitter API using ts.setup() and ts.install()
- Replace deprecated foldexpr and indentexpr functions with new API
- Use FileType autocmds for enabling treesitter features
- Add non-blocking parser installation
- Update keymap definitions for incremental selection
- Add markdown_inline, vimdoc, query parsers

Breaking change: Treesitter now loads immediately instead of lazily, which may slightly increase startup time but ensures compatibility with the new architecture.
## [optional footer(s)]
