### PR TITLE
feat(claude): tmux 連携の Claude Code 起動環境を整備

### DIFF
--- a/.config/claude/keybindings.json
+++ b/.config/claude/keybindings.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Global",
+      "bindings": {
+        "ctrl+t": "app:toggleTodos",
+        "ctrl+o": "app:toggleTranscript",
+        "ctrl+shift+o": "app:toggleTeammatePreview",
+        "ctrl+r": "history:search"
+      }
+    },
+    {
+      "context": "Chat",
+      "bindings": {
+        "escape": "chat:cancel",
+        "ctrl+f": "chat:killAgents",
+        "shift+tab": "chat:cycleMode",
+        "meta+p": "chat:modelPicker",
+        "meta+o": "chat:fastMode",
+        "ctrl+p": "chat:thinkingToggle",
+        "enter": "chat:submit",
+        "up": "history:previous",
+        "down": "history:next",
+        "ctrl+_": "chat:undo",
+        "ctrl+shift+-": "chat:undo",
+        "ctrl+g": null,
+        "ctrl+e": "chat:externalEditor",
+        "ctrl+s": "chat:stash",
+        "ctrl+v": "chat:imagePaste",
+        "ctrl+q": "chat:snippetPicker"
+      }
+    },
+    {
+      "context": "Autocomplete",
+      "bindings": {
+        "tab": "autocomplete:accept",
+        "escape": "autocomplete:dismiss",
+        "up": "autocomplete:previous",
+        "down": "autocomplete:next"
+      }
+    },
+    {
+      "context": "Settings",
+      "bindings": {
+        "escape": "confirm:no",
+        "up": "select:previous",
+        "down": "select:next",
+        "k": "select:previous",
+        "j": "select:next",
+        "ctrl+p": "select:previous",
+        "ctrl+n": "select:next",
+        "enter": "select:accept",
+        "space": "select:accept",
+        "/": "settings:search",
+        "r": "settings:retry"
+      }
+    },
+    {
+      "context": "Confirmation",
+      "bindings": {
+        "y": "confirm:yes",
+        "n": "confirm:no",
+        "enter": "confirm:yes",
+        "escape": "confirm:no",
+        "up": "confirm:previous",
+        "down": "confirm:next",
+        "tab": "confirm:nextField",
+        "space": "confirm:toggle",
+        "shift+tab": "confirm:cycleMode",
+        "ctrl+e": "confirm:toggleExplanation"
+      }
+    },
+    {
+      "context": "Tabs",
+      "bindings": {
+        "tab": "tabs:next",
+        "shift+tab": "tabs:previous",
+        "right": "tabs:next",
+        "left": "tabs:previous"
+      }
+    },
+    {
+      "context": "Transcript",
+      "bindings": {
+        "ctrl+e": "transcript:toggleShowAll",
+        "escape": "transcript:exit"
+      }
+    },
+    {
+      "context": "HistorySearch",
+      "bindings": {
+        "ctrl+r": "historySearch:next",
+        "escape": "historySearch:accept",
+        "tab": "historySearch:accept",
+        "enter": "historySearch:execute"
+      }
+    },
+    {
+      "context": "Task",
+      "bindings": {
+        "ctrl+b": "task:background"
+      }
+    },
+    {
+      "context": "ThemePicker",
+      "bindings": {
+        "ctrl+t": "theme:toggleSyntaxHighlighting"
+      }
+    },
+    {
+      "context": "Help",
+      "bindings": {
+        "escape": "help:dismiss"
+      }
+    },
+    {
+      "context": "Attachments",
+      "bindings": {
+        "right": "attachments:next",
+        "left": "attachments:previous",
+        "backspace": "attachments:remove",
+        "delete": "attachments:remove",
+        "down": "attachments:exit",
+        "escape": "attachments:exit"
+      }
+    },
+    {
+      "context": "Footer",
+      "bindings": {
+        "right": "footer:next",
+        "left": "footer:previous",
+        "enter": "footer:openSelected",
+        "escape": "footer:clearSelection"
+      }
+    },
+    {
+      "context": "MessageSelector",
+      "bindings": {
+        "up": "messageSelector:up",
+        "down": "messageSelector:down",
+        "k": "messageSelector:up",
+        "j": "messageSelector:down",
+        "ctrl+up": "messageSelector:top",
+        "shift+up": "messageSelector:top",
+        "meta+up": "messageSelector:top",
+        "shift+k": "messageSelector:top",
+        "ctrl+down": "messageSelector:bottom",
+        "shift+down": "messageSelector:bottom",
+        "meta+down": "messageSelector:bottom",
+        "shift+j": "messageSelector:bottom",
+        "enter": "messageSelector:select"
+      }
+    },
+    {
+      "context": "DiffDialog",
+      "bindings": {
+        "escape": "diff:dismiss",
+        "left": "diff:previousSource",
+        "right": "diff:nextSource",
+        "up": "diff:previousFile",
+        "down": "diff:nextFile",
+        "enter": "diff:viewDetails"
+      }
+    },
+    {
+      "context": "ModelPicker",
+      "bindings": {
+        "left": "modelPicker:decreaseEffort",
+        "right": "modelPicker:increaseEffort"
+      }
+    },
+    {
+      "context": "Select",
+      "bindings": {
+        "up": "select:previous",
+        "down": "select:next",
+        "j": "select:next",
+        "k": "select:previous",
+        "ctrl+n": "select:next",
+        "ctrl+p": "select:previous",
+        "enter": "select:accept",
+        "escape": "select:cancel"
+      }
+    },
+    {
+      "context": "Plugin",
+      "bindings": {
+        "space": "plugin:toggle",
+        "i": "plugin:install"
+      }
+    }
+  ]
+}

