### PR TITLE
feat(nix): replace gh-copilot with github-copilot-cli

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -60,8 +60,7 @@
       executable = true;
     };
 
-    # Copilot
-    ".copilot/config.json".source = ./.config/copilot/config.json;
+    # Copilot (config.json is managed by copilot-cli itself, not Home Manager)
     ".copilot/copilot-instructions.md".source = ./.config/copilot/copilot-instructions.md;
 
     # Hyprland config

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -8,7 +8,7 @@
     delta
     gh
     gh-dash
-    gh-copilot
+    github-copilot-cli           # GitHub Copilot CLI (agentic terminal assistant)
   ];
 
   # Git config symlinks (matching deploy.sh)

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -8,7 +8,7 @@
     delta
     gh
     gh-dash
-    github-copilot-cli           # GitHub Copilot CLI (agentic terminal assistant)
+    github-copilot-cli # GitHub Copilot CLI (agentic terminal assistant)
   ];
 
   # Git config symlinks (matching deploy.sh)


### PR DESCRIPTION
## [optional body]
`gh-copilot` (古いgh extension) を `github-copilot-cli` (新しいAgentic CLI) に置き換え。

新しいCopilot CLIはターミナルネイティブのAIアシスタントで、コード生成・編集・デバッグが可能。

## [optional footer(s)]
Closes #208
https://github.com/github/copilot-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)