### PR TITLE
fix(claude): /wt のエージェント起動に --cwd とユニーク名を追加

### DIFF
--- a/.config/claude/commands/wt.md
+++ b/.config/claude/commands/wt.md
@@ -43,8 +43,11 @@ herdr worktree create --cwd <repo-root> --branch <branch-name> --base main --foc
 タスク内容が具体的な場合、新しい workspace でエージェントを起動してタスクを渡す:
 
 ```bash
-herdr agent start claude --workspace <workspace-id> --focus -- claude "<タスクの説明>"
+herdr agent start claude-<branch-name 由来のユニーク名> --workspace <workspace-id> --cwd <worktree-path> --focus -- claude "<タスクの説明>"
 ```
+
+- `--cwd` は必須。省略すると呼び出し元シェルの cwd（リポジトリ本体）を引き継ぎ、worktree 外で作業が始まってしまう
+- エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする（例: `claude-x11-cleanup`）
 
 タスクが曖昧な場合は起動せず、workspace の準備完了だけ報告して終わる。
 

--- a/.config/claude/commands/wt.md
+++ b/.config/claude/commands/wt.md
@@ -47,7 +47,8 @@ herdr agent start claude-<branch-name 由来のユニーク名> --workspace <wor
 ```
 
 - `--cwd` は必須。省略すると呼び出し元シェルの cwd（リポジトリ本体）を引き継ぎ、worktree 外で作業が始まってしまう
-- エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする（例: `claude-x11-cleanup`）
+- エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする
+- 変換ルール: ブランチ名から prefix（`fix/` 等）を除き、`_` と `/` を `-` に置換して `claude-` を前置する（例: `fix/wt_agent_start_options` → `claude-wt-agent-start-options`）
 
 タスクが曖昧な場合は起動せず、workspace の準備完了だけ報告して終わる。
 


### PR DESCRIPTION
## 概要

Closes #319

`/wt` の手順 4 のエージェント起動コマンドで、Issue #305 のディスパッチ時に発覚した 2 つの問題を修正します。

## 変更内容

- `herdr agent start` に `--cwd <worktree-path>` を追加（省略すると呼び出し元シェルの cwd = リポジトリ本体でエージェントが起動し、worktree 外で作業が始まる）
- エージェント名を固定の `claude` からブランチ名由来のユニーク名に変更（固定名はセッション全体のユニーク制約により `agent_name_taken` で衝突する）
- それぞれの理由を手順内に注記として追加

## 動作確認

- [x] 実際のディスパッチ（#305）で `--cwd` 付き・ユニーク名での起動により、worktree 内 cwd でエージェントが起動することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)