### PR TITLE
build: bump github-copilot-cli to 1.0.65

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,13 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.50";
+                copilotVersion = "1.0.65";
               in
               {
                 version = copilotVersion;
                 src = prev.fetchzip {
                   url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-sjPxL9JntpsqrnhNMxaqaCfYLt30+lgt37zRN11CBb8=";
+                  hash = "sha256-NcdnOPYcKk+HR+8C7X1RA6mBgZ7EILkKrD+eoqDI/3k=";
                 };
                 # npm version may not match internal binary version string
                 doInstallCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -33,10 +33,33 @@
               in
               {
                 version = copilotVersion;
+                # 1.0.5x 以降、npm registry の tgz は npm-loader.js のみになり
+                # 本体 (index.js + ネイティブバイナリ) はプラットフォーム別の
+                # GitHub Release アセットに分離された。x86_64-linux 用を使う。
+                # The npm tarball now only ships a loader; the real index.js
+                # and native binaries live in the platform-specific release asset.
                 src = prev.fetchzip {
-                  url = "https://registry.npmjs.org/@github/copilot/-/copilot-${copilotVersion}.tgz";
-                  hash = "sha256-NcdnOPYcKk+HR+8C7X1RA6mBgZ7EILkKrD+eoqDI/3k=";
+                  url = "https://github.com/github/copilot-cli/releases/download/v${copilotVersion}/github-copilot-${copilotVersion}-linux-x64.tgz";
+                  hash = "sha256-4Af5u4K5xg76RCLu3jHY1+IxWMosu7d8fmwJy0zgwB4=";
                 };
+                # 同梱ネイティブバイナリ (.node, ripgrep) を patchelf する
+                # Patch the bundled native binaries for the Nix store.
+                nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.autoPatchelfHook ];
+                buildInputs = (old.buildInputs or [ ]) ++ [
+                  prev.stdenv.cc.cc.lib
+                  prev.glib
+                  prev.libsecret
+                ];
+                # GUI/メディア機能用のライブラリは CLI 利用では不要なので無視
+                # These GUI/media libs are only for screen-capture/input features.
+                autoPatchelfIgnoreMissingDeps = [
+                  "libX11.so.6"
+                  "libXtst.so.6"
+                  "libjpeg.so.8"
+                  "libpng16.so.16"
+                  "libpipewire-0.3.so.0"
+                  "libei.so.1"
+                ];
                 # npm version may not match internal binary version string
                 doInstallCheck = false;
               });


### PR DESCRIPTION
## 概要

`github-copilot-cli` の Nix override を `1.0.50` → `1.0.65` に更新する。

## 背景 / なぜ単純なバージョン更新では動かなかったか

当初はバージョンと npm tarball の `fetchzip` ハッシュだけを差し替えたが、
起動時に以下のエラーで失敗した:

```
Error: Cannot find module '.../@github/copilot/index.js'
code: 'MODULE_NOT_FOUND'
```

原因は GitHub 側のパッケージ構成変更。`1.0.5x` 以降、npm registry の
tgz は本体を呼び出すだけの `npm-loader.js` のみとなり、`index.js` 本体と
ネイティブバイナリ (`.node`, ripgrep) は**プラットフォーム別の GitHub
Release アセット**へ分離された。継承元 derivation の `installPhase` は
`index.js` をラップするため、ローダーしか入っていない npm tarball では
モジュールを解決できず落ちていた。

## 変更内容

- `src` を npm registry → GitHub Release の
  `github-copilot-1.0.65-linux-x64.tgz`（本体入り）に変更
- 同梱ネイティブバイナリを Nix store 向けに patchelf するため
  `autoPatchelfHook` と `glib` / `libsecret` / `cc.lib` を追加
- CLI 利用では不要な GUI/メディア用ライブラリ (X11 等) は
  `autoPatchelfIgnoreMissingDeps` で無視（nixpkgs 本家と同方針）

## 検証

- `nix build .#homeConfigurations.archie.pkgs.github-copilot-cli` 成功
- `copilot --version` → `GitHub Copilot CLI 1.0.65.` を確認

## 補足

現状 `src` は `linux-x64` 決め打ち。将来 macOS など他プラットフォームに
対応する手順は別 Issue で管理する。