### PR TITLE
feat(claude): Obsidian デイリーノート・セッションログ移植スキル /daily /session-log を追加

### DIFF
--- a/.config/claude/commands/daily.md
+++ b/.config/claude/commands/daily.md
@@ -1,0 +1,127 @@
+# Obsidian デイリーノート (ターミナル版クラウディア)
+
+朝はデイリーノートを自動作成・更新し、夜は対話型の振り返りを行います。
+cowork 環境で運用している「クラウディア」ワークフロー(Obsidian×Zettelkasten 統合)のターミナル移植です。
+
+## 使い方
+
+```
+/daily
+/daily 振り返り
+```
+
+- 引数なし: 朝モード(ノート作成・更新)
+- `振り返り` 等が入っている場合: 振り返りモード(対話型)
+
+## 前提情報
+
+- Vault: `/home/archie/Documents/Obsidian/Zettelkasten/`(ファイル直接読み書き。Obsidian MCP は使わない)
+- デイリーノート: `DailyNotes/YYYY-MM-DD.md`
+- テンプレート: `Template/Daily-v3.md`
+- GitHub ユーザー: `music-brain88`
+- 環境固有の値(統括カレンダー ID・レビュー対象 org 一覧)は `~/.claude/local/daily.local.md`(git 管理外)から読み込む。ファイルが無ければユーザーに値を確認して作成する
+
+## 手順(朝モード)
+
+### 1. 前回ノートの回収
+
+`DailyNotes/` を日付順に走査し、直近の日付ファイルを特定する(前日とは限らない。例: 6/30 の次が 7/3 ということもある)。
+そのノートから以下を回収する:
+
+- 未チェックタスク(`- [ ]`)全般
+- 末尾 `Distillation > Carry Over` の内容
+
+### 2. 今日のノート確認
+
+- `DailyNotes/YYYY-MM-DD.md`(今日の日付)が既にあれば、既存の構造を維持したまま再構成する
+- なければ `Template/Daily-v3.md` を元に作成する
+- Templater 変数(`{{date...}}`、`<% moment()... %>` 等)が未展開のまま残っていたら、実日付(YYYY-MM-DD)に置換する
+
+### 3. GitHub レビューリクエスト取得
+
+gh CLI で `~/.claude/local/daily.local.md` に書かれた対象 org 一覧を取得して統合する:
+
+```bash
+for org in <対象org一覧>; do
+  gh search prs --review-requested=music-brain88 --state=open --owner=$org --json title,url,repository,author
+done
+```
+
+- 0件なら「レビューリクエストなし ✅」
+- あれば件数を報告する(例: 「12件あり ⚠️」)
+- 前回ノートから持ち越しの項目には「(M/D から持ち越し)」を付記する
+
+### 4. カレンダー取得
+
+MCP `mcp__claude_ai_Google_Calendar__list_events` を ToolSearch でロードし、以下の両方を当日 JST で取得する:
+
+- `calendarId: <統括カレンダーID>`(`~/.claude/local/daily.local.md` に書かれた統括カレンダー。個人アカウントの reader 権限で読める)
+- `primary`
+
+OUT_OF_OFFICE(不在)イベントを検知したら、Schedule セクション冒頭に明記する。
+
+### 5. Available Time
+
+会議の隙間から集中できる時間帯を計算する。不在日の場合は「終日 terminal 開発デー」等、実態に合わせて記述する。
+
+### 6. ClickUp セクション(CTOROOM/AI Sprint)
+
+ターミナルからは会社 ClickUp に未接続のため、「cowork 側クラウディアで取得」と注記を残す(空欄のまま壊さない)。
+
+### 7. ファイル組み立て
+
+以下のセクション構成を維持する:
+
+```
+Tasks (Carry Over / CTOROOM / AI / GitHub Review Requests)
+Schedule
+Meeting Notes
+Available Time
+Notes
+Reflection
+Distillation
+```
+
+Write でファイル全体を組み立てて書き込む(部分 patch より全体組み立てが安全 — cowork 版の教訓)。
+既存の Reflection・Notes にユーザーが書いた内容があれば必ず温存する。
+
+### 8. サマリー報告
+
+持ち越し件数・レビューリクエスト件数に言及する。持ち越しがゼロなら「持ち越しなし!クリーンスタート🎉」のようなトーンで報告する。
+
+## 手順(振り返りモード)
+
+引数に「振り返り」等が含まれる場合の手順。
+
+### 1. 今日のノートを読む
+
+`DailyNotes/YYYY-MM-DD.md` を読み込み、今日の Tasks / Schedule / Notes を把握する。
+
+### 2. 対話で引き出す
+
+以下の順で対話しながら聞き出す:
+
+1. 「今日はどんな1日だった?」
+2. What went well
+3. What could be improved
+4. Learnings — 蒸留の問い:
+   - ① LLM の出力を除いて、自分が本当に理解したことは何?
+   - ② 1年後の自分に説明するなら?
+   - ③ 別の場面で使うなら?
+5. Tomorrow's Action(持ち越しから1つだけ選ぶ)
+
+### 3. Reflection の記入
+
+**Reflection はユーザーの言葉で書く。LLM が代筆しない。** ユーザーの発言を整えて転記する程度にとどめる。
+
+### 4. Distillation への追記
+
+`Distillation > Permanent Notes Candidates` に昇格候補を1行ずつ追記する。
+
+### 5. トーン
+
+カジュアル・労いを忘れずに。疲れてる様子なら無理に全項目を聞き出そうとしない。
+
+## 引数
+
+$ARGUMENTS

