### PR TITLE
Feat/add font module

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -21,6 +21,7 @@
     ./nix/modules/tmux.nix
     ./nix/modules/neovim.nix
     ./nix/modules/dev-tools.nix
+    ./nix/modules/fonts.nix
   ];
 
   # Environment variables

--- a/nix/modules/fonts.nix
+++ b/nix/modules/fonts.nix
@@ -3,6 +3,10 @@
 {
   # Font packages
   home.packages = with pkgs; [
+    # Programming font (monospace) - for terminal and editors
     hackgen-nf-font
+
+    # System UI font (sans-serif) - for browser and desktop
+    source-han-sans
   ];
 }

--- a/nix/modules/fonts.nix
+++ b/nix/modules/fonts.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, ... }:
+
+{
+  # Font packages
+  home.packages = with pkgs; [
+    hackgen-nf-font
+  ];
+}

--- a/nix/modules/fonts.nix
+++ b/nix/modules/fonts.nix
@@ -8,5 +8,8 @@
 
     # System UI font (sans-serif) - for browser and desktop
     source-han-sans
+
+    # System UI font (serif) - for documents and reading
+    source-han-serif
   ];
 }


### PR DESCRIPTION
## [optional body]
This pull request adds font management to the Nix home configuration by introducing a new module for fonts and updating the main configuration to include it. The most important changes are listed below.

Font management additions:

* Added a new module `nix/modules/fonts.nix` that installs programming (monospace), UI (sans-serif), and document (serif) fonts using Nix packages: `hackgen-nf-font`, `source-han-sans`, and `source-han-serif`.
* Included the new `fonts.nix` module in the main `home.nix` configuration to enable font installation for the user environment.
## [optional footer(s)]
