### PR TITLE
feat(hypr): 参照アプリを named special workspace 化(Obsidian / Claude Desktop)

### DIFF
--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -126,6 +126,12 @@ bind = $mainMod, Tab, workspace, previous
 bind = $mainMod, S, togglespecialworkspace, magic
 bind = $mainMod ALT, S, movetoworkspace, special:magic
 
+# 引き出し（参照アプリの named special workspace）
+# どのワークスペースからでも同じキーで呼び出せる「ちょい見」専用オーバーレイ
+# / Drawer: named special workspaces for reference apps, toggled with the same key from any workspace (glance-only)
+bind = $mainMod, O, togglespecialworkspace, obsidian
+bind = $mainMod, A, togglespecialworkspace, claude
+
 ### システム操作 ###
 # スクリーンショット（選択領域をクリップボードにコピー）
 bind = , Print, exec, grim -g "$(slurp)" - | wl-copy

--- a/.config/hypr/window-rules.conf
+++ b/.config/hypr/window-rules.conf
@@ -15,12 +15,18 @@
 #     Notification-driven apps that should live in the background are gathered here with
 #     a "Go" style rule (explicitly pinned to a fixed workspace).
 #   引き出し (special workspaces) / Drawer: 参照アプリを Bring 型（呼び出した時だけ手元に
-#   出すオーバーレイ）で扱う層。実装は別 Issue #345 でこのファイルの対象外。
+#   出すオーバーレイ）で扱う層。Super+O / Super+A でどこからでもトグル表示できる（#345）。
 #     Reference apps handled as a "Bring" style overlay (summoned only on demand via special
-#     workspaces). Implementation tracked separately in #345 and out of scope here.
+#     workspaces), toggled from anywhere with Super+O / Super+A (#345).
 windowrule = match:class ^(slack)$, workspace 4 silent
 windowrule = match:class ^(discord)$, workspace 4 silent
 windowrule = match:class ^(spotify)$, workspace 5 silent
+
+# 引き出し: 起動時に named special workspace へ直行させる（Super+O / Super+A でトグル）
+# Drawer: send these reference apps straight to their named special workspace on launch
+# （class 名は実機の hyprctl clients -j で確認済み / class names verified live via hyprctl clients -j）
+windowrule = match:class ^(obsidian)$, workspace special:obsidian silent
+windowrule = match:class ^(claude-desktop)$, workspace special:claude silent
 
 # ─── システムユーティリティ（フロート + サイズ + 配置） ──
 windowrule {

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -244,6 +244,8 @@ Hyprlandの設定は `.config/hypr/keybinds.conf` で定義されています。
 | `Super + Tab` | Toggle previous workspace | 直前のワークスペースとトグル |
 | `Super + S` | Toggle special workspace | スクラッチパッドの表示/非表示 |
 | `Super + Alt + S` | Move window to special workspace | ウィンドウをスクラッチパッドへ送る |
+| `Super + O` | Toggle Obsidian drawer (special workspace) | Obsidian引き出しの表示/非表示 |
+| `Super + A` | Toggle Claude Desktop drawer (special workspace) | Claude Desktop引き出しの表示/非表示 |
 
 ### Screenshot
 


### PR DESCRIPTION
## 概要
ワークスペース3層構造の「引き出し」層を実装。Obsidian・Claude Desktop をどのワークスペースからでも同じキーでオーバーレイ表示/非表示できるようにする。

- `keybinds.conf`: `Super+O` → Obsidian引き出し、`Super+A` → Claude Desktop引き出しをトグル
- `window-rules.conf`: 起動時に各アプリを対応する named special workspace へ直行させるルールを追加
- `window-rules.conf` 冒頭の3層構造コメント（#350でマージ済み）の「引き出し」説明を、実装済みの記述に更新
- `docs/reference/keybindings.md` に Super+O / Super+A を追記

## class 名の実機確認
稼働中の Hyprland セッションで `hyprctl clients -j` を使って確認(読み取りのみ、dispatch/reload は未使用):
- Obsidian: `obsidian`(Issue記載の想定通り。起動確認のため一時的に起動し、確認後に終了させた)
- Claude Desktop: `claude-desktop`(Issue記載の `Claude` ではなく、実際は `claude-desktop` だった)

## 既存動作への影響
- 既存の `special:magic`(Super+S、汎用スクラッチパッド)はそのまま維持
- `Super+O` / `Super+A` は既存バインドと衝突なし(事前確認済み)
- 送り返しバインド(Super+SHIFT+O 等)は Issue #346 の担当のため未実装

Closes #345