### PR TITLE
fix(ci): replace magic-nix-cache with cache-nix-action for Docker

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -101,9 +101,11 @@ jobs:
   # which prevents disk cleanup from running first.
   #
   # Strategy: Mount host's Nix store into container for cache sharing
-  # - Host installs Nix and sets up magic-nix-cache
+  # - Host installs Nix and sets up nix-community/cache-nix-action
   # - Container uses host's /nix store via volume mount
   # - This enables Nix cache to persist across CI runs
+  # Note: magic-nix-cache doesn't work well with Docker containers because
+  # it subscribes to Nix daemon events on the host, not inside containers
   verify-docker:
     name: Build & Verify (Arch Linux)
     runs-on: ubuntu-latest
@@ -130,11 +132,18 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      # Setup Nix cache on host - this cache will be shared with container
+      # Use nix-community/cache-nix-action for stable caching
+      # magic-nix-cache doesn't detect builds inside Docker containers
+      # because it subscribes to host's Nix daemon events only
       - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nix-community/cache-nix-action@v6
         with:
-          use-flakehub: false
+          primary-key: nix-docker-${{ runner.os }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-docker-${{ runner.os }}-
+          paths: |
+            /nix
+            ~/.cache/nix
+          gc-max-store-size-linux: 4294967296
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## [optional body]
Fix Nix caching in Docker-based CI builds by switching from DeterminateSystems/magic-nix-cache-action to nix-community/cache-nix-action.

**Why this change:**
- magic-nix-cache doesn't detect builds inside Docker containers
- It only subscribes to Nix daemon events on the host system
- This caused cache misses and slower CI builds

**What changed:**
- Replace magic-nix-cache-action with cache-nix-action@v6
- Configure explicit cache keys based on OS and Nix files
- Set restore prefixes for partial cache hits
- Add garbage collection with 4GB limit to manage disk space
- Cache both /nix store and ~/.cache/nix directories

## [optional footer(s)]
close #216
