### PR TITLE
fix(ci): simplify Nix cache strategy by always installing Nix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -105,11 +105,14 @@ jobs:
             ~/.cache/nix
           nix: false
 
-      # Remove Nix installer artifacts to force fresh installation
-      # This ensures nix-installer creates profiles correctly
-      # while preserving /nix/store cache for fast builds
+      # Fix /nix ownership and remove installer artifacts for fresh installation
+      # - Restore root ownership (cache restores as runner user)
+      # - Remove receipt.json to force nix-installer to run fresh
+      # - This preserves /nix/store cache while ensuring proper setup
       - name: Prepare for fresh Nix install
-        run: rm -f /nix/receipt.json /nix/nix-installer
+        run: |
+          sudo chown -R root:root /nix
+          sudo rm -f /nix/receipt.json /nix/nix-installer
 
       # Always install Nix to ensure profiles are created correctly
       - name: Install Nix


### PR DESCRIPTION
## [optional body]
Simplify the Nix cache workflow by removing complex conditional logic and always performing a fresh Nix installation.

Changes:
- Remove receipt.json before nix-installer to force fresh install
- Remove conditional Nix installation (cache hit check)
- Remove "Setup Nix from cache" step
- Remove fallback installation logic
- Update comments to reflect new cache strategy

The cache now only serves as a build artifact cache for /nix/store, while Nix is always freshly installed to ensure profiles are created correctly. This eliminates the "Cache appears corrupted" warning.


## [optional footer(s)]
Closes #241
