### PR TITLE
Feat/add font config

### DIFF
--- a/.config/fontconfig/README.md
+++ b/.config/fontconfig/README.md
@@ -1,0 +1,46 @@
+# Fontconfig Settings / フォント設定
+
+## Vivaldi Browser Font Settings / Vivaldiブラウザのフォント設定
+
+Recommended fonts for Vivaldi (Settings > Webpages > Fonts):
+
+| Category                | Font Name          | Note                          |
+| ----------------------- | ------------------ | ----------------------------- |
+| Standard / 標準         | Source Han Sans    | Default fallback              |
+| Sans-serif / ゴシック体 | Source Han Sans    | or 源ノ角ゴシック             |
+| Serif / 明朝体          | Source Han Serif   | or 源ノ明朝                   |
+| Monospace / 等幅        | HackGen Console NF | Japanese-compatible monospace |
+| Cursive / 草書体        | Source Han Sans    | No JP cursive font available  |
+| Fantasy / 装飾文字      | Source Han Sans    | No JP fantasy font available  |
+
+## Source Han Font Naming / フォント名について
+
+- **Source Han Sans** (無印) = Japanese version / 日本語版 = 源ノ角ゴシック
+- **Source Han Sans SC** = Simplified Chinese / 簡体字中国語版
+- **Source Han Sans TC** = Traditional Chinese / 繁体字中国語版
+- **Source Han Sans K** = Korean / 韓国語版
+- **Source Han Sans HC** = Hong Kong / 香港版
+
+Note: "Source Han Sans JP" does not exist. The Japanese version is the default (no suffix).
+
+## Troubleshooting / トラブルシューティング
+
+If fonts don't appear correctly in browsers:
+
+```bash
+# Refresh font cache / フォントキャッシュをリフレッシュ
+rm -rf ~/.cache/fontconfig
+fc-cache -fv
+
+# Verify font is recognized / フォントが認識されているか確認
+fc-match "Source Han Sans"
+fc-list | grep -i "source han"
+```
+
+## Installed Fonts / インストール済みフォント
+
+Managed by Nix in `nix/modules/fonts.nix`:
+
+- **hackgen-nf-font** - Programming font (monospace)
+- **source-han-sans** - System UI font (sans-serif)
+- **source-han-serif** - Document font (serif)

--- a/.config/fontconfig/fonts.conf
+++ b/.config/fontconfig/fonts.conf
@@ -1,0 +1,83 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+
+<!-- Default font (no fc-match pattern) -->
+ <match>
+  <edit mode="prepend" name="family">
+   <string>Noto Sans</string>
+  </edit>
+ </match>
+
+<!-- Default font for the ja_JP locale (no fc-match pattern) -->
+ <match>
+  <test compare="contains" name="lang">
+   <string>ja</string>
+  </test>
+  <edit mode="prepend" name="family">
+   <string>Noto Sans CJK JP</string>
+  </edit>
+ </match>
+
+<!-- Default sans-serif font -->
+ <match target="pattern">
+   <test qual="any" name="family"><string>sans-serif</string></test>
+   <!--<test qual="any" name="lang"><string>ja</string></test>-->
+   <edit name="family" mode="prepend" binding="same"><string>Noto Sans</string>  </edit>
+ </match>
+
+<!-- Default serif fonts -->
+ <match target="pattern">
+   <test qual="any" name="family"><string>serif</string></test>
+   <edit name="family" mode="prepend" binding="same"><string>Noto Serif</string>  </edit>
+   <edit name="family" mode="append" binding="same"><string>IPAPMincho</string>  </edit>
+   <edit name="family" mode="append" binding="same"><string>HanaMinA</string>  </edit>
+ </match>
+
+<!-- Default monospace fonts -->
+ <match target="pattern">
+   <test qual="any" name="family"><string>monospace</string></test>
+   <edit name="family" mode="prepend" binding="same"><string>Inconsolatazi4</string></edit>
+   <edit name="family" mode="append" binding="same"><string>IPAGothic</string></edit>
+ </match>
+
+<!-- Fallback fonts preference order -->
+ <alias>
+  <family>sans-serif</family>
+  <prefer>
+   <family>Noto Sans</family>
+   <family>Open Sans</family>
+   <family>Droid Sans</family>
+   <family>Ubuntu</family>
+   <family>Roboto</family>
+   <family>NotoSansCJK</family>
+   <family>Source Han Sans</family>
+   <family>IPAPGothic</family>
+   <family>VL PGothic</family>
+   <family>Koruri</family>
+  </prefer>
+ </alias>
+ <alias>
+  <family>serif</family>
+  <prefer>
+   <family>Noto Serif</family>
+   <family>Droid Serif</family>
+   <family>Roboto Slab</family>
+   <family>IPAPMincho</family>
+  </prefer>
+ </alias>
+ <alias>
+  <family>monospace</family>
+  <prefer>
+   <family>Inconsolatazi4</family>
+   <family>Ubuntu Mono</family>
+   <family>Droid Sans Mono</family>
+   <family>Roboto Mono</family>
+   <family>IPAGothic</family>
+  </prefer>
+ </alias>
+
+ <!-- Font directories -->
+ <dir>~/.fonts</dir>
+ <dir>~/.nix-profile/share/fonts</dir>
+</fontconfig>

--- a/home.nix
+++ b/home.nix
@@ -129,5 +129,11 @@
       source = ./.config/ncmpcpp;
       recursive = true;
     };
+
+    # fontconfig
+    ".config/fontconfig" = {
+      source = ./.config/fontconfig;
+      recursive = true;
+    };
   };
 }


### PR DESCRIPTION
## [optional body]
This pull request introduces font configuration and documentation to the project, primarily to improve font handling for Japanese and general use cases. The main changes include adding a new fontconfig setup, providing a comprehensive README for font selection and troubleshooting, and updating the home configuration to include these files.

**Font configuration and documentation:**

* Added `.config/fontconfig/fonts.conf` with custom font preferences, locale-specific rules for Japanese, and fallback font order for sans-serif, serif, and monospace categories. This ensures better font rendering and selection, especially for Japanese text.
* Created `.config/fontconfig/README.md` to document recommended fonts for Vivaldi browser, explain Source Han font naming conventions, provide troubleshooting steps, and list installed fonts managed by Nix.

**Configuration integration:**

* Updated `home.nix` to include `.config/fontconfig` in the home manager's file list, ensuring the new font configuration and documentation are properly deployed.