--- a/.config/claude/commands/session-log.md
+++ b/.config/claude/commands/session-log.md
@@ -1,0 +1,88 @@
+# セッションログを ResearchNotes へ昇格
+
+Claude Code セッションでの意思決定・洞察・成果物を Obsidian の ResearchNotes に昇格させます。
+生ログの全転写ではなく、対話で生まれた判断・設計・学びを厳選して記録する層(層1)を担います。
+
+## 使い方
+
+```
+/session-log
+/session-log <トピック>
+```
+
+- 引数なし: セッションの内容からトピックを自動推定する
+- トピックを渡した場合: それを元にファイル名・タイトルを決める
+
+## 前提情報
+
+- Vault: `/home/archie/Documents/Obsidian/Zettelkasten/`(ファイル直接読み書き。Obsidian MCP は使わない)
+- 保存先: `ResearchNotes/ClaudeCodeSession-YYYYMMDD-<TopicSlug>.md`(TopicSlug は PascalCase の英語)
+- デイリーノート: `DailyNotes/YYYY-MM-DD.md`
+
+## 手順
+
+### 1. ファイルの決定
+
+`ResearchNotes/ClaudeCodeSession-YYYYMMDD-<TopicSlug>.md` というファイル名にする。
+同日・同トピックの既存ノートが既にあれば、新規作成ではなく更新する。
+
+### 2. フォーマット
+
+実例(`ResearchNotes/ClaudeCodeSession-20260703-HerdrDialogueProtocol.md`)を読めるなら参照する。
+読めない場合は以下のスケルトンに従う:
+
+```markdown
+---
+date: YYYY-MM-DD
+tags:
+  - <プロジェクト名やテーマのケバブケース 3〜6個>
+type: research-note
+source: Claude Code session (<モデル名>)
+---
+
+# <タイトル — 何から何に到達したかが分かる一文>
+
+> Claude Code との対話セッション記録 (YYYY-MM-DD)。
+> <セッションの2〜3行サマリー(何を議論し、何を決め、何を作ったか)>
+
+## きっかけ・問題意識
+<箇条書き>
+
+## <主要な洞察ごとの見出し(2〜5個。表・引用・コード可)>
+
+## 決定事項・成果物
+- ✅ <完了したこと(PR/Issue/ファイルへのリンク付き)>
+
+## 次の一手・宿題
+- [ ] <チェックボックス>
+
+## 関連リンク
+- <URL、[[wikilink]] を積極的に(既存ノート名と繋ぐ)>
+```
+
+### 3. 記録の原則
+
+LLM 出力の羅列ではなく、「ユーザーとの対話で生まれた判断・設計・学び」を残す。
+引用すべき生ログ(エラーメッセージ・報告原文)は厳選して引用ブロックで載せる。
+
+### 4. デイリーノートへのリンク追記
+
+`DailyNotes/YYYY-MM-DD.md`(今日の日付)が存在すれば、`Notes > New Note Links` に以下を Edit で追記する:
+
+```
+[[Zettelkasten/ResearchNotes/<ファイル名(拡張子なし)>]]
+```
+
+デイリーノートが存在しない場合は追記をスキップし、その旨を報告する。
+
+### 5. 蒸留候補の追記
+
+昇格できそうな知識(Permanent Notes 候補)があれば、デイリーノートの `Distillation > Permanent Notes Candidates` にも1行ずつ追記する。
+
+### 6. 完了報告
+
+作成・更新したノートのパスと、追記したデイリーノートのセクションを報告する。
+
+## 引数
+
+$ARGUMENTS


### PR DESCRIPTION
## 概要
- cowork 環境で運用しているObsidian×Zettelkasten 統合ワークフローターミナル(Claude Code + herdr)環境に移植する
- `/daily`: デイリーノートの自動作成・更新(朝)、対話型振り返り(夜)
- `/session-log`: セッションの学びを ResearchNotes へ昇格

本日(2026-07-03)司令塔が手動実行で一周検証済みのワークフローの skill 化です。

## 詳細
- ターミナル版の強み: vault はファイルシステム直接読み書き(MCP 不要)、GitHub は gh CLI、統括カレンダーは個人 Google アカウントの reader 権限で MCP 取得可能
- 対話ログ→知識昇格の4層パイプライン(生ログ→ResearchNotes→Daily/Weekly→PermanentNotes)のうち、`/daily` が層1・層2を、`/session-log` が層1を担う
- コマンドの見出し・文体は `.config/claude/commands/wt.md` の流儀に合わせた

## 変更ファイル
- `.config/claude/commands/daily.md`(新規)
- `.config/claude/commands/session-log.md`(新規)

Closes #338
Closes #339