### PR TITLE
chore(nix): update github-copilot-cli to 1.0.31

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,13 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.25";
+                copilotVersion = "1.0.31";
               in
               {
                 version = copilotVersion;
                 src = prev.fetchzip {
                   url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-u0W1nqtahlP0LMZ/Z3XWbXe5bZrcvRNeF0YC6cEbxuM=";
+                  hash = "sha256-QDXYYbcoawk4NAdzLVS7ft1iAKC7h/3SIU3E8r0NVu4=";
                 };
                 # npm version may not match internal binary version string
                 doInstallCheck = false;


### PR DESCRIPTION
## Summary

GitHub Copilot CLI のバージョンを `1.0.25` → `1.0.31` にアップデート。

## Changes

- `flake.nix` の `copilotVersion` を `1.0.31` に更新
- 対応する tarball の SRI hash を更新

## Verification

- `nix build .#homeConfigurations.archie.activationPackage` が成功することを確認済み

## Release Notes (1.0.26 → 1.0.31)

### v1.0.31
- Windows / Ubuntu ターミナルでプロンプトフレームの描画不具合を修正

### v1.0.30
- フィードバックフォームのリンクを正しい GitHub リポジトリに修正
- `/undo` が rewind 不可のとき（git リポジトリでない / コミットなし）に説明メッセージを表示
- `skills.discover` 使用時にプラグインの skills / commands が正しく検出されるように
- ステータスバー表示項目（ディレクトリ、ブランチ、effort、コンテキストウィンドウ、クォータ）をカスタマイズできる `/statusline`（エイリアス `/footer`）を追加
- prompt モードの `--list-env` フラグを削除
- bracketed paste 処理のリグレッションで壊れていたクリップボード画像ペーストを修正
- Ctrl+V と Meta+V の両方でどのプラットフォームでも画像ペーストが可能に

### v1.0.29
- リモート MCP サーバー設定で `type` フィールド省略時に `http` がデフォルトに
- 点滅カーソルの幅が安定し、点滅時にテキストがずれない
- prompt モードでロードされた plugin / agent / skill / MCP server をログ出力する `--list-env` フラグを追加（CI パイプラインでの環境検証向け）
- **Claude Opus 4.7 のサポートを追加**
- シェルコマンドと MCP サーバーに環境変数 `COPILOT_AGENT_SESSION_ID` が渡されるように
- リポジトリオーナーをローカルユーザー名ではなく git remote URL から正しく判定
- Windows でクラッシュ終了後もターミナル状態が正しく復元されるように

### v1.0.28
- git submodule 内でパーミッションプロンプトが正しいリポジトリパスを表示
- `read_agent` が結果待機中のときに重複したバックグラウンドエージェント完了通知を送らない
- MCP マイグレーションヒントがシェルコマンドを埋め込むのではなくプラットフォーム別ドキュメントへのリンクに
- Azure リソース ID で az CLI 実行時の誤検出パス警告を解消
- Rewind ピッカーの操作を矢印キーと Enter に簡素化（1〜9 のクイック選択を廃止）
- エディタ起動失敗時に明確なエラーメッセージを表示
- マスコットが常時点滅でなく起動時に短くまばたきするように
- `--resume` ピッカーから CLI リモートコントロールセッションに接続可能に
- ターミナルタイトル更新をオプトアウトする `COPILOT_DISABLE_TERMINAL_TITLE` 環境変数をサポート
- `/clear` や `/new` 後にカスタム instructions と skills がディスクから再読込される

### v1.0.27
- Copilot Pro トライアル一時停止時に汎用ポリシーエラーではなく明確なメッセージを表示
- 入力中のステータスバーに `@files` / `#issues` ヒント、スラッシュコマンドピッカー表示時に `/help` ヒントを表示
- WSL のクリップボードコピーで不可視 BOM が混入しないように
- 会話履歴に影響を与えずにサクッと質問できる `/ask` コマンドを追加
- プラグインカタログを更新する `copilot plugin marketplace update` コマンドを追加

### v1.0.26
- Escape キーで `ask_user` / elicitation プロンプトが確実に閉じるように
- `find -exec` ブロック内の引数に対するスプリアスなディレクトリアクセスプロンプトを抑制
- コンテキスト圧縮がチェックポイント境界でツール呼び出しを分割した場合でも回復不能エラーにならない
- bash コマンド内の単一セグメントのスラッシュ接頭トークン（例: `/help`, `/start`）をファイルパスとして扱わない
- Anthropic BYOM が画像ファイル表示時に画像データを正しく含める
- パーミッションプロンプト通知フックは実際にプロンプトが表示されたときだけ発火
- `ctrl+o` が `ctrl+e` と同様にすべてのタイムラインエントリを展開
- Remote タブで PR なしでも Copilot coding agent タスクを正しく表示・ステアリング可能に
- `--remote` フラグと `/remote` コマンドのヘルプで "steering" → "remote control" にリネーム
- 同内容の custom instruction ファイル（`copilot-instructions.md` と `CLAUDE.md` 等）の重複送信を回避し、ターンごとのトークン浪費を削減
- プラグインフックにインストールディレクトリを示す `PLUGIN_ROOT` / `COPILOT_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` 環境変数を渡す
- ACP サーバーを localhost のみにバインドし、意図しないネットワーク公開を防止
- マーケットプレイスから `git` という名前のプラグインをインストールしても URL パース失敗でエラーにならない
- エンタープライズログインで URL スキームなしのホスト名（例: `github.example.com`）を受け付ける
- Windows で LSP 言語サーバーが適切なファイル URI パスで正しく初期化されるように
- ファイル編集操作の相対パスをセッション作業ディレクトリから解決するように
- 同期プロンプト内のセッションスコープセレクタがより目立ち、左右矢印キーでキーボード操作可能に
- 特定 `applyTo` パターン付き instruction ファイルは内容をインライン展開せずテーブルに集約し、コンテキストウィンドウ使用量を削減
- リポジトリ / URL / ローカルパスからのプラグインインストールに deprecation 警告を追加

<details>
<summary>参考</summary>

- <https://github.com/github/copilot-cli/releases>

</details>
