### PR TITLE
feat(claude): /wt コマンドを追加 — タスク説明から herdr worktree + workspace を自動作成

### DIFF
--- a/.config/claude/commands/wt.md
+++ b/.config/claude/commands/wt.md
@@ -1,0 +1,53 @@
+# Worktree 作成 (herdr)
+
+タスクの説明からブランチ名を自動生成し、herdr の worktree + workspace を立ち上げます。
+
+## 使い方
+
+```
+/wt CIのキャッシュが壊れてるのを直したい
+/wt nvimにcopilot連携を追加する
+```
+
+## 手順
+
+### 1. リポジトリの確認
+
+`git rev-parse --show-toplevel` でリポジトリルートを確認する。
+git リポジトリでない場合は中断してユーザーに知らせる。
+
+### 2. ブランチ名の生成
+
+ユーザーの入力（`$ARGUMENTS`）からブランチ名を生成する。
+
+命名規則:
+
+- conventional commit message のような形式で生成する（`feat/` `fix/` `chore/` `ci/` `docs/` などの type を prefix にする）
+- prefix 以降は英語の snake_case で、単語 2〜4 個を目安に簡潔に
+- 迷ったら `feat/` か `fix/` に寄せる
+
+生成したブランチ名が既存ブランチと重複していないか `git branch --list <name>` で確認し、
+重複する場合は接尾辞を変えて再生成する。
+
+### 3. worktree + workspace の作成
+
+```bash
+herdr worktree create --cwd <repo-root> --branch <branch-name> --base main --focus
+```
+
+- ベースブランチはデフォルト `main`。ユーザーが入力内で別のベースを指定した場合はそれに従う
+- 作成結果（worktree のパス、workspace ID）をユーザーに報告する
+
+### 4. エージェントの起動（任意）
+
+タスク内容が具体的な場合、新しい workspace でエージェントを起動してタスクを渡す:
+
+```bash
+herdr agent start claude --workspace <workspace-id> --focus -- claude "<タスクの説明>"
+```
+
+タスクが曖昧な場合は起動せず、workspace の準備完了だけ報告して終わる。
+
+## 引数
+
+$ARGUMENTS


### PR DESCRIPTION
## 概要

Closes #315

マルチエージェント運用でブランチ名を毎回考える手間をなくすため、タスクの説明を渡すだけで worktree + workspace の立ち上げまで行う Claude Code カスタムコマンド `/wt` を追加します。

## 変更内容

- `.config/claude/commands/wt.md` を新規追加
  - `$ARGUMENTS` からブランチ名を生成（conventional commit 風 prefix + 英語 snake_case、単語 2〜4 個、迷ったら `feat/`・`fix/`）
  - 既存ブランチとの重複チェック付き
  - `herdr worktree create --branch <name> --base main --focus` で worktree + workspace を作成
  - タスクが具体的な場合は新 workspace でエージェントを起動してタスクを渡す

## 補足

- home-manager の `.claude` エントリが `recursive = true` のため、nix 側の変更は不要（次回 `mise run nix:switch` で `~/.claude/commands/wt.md` に symlink される）
- このPR自体を `herdr worktree create`（= `/wt` が自動化する流れ）で作成して動作確認済み

## 動作確認

- [x] `herdr worktree create --cwd ~/dotfiles --branch feat/add_wt_command --base main` で worktree + workspace が作成されること
- [ ] マージ後 `mise run nix:switch` で `/wt` が Claude Code に認識されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)