### PR TITLE
feat(fish): add editor env vars and fix keybind comment

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -4,6 +4,10 @@ set -U FZF_LEGACY_KEYBINDINGS 0
 set -x LANG en_US.UTF-8
 set -x LC_CTYPE en_US.UTF-8
 
+# Editor settings
+set -x EDITOR nvim
+set -x VISUAL nvim
+
 # Aliases
 alias vim 'nvim'
 alias rm 'rm -i'

--- a/.config/fish/functions/fish_user_key_bindings.fish
+++ b/.config/fish/functions/fish_user_key_bindings.fish
@@ -15,7 +15,7 @@ function fish_user_key_bindings
   bind \ct skim-file-widget
   # Ctrl + r で履歴を検索する
   bind \cr skim-history-widget
-  # Alt + e でディレクトリを検索する
+  # Alt + d でディレクトリを検索する
   bind \ed skim-cd-widget
 
     #!/bin/fish


### PR DESCRIPTION
## [optional body]
エディタ環境変数の設定とキーバインドコメントの修正:
- EDITOR/VISUALにnvimを設定し、システム全体でnvimをデフォルトエディタとして使用
- skim-cd-widgetのキーバインドコメントを実際のキー（Alt + d）に修正
