### PR TITLE
chore(nix): update github-copilot-cli to 1.0.12

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,13 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.7";
+                copilotVersion = "1.0.12";
               in
               {
                 version = copilotVersion;
                 src = prev.fetchzip {
                   url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-MyM+eGj5S+3ACcPvVqfbu8hOMbdImiaEkj171JUIjU8=";
+                  hash = "sha256-kgv/QOALYpp9cHApglyuVFQoihcVldT8GLl5FHOM9XY=";
                 };
                 # npm version may not match internal binary version string
                 doInstallCheck = false;


### PR DESCRIPTION
## [optional body]

Update github-copilot-cli package version from 1.0.7 to 1.0.12
to get the latest features and bug fixes.

- Bump copilotVersion to 1.0.12
- Update package hash to match new version

## [optional footer(s)]

Changes in `flake.nix`:
- Updated version string in overlay
- Updated SRI hash for the new package version
