### PR TITLE
fix(ci): remove release date from release-drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,6 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 template: |
   ## 📦 v$RESOLVED_VERSION
-  **Release Date:** $TODAY
 
   ## 🎉 What's New
 


### PR DESCRIPTION
## [optional body]
Remove the "Release Date" line from the release-drafter template to simplify the release notes format.

- Remove hardcoded "Release Date: $TODAY" from template
- Streamline release notes by focusing on content over metadata
- GitHub already provides release date information in the UI
