### PR TITLE
debug(ci): investigate Nix cache nix-daemon.sh issue

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -107,11 +107,54 @@ jobs:
             ~/.cache/nix
           nix: false
 
+      # DEBUG: Inspect /nix directory after cache restore
+      - name: Debug - Inspect /nix after cache restore
+        if: steps.nix-cache.outputs.hit == 'true'
+        run: |
+          echo "=== Cache restore debug info ==="
+          echo "Cache hit: ${{ steps.nix-cache.outputs.hit }}"
+          echo ""
+          echo "=== /nix top-level contents ==="
+          ls -la /nix/ || echo "/nix does not exist"
+          echo ""
+          echo "=== /nix/var/nix/profiles contents ==="
+          ls -la /nix/var/nix/profiles/ || echo "profiles dir does not exist"
+          echo ""
+          echo "=== /nix/var/nix/profiles/default contents ==="
+          ls -la /nix/var/nix/profiles/default/ || echo "default profile does not exist"
+          echo ""
+          echo "=== Looking for nix-daemon.sh anywhere in /nix ==="
+          find /nix -name "nix-daemon.sh" 2>/dev/null || echo "nix-daemon.sh not found"
+          echo ""
+          echo "=== Looking for any profile.d directories ==="
+          find /nix -type d -name "profile.d" 2>/dev/null || echo "No profile.d directories"
+          echo ""
+          echo "=== /nix/receipt.json contents ==="
+          cat /nix/receipt.json 2>/dev/null | head -50 || echo "receipt.json does not exist"
+
       # Install Nix on host to prepare shared Nix store
       # Skip if cache was restored (Nix is already available from cache)
       - name: Install Nix
         if: steps.nix-cache.outputs.hit != 'true'
         uses: DeterminateSystems/nix-installer-action@main
+
+      # DEBUG: Inspect /nix directory after fresh Nix install
+      - name: Debug - Inspect /nix after fresh install
+        if: steps.nix-cache.outputs.hit != 'true'
+        run: |
+          echo "=== Fresh install debug info ==="
+          echo ""
+          echo "=== /nix/var/nix/profiles contents ==="
+          ls -la /nix/var/nix/profiles/ || echo "profiles dir does not exist"
+          echo ""
+          echo "=== /nix/var/nix/profiles/default contents ==="
+          ls -la /nix/var/nix/profiles/default/ || echo "default profile does not exist"
+          echo ""
+          echo "=== Looking for nix-daemon.sh anywhere in /nix ==="
+          find /nix -name "nix-daemon.sh" 2>/dev/null || echo "nix-daemon.sh not found"
+          echo ""
+          echo "=== /nix/receipt.json contents ==="
+          cat /nix/receipt.json 2>/dev/null | head -50 || echo "receipt.json does not exist"
 
       # Source Nix profile when using cached Nix (not installed fresh)
       # Falls back to fresh install if cache is corrupted
@@ -133,6 +176,18 @@ jobs:
       - name: Install Nix (fallback)
         if: steps.nix-cache.outputs.hit == 'true' && steps.setup-cached-nix.outputs.success != 'true'
         uses: DeterminateSystems/nix-installer-action@main
+
+      # DEBUG: Inspect /nix after fallback install
+      - name: Debug - Inspect /nix after fallback install
+        if: steps.nix-cache.outputs.hit == 'true' && steps.setup-cached-nix.outputs.success != 'true'
+        run: |
+          echo "=== Fallback install debug info ==="
+          echo ""
+          echo "=== /nix/var/nix/profiles/default contents ==="
+          ls -la /nix/var/nix/profiles/default/ || echo "default profile does not exist"
+          echo ""
+          echo "=== Looking for nix-daemon.sh anywhere in /nix ==="
+          find /nix -name "nix-daemon.sh" 2>/dev/null || echo "nix-daemon.sh not found"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Nixキャッシュ復元後に `nix-daemon.sh` が見つからない問題を調査するためのデバッグステップを追加

## 背景
- キャッシュは正常に復元される（3.6GB）
- しかし `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` が存在しない
- 結果として毎回 "Cache appears corrupted" ワーニングが発生し、fallback で Nix を再インストール

## 調査内容
以下の情報を収集:
1. キャッシュ復元後の `/nix` ディレクトリ構造
2. `nix-daemon.sh` の実際の場所（`find` で検索）
3. `profile.d` ディレクトリの場所
4. `receipt.json` の内容
5. 新規インストール後とfallbackインストール後の状態比較

## 期待される結果
- DeterminateSystems/nix-installer が `nix-daemon.sh` をどこに配置するか判明
- キャッシュに含まれている/いないファイルが明確になる
- 適切な修正方針が決定できる

## 関連 Issue
- #233 (closed, but warning still occurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)