### PR TITLE
feat(claude): add PR creation slash command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,26 @@
+# Pull Request 作成
+
+Pull Request を作成します。
+
+## 手順
+
+1. `.github/PULL_REQUEST_TEMPLATE.md` を読み込んでテンプレートの形式を確認
+2. `git log main..HEAD` と `git diff main...HEAD` で変更内容を確認
+3. Conventional Commits スタイルでタイトルを決定:
+   - `feat`: 新しい機能
+   - `fix`: バグ修正
+   - `docs`: ドキュメントのみの変更
+   - `chore`: コードに触れない変更
+   - `refactor`: リファクタリング
+   - `style`: フォーマットのみの変更
+   - `test`: テストの追加・修正
+   - `perf`: パフォーマンス改善
+   - `ci`: CI設定の変更
+   - `build`: ビルドシステムの変更
+4. テンプレートに沿って PR 本文を作成
+5. `gh pr create` で PR を作成
+6. 作成した PR の URL を表示
+
+## 追加情報
+
+$ARGUMENTS

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,25 +1,47 @@
 # Pull Request 作成
 
-Pull Request を作成します。
+Pull Request を作成または更新します。
 
 ## 手順
 
-1. `.github/PULL_REQUEST_TEMPLATE.md` を読み込んでテンプレートの形式を確認
-2. `git log main..HEAD` と `git diff main...HEAD` で変更内容を確認
-3. Conventional Commits スタイルでタイトルを決定:
-   - `feat`: 新しい機能
-   - `fix`: バグ修正
-   - `docs`: ドキュメントのみの変更
-   - `chore`: コードに触れない変更
-   - `refactor`: リファクタリング
-   - `style`: フォーマットのみの変更
-   - `test`: テストの追加・修正
-   - `perf`: パフォーマンス改善
-   - `ci`: CI設定の変更
-   - `build`: ビルドシステムの変更
-4. テンプレートに沿って PR 本文を作成
-5. `gh pr create` で PR を作成
-6. 作成した PR の URL を表示
+### 1. 既存PRの確認
+`gh pr list --head <current-branch>` で現在のブランチにPRが既に存在するか確認する。
+
+**PRが既に存在する場合:**
+- PR番号とURLをユーザーに表示
+- `gh pr diff <number>` でPR作成時点からの差分を確認
+- 新しいコミットがあれば差分を表示
+- ユーザーに以下を確認:
+  - PR本文を更新するか
+  - 追加のコミットをプッシュするか
+  - 何もしないか
+
+**PRが存在しない場合:** 手順2へ進む
+
+### 2. テンプレートの確認
+`.github/PULL_REQUEST_TEMPLATE.md` を読み込んでテンプレートの形式を確認し、必ずその形式に従う。
+
+### 3. 変更内容の確認
+`git log main..HEAD` と `git diff main...HEAD` で変更内容を確認する。
+
+### 4. タイトルの決定
+Conventional Commits スタイルでタイトルを決定:
+- `feat`: 新しい機能
+- `fix`: バグ修正
+- `docs`: ドキュメントのみの変更
+- `chore`: コードに触れない変更
+- `refactor`: リファクタリング
+- `style`: フォーマットのみの変更
+- `test`: テストの追加・修正
+- `perf`: パフォーマンス改善
+- `ci`: CI設定の変更
+- `build`: ビルドシステムの変更
+
+### 5. PR本文の作成
+テンプレートの形式（`## [optional body]`, `## [optional footer(s)]`）に沿ってPR本文を作成する。
+
+### 6. PR作成
+`gh pr create` でPRを作成し、作成したPRのURLを表示する。
 
 ## 追加情報
 


### PR DESCRIPTION
## [optional body]
Claude Codeのカスタムスラッシュコマンド `/pr` を追加。
PRテンプレートを使用したPR作成ワークフローを自動化し、
Conventional Commitsスタイルに従ったタイトル決定をサポートする。

### 変更内容
- `.claude/commands/pr.md`: PR作成コマンドの定義ファイルを追加

### 機能
- 既存PRの確認と更新オプション
- PR作成時点からの差分表示
- テンプレート形式の強制
- Conventional Commitsスタイルでのタイトル決定

### 使い方
Claude Codeで `/pr` と入力すると、以下の手順でPRが作成される:
1. 既存PRの確認（あればユーザーに更新オプションを提示）
2. PRテンプレートの読み込み
3. 変更内容の確認（git log, git diff）
4. Conventional Commitsスタイルでタイトルを決定
5. `gh pr create`でPR作成

## [optional footer(s)]
🤖 Generated with [Claude Code](https://claude.ai/code)