### PR TITLE
ci(nix): add push trigger to workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,15 @@
 name: Nix CI
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'llm/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## [optional body]
Enable CI runs on main branch pushes to improve cache availability across pull requests and catch issues earlier in the development cycle.

Changes:
- Add push trigger for main branch
- Exclude markdown files, docs, llm directories, LICENSE, and .gitignore from triggering builds
- Maintain existing pull_request trigger configuration

Benefits:
- Leverage GitHub Actions cache scope rules: caches created on main branch are accessible from all PR branches, improving build performance
- Provide immediate feedback on merged changes
- Avoid unnecessary builds for documentation-only updates

Note: PR branch caches are isolated from each other, making main branch cache crucial for consistent build performance across PRs.