### PR TITLE
fix(fish): remove unused fzf-fish plugin

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,5 +1,3 @@
-set -U FZF_LEGACY_KEYBINDINGS 0
-
 # Locale settings
 set -x LANG en_US.UTF-8
 set -x LC_CTYPE en_US.UTF-8

--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -6,7 +6,6 @@
     fish
     starship
     fishPlugins.done
-    fishPlugins.fzf-fish
     fishPlugins.forgit
     fishPlugins.z
     fishPlugins.bass


### PR DESCRIPTION
## [optional body]
fish 4.3へのアップグレードに伴い、使用していないfzf-fish関連の設定を削除。

- `fishPlugins.fzf-fish`をshell.nixから削除
- `FZF_LEGACY_KEYBINDINGS`設定をconfig.fishから削除

このリポジトリではfzfではなくskimを使用しているため、fzf-fishプラグインは不要。

## [optional footer(s)]
Closes #246