### PR TITLE
refactor(nix): mise 設定の管理を config.toml 単体 + force = true に変更

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -68,9 +68,11 @@
 
     # mise global config (tools available outside project dirs, e.g. claude via node)
     # mise グローバル設定（プロジェクト外でも使うツール。claude は node 経由）
-    ".config/mise" = {
-      source = ./.config/mise;
-      recursive = true;
+    # force: overwrite real files created by `mise use -g` so activation never stalls
+    # force: `mise use -g` が作る実ファイルを上書きして activation の停止を防ぐ
+    ".config/mise/config.toml" = {
+      source = ./.config/mise/config.toml;
+      force = true;
     };
 
     # GitHub Copilot CLI (uses ~/.copilot/)


### PR DESCRIPTION
## 概要

Closes #321

PR #318 のレビュー指摘のフォローアップです。mise 設定の Home Manager 管理を、ディレクトリの `recursive = true` から `config.toml` 単体の symlink + `force = true` に変更します。

## 変更内容

- `home.nix`: `".config/mise"`（recursive）→ `".config/mise/config.toml"`（force = true）

## 効果

- `mise use -g` 等が作った実ファイルとの衝突で `nix:switch` の activation が停止する問題（#318 適用時に実際に発生）を `force` の自動上書きで恒久回避
- mise がランタイムで生成するファイル（trust 情報等）と nix 管理ファイルの境界が明確になる

## 動作確認

- [ ] マージ後 `mise run nix:switch` が停止せず完了すること
- [ ] `~/.config/mise/config.toml` が symlink のままであること
- [ ] `env -C ~ mise x -- which claude` が解決すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)