### PR TITLE
feat(nix): 開発支援ツールと GPG agent 設定を追加

### DIFF
--- a/.config/gnupg/gpg-agent.conf
+++ b/.config/gnupg/gpg-agent.conf
@@ -1,0 +1,9 @@
+# Cache passphrases for a workday.
+# パスフレーズ入力を作業中はしばらく省略する
+default-cache-ttl 28800
+max-cache-ttl 86400
+
+# Keep SSH-agent cache aligned when gpg-agent is used for SSH.
+# gpg-agentをSSH agentとして使う場合も同じTTLにする
+default-cache-ttl-ssh 28800
+max-cache-ttl-ssh 86400

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -69,6 +69,9 @@
     gnused # GNU sed
     gnugrep # GNU grep
 
+    # PDF / document tools
+    poppler-utils # pdftotext, pdftoppm, pdfinfo etc.
+
     # Compression tools
     p7zip # 7-Zip
     zip

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -1,4 +1,26 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
+
+let
+  # Runtime libraries for Playwright's downloaded Chromium on non-NixOS hosts.
+  playwrightRuntimeLibs = with pkgs; [
+    nss
+    nspr
+    alsa-lib
+    atk
+    at-spi2-atk
+    cups
+    dbus
+    expat
+    libdrm
+    libxkbcommon
+    libgbm
+    gtk3
+    glib
+    pango
+    cairo
+    mesa
+  ];
+in
 
 {
   # Development tools and utilities
@@ -43,6 +65,13 @@
     cmake
     ninja
     meson
+
+    # Browser test tools
+    playwright-driver
+    (writeShellScriptBin "playwright-with-deps" ''
+      export LD_LIBRARY_PATH="${lib.makeLibraryPath playwrightRuntimeLibs}:''${LD_LIBRARY_PATH:-}"
+      exec npx playwright "$@"
+    '')
 
     # Version control
     git-crypt # Git encryption

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -9,9 +9,20 @@
     gh
     gh-dash
     github-copilot-cli # GitHub Copilot CLI (agentic terminal assistant)
+    gnupg
   ];
 
   # Git config symlinks (matching deploy.sh)
   home.file.".gitconfig".source = ../../.config/git/config;
   xdg.configFile."git/ignore".source = ../../.config/git/ignore;
+
+  # GnuPG config symlink (gpg-agent cache TTL)
+  home.file.".gnupg/gpg-agent.conf".source = ../../.config/gnupg/gpg-agent.conf;
+
+  # GnuPG expects a private home directory.
+  # GnuPGは ~/.gnupg がprivateじゃないと警告する
+  home.activation.ensureGnuPGHomePermissions = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    mkdir -p "$HOME/.gnupg"
+    chmod 700 "$HOME/.gnupg"
+  '';
 }


### PR DESCRIPTION
## [optional body]

開発環境で必要になるCLI支援まわりをHome Manager管理に寄せた。

- `feat(nix): add poppler-utils for PDF handling`
  - `poppler-utils` を追加して、`pdftotext` / `pdftoppm` / `pdfinfo` などのPDF操作CLIを使えるようにした
- `Add Playwright runtime dependencies`
  - 非NixOS環境でもPlaywrightがダウンロードしたChromiumを動かしやすいように、必要なランタイムライブラリと `playwright-with-deps` wrapperを追加した
- `Add gpg-agent cache configuration`
  - `gnupg` と `gpg-agent.conf` をHome Manager管理に追加し、GPG/SSH agentのパスフレーズキャッシュTTLを伸ばした
  - `~/.gnupg` のpermissionを `700` に揃えるactivationも追加した

確認済み:

- `nix develop --command nixpkgs-fmt --check flake.nix home.nix nix/`
- `mise run nix:check`
- `mise run nix:build`

## [optional footer(s)]

Generated for coding-agent environment updates.
