### PR TITLE
feat(herdr): tmux から herdr へ移行 — keybind 互換設定で導入

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -87,7 +87,9 @@ key = "N"
 mods = "Control|Shift"
 
 [terminal.shell]
-args = ["--login", "--command", "tmux attach || tmux"]
+# herdr は既存セッションへ自動アタッチするため attach || new の分岐は不要
+# herdr auto-attaches to an existing session, no attach-or-new branching needed
+args = ["--login", "--command", "herdr"]
 program = "/usr/bin/fish"
 
 [window]

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,24 @@
+# herdr configuration — tmux から移行 (keybind は旧 tmux.conf を踏襲)
+# Migrated from tmux; keybindings follow the previous tmux.conf.
+#
+# 以下は herdr デフォルトのまま使用 (旧 tmux 設定と一致 or 標準採用):
+# The following stay on herdr defaults (already matching tmux, or adopted as-is):
+#   focus_pane_*     = prefix+h/j/k/l   (tmux と同じ / same as tmux)
+#   split_horizontal = prefix+minus     (tmux と同じ / same as tmux)
+#   copy_mode        = prefix+[  (vi 風 v/y / vi-style v and y)
+#   zoom             = prefix+z
+#   resize_mode      = prefix+r  (モード内 h/j/k/l でリサイズ / resize with h/j/k/l)
+#   reload_config    = prefix+shift+r
+
+[terminal]
+default_shell = "fish"
+
+[ui]
+# 移行前にローカルで設定済みだった値を引き継ぎ / carried over from the pre-migration local config
+agent_panel_sort = "spaces"
+
+[keys]
+prefix = "ctrl+g"                             # tmux: set-option -g prefix C-g
+split_vertical = ["prefix+v", "prefix+|"]     # tmux: bind | split-window -h
+next_tab = ["prefix+n", "prefix+ctrl+l"]      # tmux: bind -r C-l select-window -t :+
+previous_tab = ["prefix+p", "prefix+ctrl+h"]  # tmux: bind -r C-h select-window -t :-

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -25,6 +25,10 @@ jobs:
       # headings in this repo (e.g. "## Quick Start / クイックスタート")
       # produce GitHub-slugified anchors that can shift when a heading
       # moves to a new file — anchor links must still be checked by hand.
+      # nixos.org は DDoS 対策で GitHub ランナーの IP を遮断することがあり、
+      # リンクが生きていても Connection failed になるため除外する。
+      # nixos.org intermittently blocks GitHub runner IPs (DDoS protection),
+      # so valid links fail with "Connection failed" — exclude the domain.
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
@@ -32,5 +36,6 @@ jobs:
             --no-progress
             --exclude-path polybar-themes
             --exclude-path result
