### PR TITLE
fix(hypr): migrate togglesplit/pseudotile to v0.55 syntax

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -112,7 +112,8 @@ animations {
 
 # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+    # NOTE: v0.55 で dwindle:pseudotile オプションは廃止。擬似タイル化は keybinds.conf の `pseudo` dispatcher (mainMod+P) で操作する
+    # NOTE: dwindle:pseudotile option removed in v0.55; use the `pseudo` dispatcher instead
     preserve_split = true # You probably want this
 }
 

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -39,7 +39,7 @@ bind = $mainMod, V, togglefloating
 # 疑似タイリングモードの切り替え
 bind = $mainMod, P, pseudo
 # タイリングの分割方向を切り替え
-bind = $mainMod, J, togglesplit
+bind = $mainMod, J, layoutmsg, togglesplit
 
 ## ウィンドウの最大化
 bind = SUPER, F, fullscreen, 0


### PR DESCRIPTION
## body

Hyprland 0.55.4 環境で `hyprctl configerrors` に以下の2件が出ていたため修正。

| ファイル | エラー | 対応 |
|----------|--------|------|
| `keybinds.conf:42` | `Invalid dispatcher, requested "togglesplit" does not exist` | `bind = $mainMod, J, layoutmsg, togglesplit` へ変更 |
| `hyprland.conf:115` | `config option <dwindle:pseudotile> does not exist` | オプション行を削除（擬似タイル化は `pseudo` dispatcher で継続） |

### 背景
v0.55 でレイアウト固有のコマンド（togglesplit 等）は `layoutmsg` 経由に統一され、直接 dispatcher として呼ぶと `Invalid dispatcher` になる。また `dwindle:pseudotile` オプションは廃止された。`#286` の window-rules v0.53+ 移行と同系統の追従対応。

### 動作確認
- `hyprctl dispatch layoutmsg togglesplit` が有効（ランタイムメッセージが返る）ことを確認
- `mise run nix:switch` → `hyprctl reload` 後、`hyprctl configerrors` が空になることを確認
- キーバインドの体感挙動は従来通り（`Super+J` 分割トグル / `Super+P` 擬似タイル）

## footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)