### PR TITLE
chore(nix): update github-copilot-cli to 1.0.50

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,13 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.31";
+                copilotVersion = "1.0.50";
               in
               {
                 version = copilotVersion;
                 src = prev.fetchzip {
                   url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-QDXYYbcoawk4NAdzLVS7ft1iAKC7h/3SIU3E8r0NVu4=";
+                  hash = "sha256-sjPxL9JntpsqrnhNMxaqaCfYLt30+lgt37zRN11CBb8=";
                 };
                 # npm version may not match internal binary version string
                 doInstallCheck = false;


### PR DESCRIPTION
## Summary
- Bump `github-copilot-cli` from `1.0.31` to `1.0.50` in the flake overlay
- Update the `fetchzip` hash for the new npm tarball

## Test plan
- [x] `mise run nix:build` succeeds
- [x] `mise run nix:switch` activates without errors
- [x] `copilot --version` reports `1.0.50` after switch
- [x] CI (`nix flake check`, Docker verify) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)