### PR TITLE
fix(nix): python311 指名を廃止して CI を高速化

### DIFF
--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -26,7 +26,9 @@
       nodePackages.vscode-langservers-extracted # HTML, CSS, JSON, ESLint
       nodePackages.yaml-language-server
       nodePackages.bash-language-server
-      python311Packages.python-lsp-server
+      # NOTE: python3 (デフォルト版) を使うことでバイナリキャッシュに乗せる（3.11 指名はソースビルドに落ちる）
+      # Use default python3 to hit cache.nixos.org; pinning 3.11 forces source builds
+      python3Packages.python-lsp-server
       rust-analyzer
       gopls
       terraform-ls
@@ -59,7 +61,7 @@
       gcc # Compiler for some plugins
 
       # Python support for Neovim
-      python311Packages.pynvim
+      python3Packages.pynvim
 
       # Clipboard support
       wl-clipboard # Wayland
@@ -87,7 +89,7 @@
   # Environment variables for Neovim
   home.sessionVariables = {
     # Point to Nix-managed Python
-    NVIM_PYTHON3_HOST_PROG = "${pkgs.python311.withPackages (ps: [ ps.pynvim ])}/bin/python3";
+    NVIM_PYTHON3_HOST_PROG = "${pkgs.python3.withPackages (ps: [ ps.pynvim ])}/bin/python3";
   };
 
   # Note: Existing Neovim configuration in .config/nvim/ is symlinked via home.nix


### PR DESCRIPTION
## 概要
CI の Build & Verify (Arch Linux) が約 45 分かかる問題の根本対策。`nix/modules/neovim.nix` の `python311` 指名（3箇所）をデフォルトの `python3` に変更する。

Closes #291

## 原因
- flake は nixos-unstable を追っており、デフォルト Python は 3.13
- `python311Packages.*` は cache.nixos.org にバイナリが無く、依存ツリー丸ごと（checkPhase のテスト実行込み）ソースビルドに落ちていた
- 実測: `nix build` 2380 秒のうち、python3.11 系のビルドが大半（pytest-benchmark 単体で 555 秒など）

## 変更内容
- `python311Packages.python-lsp-server` → `python3Packages.python-lsp-server`
- `python311Packages.pynvim` → `python3Packages.pynvim`
- `NVIM_PYTHON3_HOST_PROG` の `python311.withPackages` → `python3.withPackages`

## 検証
- `nix build --dry-run` で確認済み: ビルドが必要なのは home-manager のラッパー 5 derivation のみ、Python 系は全て **1.5 MiB のバイナリ取得**に変わった
- `nixpkgs-fmt --check` パス
- このPR自体の CI 実行時間が効果測定になる（従来比 -30 分以上を期待）

## 影響範囲
- Neovim の Python ホスト・pylsp が 3.11 → 3.13 になる（pynvim / python-lsp-server は 3.13 対応済み）
- mise の `python = "3.11"`（ランタイム管理）は本件と無関係のため変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)