--- a/.config/claude/keybindings.json
+++ b/.config/claude/keybindings.json
@@ -26,7 +26,7 @@
         "ctrl+_": "chat:undo",
         "ctrl+shift+-": "chat:undo",
         "ctrl+g": null,
-        "ctrl+e": "chat:externalEditor",
+        "ctrl+x ctrl+e": "chat:externalEditor",
         "ctrl+s": "chat:stash",
         "ctrl+v": "chat:imagePaste",
         "ctrl+q": "chat:snippetPicker"

--- a/.config/tmux/scripts/tmux-claude-popup
+++ b/.config/tmux/scripts/tmux-claude-popup
@@ -7,7 +7,7 @@
 # Launch (or re-attach to) a persistent Claude session inside a tmux popup;
 # closing the popup only detaches the client, the session keeps running.
 #
-# Usage: tmux-claude-popup launch [cwd|git-root]
+# Usage: tmux-claude-popup launch [cwd|git-root] [base-dir]
 set -euo pipefail
 
 # popup サイズと起動コマンドは環境変数で上書き可能 / overridable via env vars

--- a/.config/tmux/scripts/tmux-claude-popup
+++ b/.config/tmux/scripts/tmux-claude-popup
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tmux-claude-popup: per-directory persistent Claude Code session launcher.
+#
+# 各ディレクトリ(既定は git リポジトリの root)ごとに永続 tmux セッションを
+# 1 つ用意し、popup から attach する。popup を閉じてもセッションは生き続けるので、
+# 会話履歴・tool state・スクロールバックがそのまま保持される。
+# Launch (or re-attach to) a persistent Claude session inside a tmux popup;
+# closing the popup only detaches the client, the session keeps running.
+#
+# Usage: tmux-claude-popup launch [cwd|git-root]
+set -euo pipefail
+
+# popup サイズと起動コマンドは環境変数で上書き可能 / overridable via env vars
+POPUP_W="${CLAUDE_POPUP_W:-90%}"
+POPUP_H="${CLAUDE_POPUP_H:-90%}"
+CLAUDE_CMD="${CLAUDE_CMD:-claude}"
+
+# セッションの基準ディレクトリを決める / resolve the session's root directory
+# $1: モード (cwd|git-root) / $2: 起点ディレクトリ (pane の cwd)
+resolve_root() {
+  local mode="${1:-git-root}" base="${2:-$PWD}"
+  case "$mode" in
+    cwd)
+      printf '%s' "$base"
+      ;;
+    git-root)
+      # git 管理下ならリポジトリ root、そうでなければ起点 cwd にフォールバック
+      git -C "$base" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$base"
+      ;;
+    *)
+      printf '%s' "$base"
+      ;;
+  esac
+}
+
+main() {
+  if [ "${1:-}" != "launch" ]; then
+    echo "Usage: $0 launch [cwd|git-root] [base-dir]" >&2
+    exit 1
+  fi
+
+  local mode base root session
+  mode="${2:-git-root}"
+
+  # 起点は tmux キーバインドから渡される #{pane_current_path}。
+  # run-shell はサーバの cwd(通常 $HOME)で動くので $PWD は使えない。
+  # 渡された値が実在しなければ tmux に問い合わせ、最後は $PWD にフォールバック。
+  base="${3:-}"
+  if [ -z "$base" ] || [ ! -d "$base" ]; then
+    base="$(tmux display-message -p '#{pane_current_path}' 2>/dev/null || true)"
+  fi
+  if [ -z "$base" ] || [ ! -d "$base" ]; then
+    base="$PWD"
+  fi
+
+  root="$(resolve_root "$mode" "$base")"
+  # パス区切りや特殊文字を吸収するため md5 8 文字をセッション名にする
+  # md5 8 chars keeps the name fixed-length and path-safe
+  session="claude-$(printf '%s' "$root" | md5sum | cut -c1-8)"
+
+  # セッションが無ければ detach 状態で作成 / create detached if it does not exist
+  if ! tmux has-session -t "$session" 2>/dev/null; then
+    tmux new-session -d -s "$session" -c "$root" "$CLAUDE_CMD"
+    # popup 内をクリーンにするため status bar を消す / hide status bar inside popup
+    tmux set-option -t "$session" status off
+  fi
+
+  tmux display-popup -E -w "$POPUP_W" -h "$POPUP_H" \
+    -T " Claude :: $(basename "$root") " \
+    -e COLORTERM=truecolor \
+    "tmux attach-session -t '$session'"
+}
+
+main "$@"

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -132,3 +132,14 @@ if "which win32yank.exe" "bind-key -T copy-mode-vi y     send-keys -X copy-p    
 if "which win32yank.exe" "bind-key -T copy-mode-vi Enter send-keys -X copy-p    ipe-and-cancel 'win32yank.exe -i'"
 # pでペースト
 if "which win32yank.exe" "bind-key p run 'tmux set-buffer -- \"$(win32yank.e    xe -o)\"; tmux paste-buffer'"
