### PR TITLE
fix(nix): correct mise configuration field name

### DIFF
--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -110,7 +110,7 @@
     enable = true;
     enableFishIntegration = true;
 
-    settings = {
+    globalConfig = {
       tools = {
         node = "lts";
         python = "3.11";


### PR DESCRIPTION
## fix(nix): settings.tools が不正なフィールドとして警告される問題を修正

`programs.mise.settings.tools` → `programs.mise.globalConfig.tools` に変更。

Home Manager の `programs.mise.settings` は mise の `[settings]` セクションに対応するため、
tool バージョン定義が `[settings.tools]` として出力されてしまい mise が認識できなかった。
`globalConfig.tools` に移動することで正しく `[tools]` セクションとして出力されるようになる。

## Refs
- Closes #271