### PR TITLE
feat(nix): add denops and skim dependencies

### DIFF
--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -64,6 +64,9 @@
       # Clipboard support
       wl-clipboard # Wayland
       xclip # X11
+
+      # denops.vim dependencies
+      deno
     ];
   };
 

--- a/nix/modules/rust-tools.nix
+++ b/nix/modules/rust-tools.nix
@@ -21,6 +21,7 @@
     tokei # code statistics tool
     jql # JSON query language
     oxker # Docker TUI
+    skim # Command-line fuzzy finder
   ];
 
   # Environment variables for Rust


### PR DESCRIPTION
## [optional body]
Neovim と Rust ツールセットに新しい依存関係を追加しました:

- Neovim モジュールに Deno を追加
  - denops.vim プラグインのサポートに必要
  - Vim/Neovim プラグインを Deno/TypeScript で書けるようになる

- Rust ツールに skim を追加
  - Rust で書かれたコマンドライン用のファジーファインダー
  - fzf の代替として使える高速なツール

これらの追加により、Neovim の機能拡張とコマンドライン操作が
より快適になるよ！🚀