### PR TITLE
fix(nix): Python/Node バージョンの source of truth を統一

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -109,6 +109,20 @@ home.file.".config/fish/config.fish".source = ../../.config/fish/config.fish;
 - 設定ファイルの中身
 - プラグインの設定（Neovimのdein.vim等）
 
+### 言語ランタイムのバージョン方針 / Language Runtime Version Policy
+
+Python / Node などの言語ランタイムは、NixとmiseのW管理にならないよう役割を分担する：
+
+| 担当 | 役割 | 例 |
+|------|------|-----|
+| **Nix** | ベースライン提供（バージョン指名しない） | `python3`, `nodejs`（`nix/modules/dev-tools.nix`） |
+| **mise** | プロジェクトごとのバージョン固定 | 各リポジトリの `.mise.toml`（例: `node = "22.15.1"`） |
+
+- Nix側でバージョンを指名しない理由: デフォルト版はHydraのバイナリキャッシュに乗るが、指名するとソースビルドに落ちやすい（`nix/modules/neovim.nix` のpython3コメント参照）
+- miseの `globalConfig` にツールを書かない理由: source of truth を各プロジェクトの `.mise.toml` に一本化するため
+
+Nix provides unpinned baseline runtimes (binary-cache friendly); mise pins versions per project via each repo's `.mise.toml`. No global mise tools, so there is exactly one source of truth per project.
+
 ### なぜこのアプローチ？
 
 #### 1. ツールごとに設定形式が異なる

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -56,8 +56,12 @@ in
     sqlite # SQLite
 
     # Language runtimes
-    nodejs_20 # Node.js
-    python311 # Python 3.11
+    # 方針: Nix はベースライン提供のみ (バージョン指名しない = バイナリキャッシュに乗る)。
+    # プロジェクトごとのバージョン固定は mise (各リポジトリの .mise.toml) で行う。
+    # Policy: Nix provides baseline runtimes only (unpinned = cached by Hydra);
+    # per-project versions are pinned via mise (.mise.toml in each repo).
+    nodejs # Node.js
+    python3 # Python
     go # Go language
     ruby # Ruby
     php # PHP
@@ -140,16 +144,13 @@ in
 
   # Mise (formerly rtx) - polyglot runtime manager
   # Replaces Volta for Node.js version management
+  # NOTE: globalConfig でツールを指定しない — バージョンの source of truth は
+  # 各プロジェクトの .mise.toml (ベースラインは上記 Language runtimes の Nix 側)
+  # No globalConfig tools here: per-project .mise.toml is the source of truth
+  # (baseline runtimes come from Nix above).
   programs.mise = {
     enable = true;
     enableFishIntegration = true;
-
-    globalConfig = {
-      tools = {
-        node = "lts";
-        python = "3.11";
-      };
-    };
   };
 
   # Zoxide - smarter cd command (alternative to z)

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -56,7 +56,7 @@
 
       # Additional tools (not duplicated - others come from specialized modules)
       # ripgrep, fd: rust-tools.nix
-      # fzf, gnumake, unzip, nodejs_20: dev-tools.nix
+      # fzf, gnumake, unzip, nodejs: dev-tools.nix
       # git: git.nix
       gcc # Compiler for some plugins
 


### PR DESCRIPTION
## [optional body]

dotfiles 全体評価(#301)で見つかった、ランタイムバージョンの3重管理を解消する。

### 方針(役割分担を明文化)
| 担当 | 役割 |
|------|------|
| **Nix** | ベースライン提供 — バージョン指名しない(= Hydra のバイナリキャッシュに乗る) |
| **mise** | プロジェクトごとのピン留め — 各リポジトリの `.mise.toml` が source of truth |

### 変更内容
- `dev-tools.nix`: `python311` → `python3`、`nodejs_20` → `nodejs`(方針をバイリンガルコメントで明記)
- `dev-tools.nix`: `programs.mise` の `globalConfig.tools`(`node = "lts"`, `python = "3.11"`)を削除 — グローバル指定という第3の source of truth を排除
- `neovim.nix`: クロスリファレンスコメントの `nodejs_20` 表記を追従
- `docs/explanation/architecture.md`: 「言語ランタイムのバージョン方針」セクションを追加(#292 で踏んだ「指名版はソースビルド落ち」の経緯も反映)

### 検証
- `nixpkgs-fmt --check`: 0 / 11 reformatted
- `mise run nix:check`: all checks passed
- `mise run nix:build`: 成功 — ベースラインは Python 3.13.11 / Node v24.13.0 に解決

### 補足
- flake.nix の CI 用 `python311Packages` override(websockets/cbor2 の doCheck=false)は python311 の撤去でいずれ dead になる可能性あり。CI が通ることを確認してから別途整理するのが安全なので今回は触っていない

## [optional footer(s)]

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
