### PR TITLE
fix(nix): モジュール衛生 — 重複パッケージ・staleコメント・無効化済みinputの整理

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -38,44 +17,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "neovim-nightly-overlay": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "neovim-src": "neovim-src",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770509107,
-        "narHash": "sha256-YsfKRbd5fbcb2VTxywzAGpc4txXApMXfG0vtxEldt7Q=",
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "rev": "0bb52596f3ea543781d2c20b1c2ee495a174a7d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "type": "github"
-      }
-    },
-    "neovim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1770505476,
-        "narHash": "sha256-HvlTxVEso/hl9lwweHerBRLtI/q05SQTxDr2l0Njfig=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "ed8fbd2e2992cb264cb62585098a1c7acc5c4585",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
         "type": "github"
       }
     },
@@ -114,7 +55,6 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
-        "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nixpkgs": "nixpkgs",
         "nixpkgs-herdr": "nixpkgs-herdr"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,12 +9,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Neovim plugins and ecosystem
-    neovim-nightly-overlay = {
-      url = "github:nix-community/neovim-nightly-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     # herdr 用の新しめ nixpkgs: メインの locked nixpkgs には herdr が未収録。
     # 全体を update せず、この input だけで herdr を供給する (バイナリキャッシュ有効)。
     # Newer nixpkgs pin for herdr only: the main locked nixpkgs predates herdr.
@@ -22,15 +16,13 @@
     nixpkgs-herdr.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, home-manager, neovim-nightly-overlay, ... }@inputs:
+  outputs = { self, nixpkgs, home-manager, ... }@inputs:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
         overlays = [
-          # neovim-nightly-overlay disabled: waiting for upstream fix for nixpkgs lua argument removal
-          # neovim-nightly-overlay.overlays.default
           # Bump github-copilot-cli to latest release (nixpkgs lags behind npm)
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:

--- a/home.nix
+++ b/home.nix
@@ -42,9 +42,6 @@
   xdg.dataHome = "${config.home.homeDirectory}/.local/share";
   xdg.cacheHome = "${config.home.homeDirectory}/.cache";
 
-  # Allow unfree packages (if needed)
-  nixpkgs.config.allowUnfree = true;
-
   # Manage dotfiles with Home Manager
   # Symlinks matching deploy.sh
   home.file = {

--- a/nix/modules/base.nix
+++ b/nix/modules/base.nix
@@ -7,13 +7,13 @@
   # git: git.nix
   # cmake, gnumake: dev-tools.nix
   # htop: dev-tools.nix
+  # pkg-config: rust-tools.nix (paired with openssl.dev for native crates)
   home.packages = with pkgs; [
     # Core utilities (not duplicated elsewhere)
     gnutar
     gzip
 
-    # Build tools (pkg-config, protobuf not in other modules)
-    pkg-config
+    # Build tools (protobuf not in other modules)
     protobuf
 
     # Notification system

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -104,10 +104,10 @@ in
     poppler-utils # pdftotext, pdftoppm, pdfinfo etc.
 
     # Compression tools
+    # gzip is in base.nix
     p7zip # 7-Zip
     zip
     unzip
-    gzip
     bzip2
     xz
 


### PR DESCRIPTION
## [optional body]

dotfiles 全体評価(#300)で見つかった Nix 側の衛生問題をまとめて解消する。

### 重複パッケージの解消
- **pkg-config** → `rust-tools.nix` に一本化。`openssl.dev` と対で native crates のビルドに使う文脈があるため。`base.nix` の「pkg-config … not in other modules」という虚偽化していたコメントも修正し、ヘッダーのクロスリファレンス(`curl, wget: dev-tools.nix` 形式)に追記
- **gzip** → `base.nix`(Core utilities)に一本化し、`dev-tools.nix` の compression セクションから削除(参照コメントを残置)

### 無効化済み input の削除
- `neovim-nightly-overlay` は overlay がコメントアウトされて無効なのに fetch & lock され続けていた。input ごと削除し、`flake.lock` から関連エントリ60行(`flake-parts` / `neovim-src` 含む)を除去。必要になったら input を復活させる

### allowUnfree の一本化
- `flake.nix` と `home.nix` の二重指定を解消し、`flake.nix` 側のみに。`pkgs` は flake から渡されるため `home.nix` 側の `nixpkgs.config.allowUnfree` はほぼ inert だった

### 検証
- `nixpkgs-fmt --check`: 0 / 11 reformatted
- `mise run nix:check`: all checks passed
- `mise run nix:build`: 成功

## [optional footer(s)]

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
