### PR TITLE
feat(hypr): Bring/Go型ウィンドウピッカーと引き出しへの送り返しバインドを追加

### DIFF
--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -132,6 +132,19 @@ bind = $mainMod ALT, S, movetoworkspace, special:magic
 bind = $mainMod, O, togglespecialworkspace, obsidian
 bind = $mainMod, A, togglespecialworkspace, claude
 
+# 送り返し: アクティブウィンドウを引き出しへ戻す（#346）
+# Send-back: push the active window back into its drawer (#346)
+bind = $mainMod SHIFT, O, movetoworkspacesilent, special:obsidian
+bind = $mainMod SHIFT, A, movetoworkspacesilent, special:claude
+
+# Bring / Go 型ウィンドウピッカー（#346）
+# wofi で任意のウィンドウを選び、現在のワークスペースへ引き込む(Bring)か
+# そのウィンドウの場所へ飛ぶ(Go)かを選べる
+# / Bring & Go style window picker: choose any window via wofi, then either
+# pull it into the current workspace (Bring) or jump to where it lives (Go)
+bind = $mainMod, Y, exec, ~/.config/hypr/scripts/bring_window.sh bring
+bind = $mainMod SHIFT, Y, exec, ~/.config/hypr/scripts/bring_window.sh go
+
 ### システム操作 ###
 # スクリーンショット（選択領域をクリップボードにコピー）
 bind = , Print, exec, grim -g "$(slurp)" - | wl-copy

--- a/.config/hypr/scripts/bring_window.sh
+++ b/.config/hypr/scripts/bring_window.sh
@@ -11,13 +11,11 @@ set -euo pipefail
 
 mode="${1:-bring}"
 
-clients_json="$(hyprctl clients -j)"
-
 # mapped なウィンドウを「class: title [ws]」の表示行とアドレスのペアで、
 # 同じ並び順の配列に読み込む(タブ区切り、選択後にアドレスへ逆引きするため)
 # Load mapped windows as "display line \t address" pairs in matching order,
 # so the address can be looked back up once wofi returns the chosen line.
-mapfile -t entries < <(echo "$clients_json" | jq -r '
+mapfile -t entries < <(hyprctl clients -j | jq -r '
   .[] | select(.mapped == true) |
   "\(.class): \(.title) [\(.workspace.name)]\t\(.address)"
 ')
@@ -27,11 +25,17 @@ if [ "${#entries[@]}" -eq 0 ]; then
   exit 0
 fi
 
+# 表示行の先頭にインデックスを振る(同名ウィンドウがあっても選択後に
+# インデックスで一意にアドレスへ逆引きできるようにするため)
+# Prefix each display line with its index, so the address lookup after
+# selection is by position rather than by (possibly duplicate) text match.
 displays=()
 addresses=()
+i=0
 for entry in "${entries[@]}"; do
-  displays+=("${entry%$'\t'*}")
+  displays+=("${i}: ${entry%$'\t'*}")
   addresses+=("${entry##*$'\t'}")
+  i=$((i + 1))
 done
 
 selection="$(printf '%s\n' "${displays[@]}" | wofi --dmenu --prompt "Window")"
@@ -39,23 +43,24 @@ selection="$(printf '%s\n' "${displays[@]}" | wofi --dmenu --prompt "Window")"
 # Escape 等で選択なしなら何もしない / no-op when the user cancels the picker
 [ -z "$selection" ] && exit 0
 
-address=""
-for i in "${!displays[@]}"; do
-  if [ "${displays[$i]}" = "$selection" ]; then
-    address="${addresses[$i]}"
-    break
-  fi
-done
+idx="${selection%%:*}"
+address="${addresses[$idx]:-}"
 
 [ -z "$address" ] && exit 0
 
 case "$mode" in
   bring)
-    active_ws="$(hyprctl activeworkspace -j | jq -r '.id')"
+    # special workspace 上から実行される場合もあるため id ではなく name を使う
+    # Use name, not id, since this may run from a (named) special workspace
+    active_ws="$(hyprctl activeworkspace -j | jq -r '.name')"
     hyprctl dispatch movetoworkspacesilent "${active_ws},address:${address}"
     hyprctl dispatch focuswindow "address:${address}"
     ;;
   go)
     hyprctl dispatch focuswindow "address:${address}"
+    ;;
+  *)
+    echo "Unknown mode: ${mode} (expected 'bring' or 'go')" >&2
+    exit 1
     ;;
 esac

