### PR TITLE
refactor(nvim): use stdpath for config directory

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -30,7 +30,7 @@ if not string.match(vim.o.runtimepath, '/dein.vim') then
 end
 
 if vim.call('dein#load_state', dein_dir) == 1 then
-  local dein_toml_dir = vim.env.HOME .. '/dotfiles/.config/nvim'
+  local dein_toml_dir = vim.fn.stdpath('config')
   local status_line_dir = '/status_line'
   local mini_dir = '/mini'
 


### PR DESCRIPTION
## [optional body]
Replace hardcoded HOME path with vim.fn.stdpath('config') for better portability and compatibility with Neovim's standard directory structure.

Benefits:
- Works correctly across different OS environments
- Respects XDG_CONFIG_HOME if set
- More idiomatic Neovim configuration
- Removes dependency on HOME environment variable
