### PR TITLE
chore(nvim): upgrade Claude models to 4.5 versions

### DIFF
--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -160,7 +160,8 @@ local config = {
   -- model = 'claude-3.7-sonnet', -- 使用するモデル
   -- model = 'claude-sonnet-4', -- 使用するモデル
   -- model = 'claude-opus-4', -- 使用するモデル
-  model = 'claude-opus-41', -- 使用するモデル
+  -- model = 'claude-opus-41', -- 使用するモデル
+  model = 'claude-opus-4.5', -- 使用するモデル
   -- model = 'claude-3.5-sonnet', -- 使用するモデル
   -- model = 'gemini-2.0-flash-001', -- 使用するモデル
   -- model = 'o1', -- 使用するモデル
@@ -225,7 +226,7 @@ vim.keymap.set('n', '<leader>cm', function()
     
     -- コミットメッセージ生成時のみsonnet4を使用
     require('CopilotChat').ask(formatted_prompt, {
-        model = 'claude-sonnet-4'  -- このaskだけsonnet4を使用
+        model = 'claude-sonnet-4.5'  -- このaskだけsonnet4を使用
     })
 end, { desc = "Generate Commit Message" })
 


### PR DESCRIPTION
## [optional body]
デフォルトモデルとコミットメッセージ生成用モデルをClaudeの最新4.5バージョンにアップグレード

変更内容:
- デフォルトモデルを opus-41 から opus-4.5 に更新
- コミットメッセージ生成用モデルを sonnet-4 から sonnet-4.5 に更新

理由:
- Claude 4.5シリーズは前バージョンと比較して性能が向上
- より正確なコード生成とコミットメッセージの品質向上が期待できる

影響範囲:
- 通常のCopilot Chat操作は opus-4.5 を使用
- <leader>cm でのコミットメッセージ生成は sonnet-4.5 を使用
