### PR TITLE
fix(ci): lightweight Docker image with Nix store mount strategy

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -99,6 +99,11 @@ jobs:
   # Note: We manually pull/run Docker instead of using `container:` section
   # because `container:` pulls the image BEFORE any steps run,
   # which prevents disk cleanup from running first.
+  #
+  # Strategy: Mount host's Nix store into container for cache sharing
+  # - Host installs Nix and sets up magic-nix-cache
+  # - Container uses host's /nix store via volume mount
+  # - This enables Nix cache to persist across CI runs
   verify-docker:
     name: Build & Verify (Arch Linux)
     runs-on: ubuntu-latest
@@ -121,6 +126,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Install Nix on host to prepare shared Nix store
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      # Setup Nix cache on host - this cache will be shared with container
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -131,13 +146,14 @@ jobs:
       - name: Pull Docker image
         run: docker pull ghcr.io/${{ github.repository }}/dotfiles-env:latest
 
-      # Build and verify inside container
+      # Build and verify inside container with host's Nix store mounted
       # Note: activate is skipped because container runs as root but config is for archie user
       # See: https://github.com/music-brain88/dotfiles/issues/200
       - name: Build and verify Home Manager configuration in container
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
+            -v "/nix:/nix" \
             -w /workspace \
             ghcr.io/${{ github.repository }}/dotfiles-env:latest \
             bash -c '

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,22 +34,14 @@ RUN rustup default stable
 # 作業ディレクトリの設定
 WORKDIR /root
 
-# dotfiles のコピー（あなたのリポジトリにある場合）
-COPY . dotfiles/
-
 # Nix のインストール（DeterminateSystems installer - Docker向けに最適化）
-# flake checkはnix.ymlワークフローのcheckジョブで実行するため、ここでは省略
 RUN curl -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none --no-confirm
 
 # 環境変数にNixのPATHを追加（DeterminateSystems installerのパス）
 ENV PATH="/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:${PATH}"
 
-# Home Manager のビルド（結果をイメージに含めてDockerレイヤーキャッシュを活用）
-# このステップでNixストアがイメージに焼き込まれる
-WORKDIR /root/dotfiles
-RUN nix build .#homeConfigurations.archie.activationPackage
-
-# 作業ディレクトリをrootに戻す
-WORKDIR /root
+# nix buildはCI時にランタイムで実行
+# ホストのNixストアをマウントしてmagic-nix-cacheでキャッシュを効かせる
+# dotfilesはCI時にボリュームマウントで提供
 
 CMD ["bash"]


### PR DESCRIPTION
## [optional body]

Dockerイメージのビルドに52分かかっていた問題を修正。

### 原因
- `COPY . dotfiles/` → ソース変更でレイヤーキャッシュ無効化
- `nix build` → 毎回フルビルド

### 解決策
- Dockerイメージを軽量化（`COPY` + `nix build`を削除）
- ホストのNixストアをコンテナにマウントする戦略を導入
- magic-nix-cacheでCI間のキャッシュ共有を実現

### 期待される効果

| 項目 | Before | After |
|------|--------|-------|
| Dockerビルド | ~52分 | ~数分 |
| verify-docker (2回目以降) | ~40分 | 数分 (キャッシュヒット時) |

## [optional footer(s)]

Closes #206

参考: https://github.com/music-brain88/dotfiles/actions/runs/20617220181/job/59212211108