### PR TITLE
ci: DeterminateSystems actions を SHA pin し flake.lock 自動更新を導入

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,11 +37,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
+      # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:
           use-flakehub: false
 
@@ -116,7 +118,7 @@ jobs:
 
       # Always install Nix to ensure profiles are created correctly
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,39 @@
+name: Update flake.lock
+
+# flake inputs (nixpkgs, home-manager 等) を定期的に更新して PR を自動作成する。
+# nix.yml の CI (flake check + Docker 内での build & activate) が更新の安全網になる。
+# Periodically bump flake inputs and open a PR; nix.yml CI (flake check +
+# build & activate inside the Arch container) acts as the safety net.
+#
+# NOTE: GITHUB_TOKEN が作成した PR には CI が自動で走らない (GitHub の仕様)。
+# CI を走らせるには PR を close/reopen するか、ブランチに空 push する。
+# PRs created with GITHUB_TOKEN do not trigger workflows; close/reopen the PR
+# (or push to its branch) to kick off CI.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # 毎週月曜 03:00 UTC (12:00 JST) / weekly on Monday
+  workflow_dispatch: # 手動実行 / manual trigger
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
+      # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
+        with:
+          pr-title: 'build(nix): flake.lock を更新'
+          commit-msg: 'build(nix): flake.lock を更新'
+          pr-labels: |
+            nix

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -15,6 +15,14 @@ on:
     - cron: '0 3 * * 1' # 毎週月曜 03:00 UTC (12:00 JST) / weekly on Monday
   workflow_dispatch: # 手動実行 / manual trigger
 
+# 多重実行防止: schedule と手動実行が重なっても、同じ update ブランチへの
+# push が競合しないよう常に1つだけ走らせる (実行中があれば待機)
+# Prevent overlapping runs (schedule + manual) from racing on the same
+# update branch; queue instead of cancelling.
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: false
+
 jobs:
   update-flake-lock:
     runs-on: ubuntu-latest
@@ -33,6 +41,11 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
+          # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
+          # 未設定なら github.token にフォールバック (ヘッダー記載のとおり CI は手動起動)。
+          # With a PAT in secrets.FLAKE_UPDATE_TOKEN the created PR triggers CI
+          # automatically; falls back to github.token otherwise (manual CI kick).
+          token: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
           pr-title: 'build(nix): flake.lock を更新'
           commit-msg: 'build(nix): flake.lock を更新'
           pr-labels: |


### PR DESCRIPTION
## [optional body]

dotfiles 全体評価(#303)より。CI の supply-chain リスクと flake.lock の停滞(nixpkgs / home-manager が約5ヶ月前のまま)を解消する。

### actions の SHA pin
- `nix.yml` の `DeterminateSystems/nix-installer-action@main`(2箇所)→ **v22 のコミット SHA** に pin
- `DeterminateSystems/magic-nix-cache-action@main` → **v14 のコミット SHA** に pin
- 末尾コメントで対応 tag を明示(`# v22` 形式)。mutable な `@main` は上流の破壊的変更・侵害がそのまま流れ込むため排除
- その他の actions(checkout@v4 等)は tag pin 済みのため現状維持

### flake.lock の自動更新
- `update-flake-lock.yml` を新規追加:
  - 毎週月曜 03:00 UTC(12:00 JST)+ `workflow_dispatch` で手動実行可
  - `DeterminateSystems/update-flake-lock`(v28 SHA pin)が update PR を自動作成(タイトル/コミットは conventional 形式、ラベル `nix`)
  - 既存の nix.yml CI(flake check + Arch コンテナ内 build & activate)が更新の安全網になる
- **既知の制約**: `GITHUB_TOKEN` が作成した PR には CI が自動で走らない(GitHub の仕様)。PR を close/reopen するか空 push で起動する。workflow 内コメントにも明記済み

### 検証
- 両 workflow の YAML パース OK
- SHA は GitHub API で各リリース tag から解決(annotated tag は commit まで dereference)

## [optional footer(s)]

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
