### PR TITLE
fix(starship): replace emoji with Nerd Font glyphs to fix prompt width calculation

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -245,7 +245,7 @@ style = "bg:#1A73E8 fg:#EEEEEE"
 format = '[[](bg:#1A73E8 fg:#464347)$symbol$account(\($region\))[](bg:#464347 fg:#1A73E8)]($style)'
 
 [git_branch]
-symbol = ""
+symbol = "󰊢 "
 #symbol = " " # alternate
 style = "bg:#96ab5f fg:#111111"
 # truncation_length = 4
@@ -281,9 +281,9 @@ diverged = " ⇕${ahead_count} ${behind_count}"
 conflicted = "  ${count}"
 deleted = "  ${count}"
 renamed = " » ${count}"
-modified = "📝${count}"
+modified = "󰏫 ${count}"
 staged = "  ${count}"
-untracked = " 🐾${count}"
+untracked = " 󱪝 ${count}"
 format = "([[](bg:#E0B25D fg:#464347)$stashed$staged$modified$renamed$untracked$deleted$conflicted$ahead_behind[](bg:#464347 fg:#E0B25D)]($style))"
 
 [golang]
@@ -326,7 +326,7 @@ format = "[[](bg:#4063D8 fg:#464347)$symbol$version[](bg:#464347 fg:#4063D
 
 [kubernetes]
 disabled = false
-symbol = "☸︎  "
+symbol = "󱃾 "
 style = "bg:#3371E3 fg:#EEEEEE"
 format = '[[](bg:#3371E3 fg:#464347)$symbol$context(\($namespace\))[](bg:#464347 fg:#3371E3)]($style)'
 # ARNからクラスター名だけを抽出


### PR DESCRIPTION
## Summary

starshipプロンプトで使用していた絵文字（☸︎, 📝, 🐾）がターミナルの文字幅計算とズレを起こし、
シェル入力時に文字が重複表示される問題（例: `git` → `ggit`）を修正。

絵文字をNerd Fontグリフに置き換えることで文字幅計算を安定させた。

| モジュール | 変更前 | 変更後 | Nerd Font |
|-----------|--------|--------|-----------|
| kubernetes | `☸︎` (U+2638 + U+FE0E) | `󱃾` (U+F10FE) | nf-md-kubernetes |
| git_branch | `` (U+E65D) | `󰊢` (U+F02A2) | nf-md-git |
| git_status (modified) | `📝` | `󰏫` | nf-md-pencil_outline |
| git_status (untracked) | `🐾` | `󱪝` (U+F1A9D) | nf-md-eye_off |

## Footer

Closes #273