+            --exclude '^https://nixos\.org'
             '**/*.md'
           fail: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Organized by [Diátaxis](https://diataxis.fr) (🎓tutorial / 🔧how-to / 📖r
 
 **Quick Keybindings Reference:**
 - Fish: `Ctrl+t` (file search), `Ctrl+r` (history), `Ctrl+y` (git branch)
-- Tmux: prefix is `Ctrl+g`, split with `|` and `-`, vim-style navigation with `h/j/k/l`
+- herdr: prefix is `Ctrl+g`, split with `|` and `-`, vim-style navigation with `h/j/k/l` (tmux from which we migrated is kept during the transition)
 - Hyprland: `Super` as modifier, `Super+Enter` (terminal), `Super+D` (launcher)
 
 ## Development Environments

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -9,7 +9,8 @@
 ## 📚 Table of Contents
 
 - [Fish Shell](#fish-shell)
-- [Tmux](#tmux)
+- [herdr](#herdr)
+- [Tmux](#tmux-deprecated-herdrへ移行中) *(deprecated)*
 - [Hyprland](#hyprland)
 - [Neovim](#neovim) *(separate document)*
 - [Shell Aliases](#shell-aliases)
@@ -50,7 +51,63 @@ Fish shellのキーバインドは `.config/fish/functions/fish_user_key_binding
 
 ---
 
-## 🖥️ Tmux
+## 🤖 herdr
+
+herdrの設定は `.config/herdr/config.toml` で定義されています。keybindは旧tmux設定を踏襲しています。
+
+### Prefix Key
+
+| Key | Description |
+|-----|-------------|
+| `Ctrl+g` | Prefix key (prefixキー) |
+
+### Pane Operations
+
+| Keybind | Description | 説明 |
+|---------|-------------|------|
+| `prefix + \|` / `prefix + v` | Split pane vertically | ペインを縦に分割 |
+| `prefix + -` | Split pane horizontally | ペインを横に分割 |
+| `prefix + h/j/k/l` | Move between panes (Vim-style) | ペイン間を移動 (Vim風) |
+| `prefix + z` | Zoom focused pane | ペインをズーム |
+| `prefix + x` | Close pane | ペインを閉じる |
+| `prefix + r` | Resize mode (then `h/j/k/l`) | リサイズモード (h/j/k/lで調整) |
+
+### Tab (Window) Operations
+
+| Keybind | Description | 説明 |
+|---------|-------------|------|
+| `prefix + c` | New tab | 新規タブ |
+| `prefix + Ctrl+h` / `prefix + p` | Previous tab | 前のタブへ |
+| `prefix + Ctrl+l` / `prefix + n` | Next tab | 次のタブへ |
+| `prefix + 1..9` | Jump to tab | タブへジャンプ |
+
+### Session / Workspace
+
+| Keybind | Description | 説明 |
+|---------|-------------|------|
+| `prefix + q` | Detach (session keeps running) | デタッチ (セッションは維持) |
+| `prefix + w` | Workspace picker | ワークスペース選択 |
+| `prefix + b` | Toggle sidebar | サイドバー表示切替 |
+| `prefix + Shift+r` | Reload config | 設定ファイルをリロード |
+| `prefix + ?` | Show all keybindings | 全keybind一覧を表示 |
+
+### Copy Mode
+
+`prefix + [` でコピーモードに入る。viキーバインドを使用。
+
+| Keybind | Description | 説明 |
+|---------|-------------|------|
+| `v` | Begin selection | 選択開始 |
+| `y` | Copy to clipboard | クリップボードにコピー |
+| `q` / `Esc` | Exit copy mode | コピーモードを抜ける |
+
+マウス操作はネイティブ対応 (クリック・ドラッグ選択・境界ドラッグでリサイズ)。
+
+---
+
+## 🖥️ Tmux (deprecated: herdrへ移行中)
+
+> **Note**: herdrへの併存移行期間中です。移行完了後にこのセクションと設定は削除されます。
 
 Tmuxの設定は `.tmux.conf` で定義されています。
 

--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-herdr": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-herdr": "nixpkgs-herdr"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,12 @@
       url = "github:nix-community/neovim-nightly-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # herdr 用の新しめ nixpkgs: メインの locked nixpkgs には herdr が未収録。
+    # 全体を update せず、この input だけで herdr を供給する (バイナリキャッシュ有効)。
+    # Newer nixpkgs pin for herdr only: the main locked nixpkgs predates herdr.
+    # Avoids a full nixpkgs bump while keeping Hydra's binary cache.
+    nixpkgs-herdr.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
   outputs = { self, nixpkgs, home-manager, neovim-nightly-overlay, ... }@inputs:
@@ -63,6 +69,11 @@
                 # npm version may not match internal binary version string
                 doInstallCheck = false;
               });
+          })
+          # herdr を専用 pin の nixpkgs から供給 (メインの locked nixpkgs には未収録)
+          # Provide herdr from its dedicated nixpkgs pin (absent from the main lock)
+          (final: prev: {
+            herdr = inputs.nixpkgs-herdr.legacyPackages.${system}.herdr;
           })
           # Fix for CI: some package tests are flaky in GitHub Actions environment
           (final: prev: {

--- a/home.nix
+++ b/home.nix
@@ -18,7 +18,8 @@
     ./nix/modules/rust-tools.nix
     ./nix/modules/shell.nix
     ./nix/modules/git.nix
-    ./nix/modules/tmux.nix
+    ./nix/modules/tmux.nix # 併存期間中: herdr 移行完了後に削除予定 / kept during herdr migration
+    ./nix/modules/herdr.nix
     ./nix/modules/neovim.nix
     ./nix/modules/dev-tools.nix
     ./nix/modules/fonts.nix

--- a/nix/modules/herdr.nix
+++ b/nix/modules/herdr.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  # herdr - agent multiplexer (tmux の後継 / successor to tmux)
+  # pkgs.herdr は flake.nix の overlay 経由で新しい nixpkgs から供給される
+  # pkgs.herdr comes from a newer nixpkgs pin via the overlay in flake.nix
+  home.packages = with pkgs; [
+    herdr
+  ];
+
+  # herdr config symlink (keybind は旧 tmux 設定互換 / tmux-compatible keybindings)
+  home.file.".config/herdr/config.toml".source = ../../.config/herdr/config.toml;
+}


### PR DESCRIPTION
## 概要

tmux をやめて [herdr](https://github.com/ogulcancelik/herdr)(AI エージェント向けターミナルマルチプレクサ)へ移行する。**keybind は現行 tmux 設定(prefix `Ctrl+g` など)をそのまま維持**する。

## 変更内容

### herdr 導入
- **`.config/herdr/config.toml`** (新規): keybind 上書きは実質 4 項目のみ
  - `prefix = "ctrl+g"`、`split_vertical = ["prefix+v", "prefix+|"]`、`next_tab` / `previous_tab` に `prefix+ctrl+l/h` を追加
  - ペイン移動 `prefix+h/j/k/l`・横分割 `prefix+-`・copy mode(vi 風 `v`/`y`)は **herdr デフォルトが tmux 設定と一致**するため記述不要
  - 移行前にローカル設定済みだった `agent_panel_sort = "spaces"` を引き継ぎ
- **`nix/modules/herdr.nix`** (新規): パッケージ導入 + config symlink(既存 tmux.nix のパターン踏襲)

### Nix 供給方法
- herdr はメインの locked nixpkgs(古い rev)に未収録のため、**専用 input `nixpkgs-herdr`** + overlay で `pkgs.herdr` を供給
- 全体の `nix flake update` を避けつつ Hydra のバイナリキャッシュが効く(CI 影響最小)

### 起動切替・ドキュメント
- alacritty の自動起動: `tmux attach || tmux` → `herdr`(herdr は既存セッションへ自動アタッチ)
- `docs/reference/keybindings.md` に herdr セクション追加、tmux セクションは deprecated 注記
- CLAUDE.md の Quick Keybindings を更新

### 方針(ユーザー決定事項)
1. `prefix+r` は herdr デフォルト(リサイズモード)を採用、リロードは `prefix+Shift+r`
2. tmux は**併存期間**を設けて残置 → 慣れたら削除 PR で撤去
3. Claude Code 起動は herdr ネイティブのエージェント機能に任せる(旧 `prefix+C` ポップアップの代替)

## 検証

- [x] `mise run nix:check` 通過
- [x] `mise run nix:switch` 成功、`~/.config/herdr/config.toml` が store への symlink になることを確認
- [x] `herdr --version` → 0.7.1(最新リリースと同一)
- [x] `herdr server reload-config` → `status: applied`、diagnostics なし(`prefix+|` の配列バインド含めパース成功)
- [ ] 実操作(分割・ペイン移動・タブ切替・copy mode・detach/attach)※マージ前に実機確認
- [ ] alacritty 新規起動で herdr が自動起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jtAZVWiLDFVtkydACMJUC