### PR TITLE
fix(mise): mise グローバル設定を追加 — リポジトリ外でも node/claude を利用可能に

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,5 @@
+# mise global config / mise グローバル設定
+# Tools available in every directory (claude is installed as an npm global under this node)
+# 全ディレクトリで有効なツール（claude はこの node 配下の npm グローバルとしてインストールされる）
+[tools]
+node = "22.15.1"

--- a/home.nix
+++ b/home.nix
@@ -66,6 +66,13 @@
       executable = true;
     };
 
+    # mise global config (tools available outside project dirs, e.g. claude via node)
+    # mise グローバル設定（プロジェクト外でも使うツール。claude は node 経由）
+    ".config/mise" = {
+      source = ./.config/mise;
+      recursive = true;
+    };
+
     # GitHub Copilot CLI (uses ~/.copilot/)
     # NOTE: config.json is seeded via activation script (Copilot CLI writes to it dynamically)
     ".copilot/copilot-instructions.md".source = ./.config/copilot/copilot-instructions.md;


### PR DESCRIPTION
## 概要

Closes #317

新規 herdr workspace（ホームディレクトリ等、`.mise.toml` を持たない場所）で `claude` が `Unknown command` になる問題の修正です。claude は mise 管理の node 配下の npm グローバルですが、node がプロジェクトローカル（`~/dotfiles/.mise.toml`）でしか定義されていなかったため、リポジトリ外では PATH に乗りませんでした。

## 変更内容

- `.config/mise/config.toml` を新規追加（`[tools] node = "22.15.1"` のグローバル定義）
- `home.nix` に `.config/mise` の symlink エントリを追加

## 適用手順（マージ後）

`mise use -g` で生成した実ファイルが symlink 作成の邪魔になるため、先に退避が必要:

```bash
rm ~/.config/mise/config.toml
mise run nix:switch
```

## 動作確認

- [x] `mise use -g node@22.15.1` 適用後、ホームディレクトリから `mise x -- which claude` が解決すること
- [ ] マージ後 `nix:switch` で `~/.config/mise/config.toml` が symlink になること
- [ ] 新規 herdr workspace のシェルで `claude` が起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)