### PR TITLE
feat(copilot): add global copilot-instructions symlink

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -67,6 +67,8 @@
 
     # Copilot (config.json is managed by copilot-cli itself, not Home Manager)
     ".copilot/copilot-instructions.md".source = ./.config/copilot/copilot-instructions.md;
+    # Global copilot-instructions for GitHub Copilot (VS Code, etc.)
+    ".github/copilot-instructions.md".source = ./.config/copilot/copilot-instructions.md;
     # Skills directory for GitHub Copilot Agent Skills support
     ".copilot/skills" = {
       source = ./.config/copilot/skills;


### PR DESCRIPTION
## [optional body]

GitHub Copilot（VS Code等）がグローバルに参照する `~/.github/copilot-instructions.md` へのシンボリックリンクを追加。

既存の `.config/copilot/copilot-instructions.md` を共有し、Copilot CLIとVS Code拡張機能の両方で同じ設定を使えるようになります。

## [optional footer(s)]

関連設定:
- Copilot CLI: `.copilot/copilot-instructions.md`
- VS Code等グローバル: `.github/copilot-instructions.md`