### PR TITLE
fix(claude): /wt のエージェント起動を上下分割(--split down)に変更

### DIFF
--- a/.config/claude/commands/wt.md
+++ b/.config/claude/commands/wt.md
@@ -43,10 +43,11 @@ herdr worktree create --cwd <repo-root> --branch <branch-name> --base main --foc
 タスク内容が具体的な場合、新しい workspace でエージェントを起動してタスクを渡す:
 
 ```bash
-herdr agent start claude-<branch-name 由来のユニーク名> --workspace <workspace-id> --cwd <worktree-path> --focus -- claude "<タスクの説明>"
+herdr agent start claude-<branch-name 由来のユニーク名> --workspace <workspace-id> --cwd <worktree-path> --split down --focus -- claude "<タスクの説明>"
 ```
 
 - `--cwd` は必須。省略すると呼び出し元シェルの cwd（リポジトリ本体）を引き継ぎ、worktree 外で作業が始まってしまう
+- `--split down` で pane を上下分割にする（省略時はデフォルトの `right` で左右分割になってしまう）
 - エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする
 - 変換ルール: ブランチ名から prefix（`fix/` 等）を除き、`_` と `/` を `-` に置換して `claude-` を前置する（例: `fix/wt_agent_start_options` → `claude-wt-agent-start-options`）
 


### PR DESCRIPTION
## 概要

`/wt` でエージェントを起動すると pane が左右分割で開いてしまう問題の修正です。
`.config/claude/commands/wt.md` の手順4のコマンド例に `--split down` を追加し、上下分割で開くようにしました。

Closes #328

## 変更内容

- 手順4の `herdr agent start` コマンド例に `--split down` を追加
- 手順4の箇条書きに `--split down` の説明を1行追加

## 動作確認

- `herdr agent start test-split --workspace w1E --cwd <worktree-path> --split down -- bash -c 'echo split-down-ok'` を実行し、`--split down` オプションがエラーなく受理され pane が作成されることを確認(確認後 pane は削除済み)
- `~/.claude/commands` は dotfiles への symlink 経由なので、マージ後の次回 `/wt` 実行から上下分割が反映されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)