### PR TITLE
chore(nix): update github-copilot-cli to 1.0.25

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,13 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.12";
+                copilotVersion = "1.0.25";
               in
               {
                 version = copilotVersion;
                 src = prev.fetchzip {
                   url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-kgv/QOALYpp9cHApglyuVFQoihcVldT8GLl5FHOM9XY=";
+                  hash = "sha256-u0W1nqtahlP0LMZ/Z3XWbXe5bZrcvRNeF0YC6cEbxuM=";
                 };
                 # npm version may not match internal binary version string
                 doInstallCheck = false;


### PR DESCRIPTION
## [optional body]
`github-copilot-cli` のバージョンを 1.0.12 から 1.0.25 に更新。
npm registry の最新版に追従するためのバージョンバンプとハッシュ更新。

## [optional footer(s)]
https://www.npmjs.com/package/@github/copilot