### PR TITLE
fix(fish): remove duplicate mise activation lines

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -60,5 +60,3 @@ starship init fish | source
 # set -gx PATH "$VOLTA_HOME/bin" $PATH
 
 ~/.local/bin/mise activate fish | source
-eval (/home/archie/.local/bin/mise activate fish)
-~/.local/bin/mise activate fish | source


### PR DESCRIPTION
## [optional body]
Remove redundant mise activation commands that were causing duplicate initialization in fish shell configuration.

- Remove eval command using home path
- Remove duplicate source command
- Keep only the clean relative path version

This fixes shell startup performance and eliminates potential conflicts from multiple mise initializations.