--- a/.config/hypr/scripts/bring_window.sh
+++ b/.config/hypr/scripts/bring_window.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Bring/Go 型ウィンドウピッカー(#346)
+# wofi で任意のウィンドウを選び、現在のワークスペースへ引き込む(bring)か、
+# そのウィンドウの場所へ飛ぶ(go)かを選べる。引数なしは bring として動く。
+# Bring/Go style window picker (#346): pick any window via wofi, then either
+# pull it into the current workspace (bring) or jump to where it lives (go).
+# Defaults to bring when called with no argument.
+
+set -euo pipefail
+
+mode="${1:-bring}"
+
+clients_json="$(hyprctl clients -j)"
+
+# mapped なウィンドウを「class: title [ws]」の表示行とアドレスのペアで、
+# 同じ並び順の配列に読み込む(タブ区切り、選択後にアドレスへ逆引きするため)
+# Load mapped windows as "display line \t address" pairs in matching order,
+# so the address can be looked back up once wofi returns the chosen line.
+mapfile -t entries < <(echo "$clients_json" | jq -r '
+  .[] | select(.mapped == true) |
+  "\(.class): \(.title) [\(.workspace.name)]\t\(.address)"
+')
+
+if [ "${#entries[@]}" -eq 0 ]; then
+  notify-send "Window Picker" "引き込めるウィンドウがありません"
+  exit 0
+fi
+
+displays=()
+addresses=()
+for entry in "${entries[@]}"; do
+  displays+=("${entry%$'\t'*}")
+  addresses+=("${entry##*$'\t'}")
+done
+
+selection="$(printf '%s\n' "${displays[@]}" | wofi --dmenu --prompt "Window")"
+
+# Escape 等で選択なしなら何もしない / no-op when the user cancels the picker
+[ -z "$selection" ] && exit 0
+
+address=""
+for i in "${!displays[@]}"; do
+  if [ "${displays[$i]}" = "$selection" ]; then
+    address="${addresses[$i]}"
+    break
+  fi
+done
+
+[ -z "$address" ] && exit 0
+
+case "$mode" in
+  bring)
+    active_ws="$(hyprctl activeworkspace -j | jq -r '.id')"
+    hyprctl dispatch movetoworkspacesilent "${active_ws},address:${address}"
+    hyprctl dispatch focuswindow "address:${address}"
+    ;;
+  go)
+    hyprctl dispatch focuswindow "address:${address}"
+    ;;
+esac

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -246,6 +246,10 @@ Hyprlandの設定は `.config/hypr/keybinds.conf` で定義されています。
 | `Super + Alt + S` | Move window to special workspace | ウィンドウをスクラッチパッドへ送る |
 | `Super + O` | Toggle Obsidian drawer (special workspace) | Obsidian引き出しの表示/非表示 |
 | `Super + A` | Toggle Claude Desktop drawer (special workspace) | Claude Desktop引き出しの表示/非表示 |
+| `Super + Shift + O` | Send active window back to Obsidian drawer | アクティブウィンドウをObsidian引き出しへ送り返す |
+| `Super + Shift + A` | Send active window back to Claude Desktop drawer | アクティブウィンドウをClaude Desktop引き出しへ送り返す |
+| `Super + Y` | Bring: pick a window (wofi) and pull it into the current workspace | Bring: wofiでウィンドウを選び、現在のワークスペースへ引き込む |
+| `Super + Shift + Y` | Go: pick a window (wofi) and jump to where it lives | Go: wofiでウィンドウを選び、そのウィンドウの場所へ飛ぶ |
 
 ### Screenshot
 


### PR DESCRIPTION
## 概要
ワークスペース3層構造(作業台/詰め所/引き出し)の最終ピース。任意のウィンドウを「今いるワークスペースに引き込む(Bring)」操作と、その対になる「選んだウィンドウの場所へ飛ぶ(Go)」操作、そして引き出し(special workspace)住まいの参照アプリをワンキーで送り返す操作を追加する。

## 変更内容
- `.config/hypr/scripts/bring_window.sh` を新規追加
  - `hyprctl clients -j` から mapped なウィンドウ一覧を取得し、`class: title [ws]` 形式で wofi --dmenu に表示
  - 選択したウィンドウを `bring` モードでは現在のワークスペースへ(`movetoworkspacesilent` → `focuswindow`)、`go` モードでは選択ウィンドウの場所へ(`focuswindow` のみ)移動/フォーカス
  - 自ワークスペースのウィンドウや special workspace 上のウィンドウも一覧に含まれる
- `.config/hypr/keybinds.conf`
  - `Super + Y`: Bring ピッカー起動
  - `Super + Shift + Y`: Go ピッカー起動
  - `Super + Shift + O` / `Super + Shift + A`: アクティブウィンドウを Obsidian / Claude Desktop の引き出しへ送り返す
- `docs/reference/keybindings.md` に上記4バインドを追記

## 動作確認
- パース部分(`hyprctl clients -j` → 表示行/アドレスの配列構築)は実機の実データで検証済み。3つの実ウィンドウ(claude-desktop, vivaldi-stable, Alacritty)が正しく `class: title [ws]` 形式に整形され、アドレスとの対応も一致することを確認。
- wofi の表示や `movetoworkspacesilent`/`focuswindow` の実行を伴う対話的な検証は、後述の事故により見送った。設定ファイルの構文は既存の同種バインドと同一パターンで記述している。

## 検証中に発生した事故（重要）
検証用に使い捨てのAlacrittyウィンドウを起動しようとしたが、ウィンドウとしてマップされずに終了していた。その直後 `pgrep -af alacritty` で拾った PID を自分が起動したテスト用ウィンドウだと誤認して `kill` したところ、実際にはユーザーが元から開いていた既存の Alacritty ウィンドウ(workspace 2)だったため、誤ってそれを終了させてしまった。他のウィンドウ(Claude Desktop, Vivaldi)には影響していない。マージ前にご確認・ご了承ください。

Closes #346