### PR TITLE
fix(nix): terraform (unfree) を OpenTofu に置き換えて CI を高速化

### DIFF
--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -45,7 +45,9 @@ in
     kubectl # Kubernetes CLI
     k9s # Kubernetes TUI
     helm # Kubernetes package manager
-    terraform # Infrastructure as code
+    # NOTE: terraform は unfree (BUSL) でバイナリキャッシュに乗らないため OpenTofu を使用（コマンド名は tofu）
+    # terraform is unfree (BUSL) and never cached by Hydra; use OpenTofu instead (command: tofu)
+    opentofu # Infrastructure as code (Terraform-compatible)
     ansible # Configuration management
 
     # Database tools


### PR DESCRIPTION
## 概要
CI 高速化の第二弾（第一弾: #292）。unfree ライセンスのため永久にバイナリキャッシュに乗らない terraform を、Terraform 互換のフリーな fork である OpenTofu に置き換える。

Closes #293

## 原因
- terraform は BUSL（unfree）のため Hydra がビルドせず、cache.nixos.org にバイナリが存在しない
- GitHub Actions キャッシュ（10GB 上限）から追い出されるたびに約 20 分（実測 1172s）の Go コンパイルが再発

## 変更内容
- dev-tools.nix: `terraform` → `opentofu`
- neovim.nix の `terraform-ls` は MPL-2.0 でキャッシュ済み・OpenTofu でも利用可のため維持

## 検証
- `nix build --dry-run`: opentofu-1.11.4 は **21.3 MiB のバイナリ取得のみ**、ビルドは home-manager ラッパー 3 derivation だけ
- `nixpkgs-fmt --check` パス

## 影響・注意
- コマンド名が `terraform` → `tofu` に変わる（必要なら shell alias で吸収可能）
- 既存の .tf ファイルはそのまま利用可能

## 期待効果
#292 と合わせて Build & Verify が約 45 分 → 8〜10 分程度になる見込み（このPRの CI 実行時間が測定値）

🤖 Generated with [Claude Code](https://claude.com/claude-code)