+
+# ----------------------------------------
+# Claude Code integration
+# ----------------------------------------
+# prefix + C : git リポジトリ(無ければ cwd)ごとの永続 Claude セッションを
+#              popup で起動 / 再アタッチする。popup を閉じてもセッションは生き続け、
+#              会話履歴がそのまま保持される。
+#              閉じる(=デタッチ)には popup 内で prefix + d (C-g d)。
+# prefix + C : launch/re-attach a per-git-root persistent Claude popup;
+#              closing it (prefix + d) only detaches, the session survives.
+bind C run-shell "$HOME/.local/bin/tmux-claude-popup launch git-root '#{pane_current_path}'"

--- a/nix/modules/tmux.nix
+++ b/nix/modules/tmux.nix
@@ -13,4 +13,11 @@
 
   # Tmux config symlink (matching deploy.sh)
   home.file.".tmux.conf".source = ../../.config/tmux/tmux.conf;
+
+  # Claude Code popup launcher (per-directory persistent session)
+  # ~/.local/bin is already on PATH; tmux.conf binds it to prefix + C.
+  home.file.".local/bin/tmux-claude-popup" = {
+    source = ../../.config/tmux/scripts/tmux-claude-popup;
+    executable = true;
+  };
 }


### PR DESCRIPTION
## [optional body]

Claude Code を tmux ワークフローに統合し、キーバインド設定をリポ管理下に置く。

### tmux ポップアップランチャー (`prefix + C`)
- 現在の pane の git リポジトリ root（無ければ cwd）ごとに、永続 tmux セッションを起動 / 再アタッチする `tmux-claude-popup` を追加。
- popup を閉じても裏のセッションは生き続けるため、会話履歴・tool state・スクロールバックがそのまま保持される（閉じる = `prefix + d` でデタッチのみ）。
- pane の cwd は `#{pane_current_path}` 経由で渡す。`run-shell` はサーバの cwd（通常 `$HOME`）で動き `$PWD` が使えないため。
- セッション名は root パスの md5 8 文字で固定長・パス安全にしている。
- `nix/modules/tmux.nix` でスクリプトを `~/.local/bin` に executable symlink。

### Claude キーバインド管理
- `~/.claude/keybindings.json` をリポ管理下に追加。
- `ctrl+g` は tmux の prefix (`C-g`) と衝突するため `null` で無効化。
- 外部エディタ起動は `ctrl+x ctrl+e` の chord に割り当て（bash の emacs モードと同じ）。`ctrl+e` 単体は入力欄の行末移動（emacs 風）に温存する。

## [optional footer(s)]
