### PR TITLE
fix(ci): paths フィルタを required status checks と両立する方式に変更

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,21 +1,61 @@
 name: Docs Lint
 
+# NOTE: トリガーに paths を使わない — required status checks と両立させるため。
+# トリガー段階で workflow を止めるとチェックが報告されず、コードのみの PR が
+# 「Expected — waiting for status」のままマージ不能になる (#312)。
+# changes ジョブで .md の変更を判定し、無ければ link-check を skip する
+# (skip されたジョブは required checks 上は成功扱いになる)。
+# Do NOT use paths triggers: it breaks required status checks (#312).
+# The changes job detects markdown changes; link-check skips itself otherwise
+# (skipped jobs satisfy required checks).
+
 on:
   push:
     branches:
       - main
-    paths:
-      - '**/*.md'
   pull_request:
     branches:
       - main
-    paths:
-      - '**/*.md'
 
 jobs:
+  # .md の変更有無を判定する / Detect whether any markdown files changed
+  changes:
+    name: Detect Docs Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect markdown changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          # base が取れない場合 (force push / ブランチ新規作成等) は安全側に倒して実行する
+          # If the base SHA is unavailable, fail open and run the check
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$base" 2>/dev/null; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+            echo "base unavailable -> docs=true"
+            exit 0
+          fi
+          if git diff --name-only "$base" HEAD | grep -E '\.md$' | grep -q .; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
   link-check:
     name: Check Markdown Links
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,29 +1,64 @@
 name: Nix CI
 
+# NOTE: トリガーに paths-ignore を使わない — required status checks と両立させるため。
+# トリガー段階で workflow を止めるとチェックが一切報告されず、PR が
+# 「Expected — waiting for status」のままマージ不能になる (#312)。
+# 代わりに changes ジョブで変更を判定し、対象外なら各ジョブを skip する
+# (skip されたジョブは required checks 上は成功扱いになる)。
+# Do NOT use paths-ignore on triggers: it breaks required status checks (#312).
+# The changes job detects what changed and downstream jobs skip themselves;
+# skipped jobs satisfy required checks.
+
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'llm/**'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'llm/**'
-      - 'LICENSE'
-      - '.gitignore'
 
 jobs:
+  # 変更ファイルを判定して下流ジョブの実行要否を決める
+  # Detect changed files to decide whether the heavy jobs need to run
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          # base が取れない場合 (force push / ブランチ新規作成等) は安全側に倒して実行する
+          # If the base SHA is unavailable, fail open and run everything
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$base" 2>/dev/null; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "base unavailable -> code=true"
+            exit 0
+          fi
+          # docs/llm/md/LICENSE/.gitignore 以外に変更があれば code=true
+          # (旧 paths-ignore と同じ除外セット)
+          if git diff --name-only "$base" HEAD | grep -vE '(\.md$|^docs/|^llm/|^LICENSE$|^\.gitignore$)' | grep -q .; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build Docker image with Nix pre-installed
   build-image:
     name: Build Docker Image
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/build-docker-image.yml
     permissions:
       contents: read
@@ -33,6 +68,8 @@ jobs:
   check:
     name: Nix Check & Format
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,7 +114,8 @@ jobs:
   verify-docker:
     name: Build & Verify (Arch Linux)
     runs-on: ubuntu-latest
-    needs: [build-image, check]
+    needs: [changes, build-image, check]
+    if: needs.changes.outputs.code == 'true'
     steps:
       # Free up disk space BEFORE pulling the large Docker image
       - name: Free disk space


### PR DESCRIPTION
## [optional body]

required status checks の導入(ruleset「main」)により発覚した問題への根本対応。トリガーの `paths` / `paths-ignore` で workflow ごと止めると、そのチェックは永遠に「Expected — waiting for status」のままになり:

- **コードのみの PR** → `Check Markdown Links` が報告されず詰まる
- **docs のみの PR** → `Nix Check & Format` / `Build & Verify (Arch Linux)` が報告されず詰まる

### 対応方式(GitHub 推奨パターン)
workflow は常に起動し、`changes` ジョブが `git diff` で変更ファイルを判定 → 対象外なら下流ジョブを job-level `if:` で skip。**skip されたジョブは required checks 上「成功」扱い**になるため、どの種類の PR も詰まらない。

| workflow | 判定 | skip 条件 |
|----------|------|-----------|
| `nix.yml` | 旧 paths-ignore と同じ除外セット(docs/llm/md/LICENSE/.gitignore) | それ以外の変更が無ければ build-image / check / verify-docker を skip |
| `docs-lint.yml` | `.md` の変更有無 | 無ければ link-check を skip |

- base SHA が取れないケース(force push / ブランチ新規作成)は**安全側に倒して実行**
- CI 節約効果は従来の paths フィルタと同等(changes ジョブ約10秒が追加されるだけ)

### 検証
- 両 workflow の YAML パース OK
- 判定ロジックを5パターン(docsのみ / コード込み / 空 / md有り / md無し)で単体テスト済み
- **本 PR 自体が「コードのみ変更」の実地テスト**: pull_request イベントは PR 側の workflow 定義で走るため、Nix 系2つは実行・Check Markdown Links は skip で required 3つ全てが充足されるはず

## [optional footer(s)]

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
