### PR TITLE
refactor(claude): wt.md / wtclean.md を Agent SOP 形式に再構成

### DIFF
--- a/.config/claude/commands/wt.md
+++ b/.config/claude/commands/wt.md
@@ -1,33 +1,31 @@
 # Worktree 作成 (herdr)
 
+## Overview
+
 タスクの説明からブランチ名を自動生成し、herdr の worktree + workspace を立ち上げます。
 
-## 使い方
+## Parameters
 
-```
-/wt CIのキャッシュが壊れてるのを直したい
-/wt nvimにcopilot連携を追加する
-```
+- **タスク説明**(必須): ユーザーが `/wt` に続けて入力する自然文。ブランチ名の生成、worktree/workspace の作成、および該当する場合はエージェントへの作業指示プロンプト作成の入力になる(実体は末尾の [引数](#引数) セクション参照)
 
-## 手順
+## Steps
 
 ### 1. リポジトリの確認
 
-`git rev-parse --show-toplevel` でリポジトリルートを確認する。
-git リポジトリでない場合は中断してユーザーに知らせる。
+**Constraints:**
+- **MUST**: `git rev-parse --show-toplevel` でリポジトリルートを確認する
+- **MUST**: git リポジトリでない場合は中断してユーザーに知らせる
 
 ### 2. ブランチ名の生成
 
 ユーザーの入力（`$ARGUMENTS`）からブランチ名を生成する。
 
-命名規則:
-
-- conventional commit message のような形式で生成する（`feat/` `fix/` `chore/` `ci/` `docs/` などの type を prefix にする）
-- prefix 以降は英語の snake_case で、単語 2〜4 個を目安に簡潔に
-- 迷ったら `feat/` か `fix/` に寄せる
-
-生成したブランチ名が既存ブランチと重複していないか `git branch --list <name>` で確認し、
-重複する場合は接尾辞を変えて再生成する。
+**Constraints:**
+- **MUST**: conventional commit message のような形式で生成する(`feat/` `fix/` `chore/` `ci/` `docs/` などの type を prefix にする)
+- **SHOULD**: prefix 以降は英語の snake_case で、単語 2〜4 個を目安に簡潔に
+- **SHOULD**: 迷ったら `feat/` か `fix/` に寄せる
+- **MUST**: 生成したブランチ名が既存ブランチと重複していないか `git branch --list <name>` で確認する
+- **MUST**: 重複する場合は接尾辞を変えて再生成する
 
 ### 3. worktree + workspace の作成
 
@@ -35,20 +33,22 @@ git リポジトリでない場合は中断してユーザーに知らせる。
 herdr worktree create --cwd <repo-root> --branch <branch-name> --base main --focus
 ```
 
-- ベースブランチはデフォルト `main`。ユーザーが入力内で別のベースを指定した場合はそれに従う
-- 作成結果（worktree のパス、workspace ID）をユーザーに報告する
+**Constraints:**
+- **MUST**: ベースブランチはデフォルト `main`。ユーザーが入力内で別のベースを指定した場合はそれに従う
+- **MUST**: 作成結果(worktree のパス、workspace ID)をユーザーに報告する
 
 #### worktree の準備
 
 worktree 作成直後に以下を行う:
 
-- `mise trust <worktree-path>` を実行する（mise trust は絶対パス単位で管理されるため、新規 worktree は毎回 untrusted で始まる。忘れると `mise run` が「no tasks defined」で失敗する — #335）
-- allowlist を配置する: `mkdir -p <worktree-path>/.claude && cp ~/.claude/templates/wt-settings.local.json <worktree-path>/.claude/settings.local.json`
+**Constraints:**
+- **MUST**: `mise trust <worktree-path>` を実行する(詳細: Troubleshooting「mise trust 忘れ」参照)
+- **MUST**: allowlist を配置する: `mkdir -p <worktree-path>/.claude && cp ~/.claude/templates/wt-settings.local.json <worktree-path>/.claude/settings.local.json`
   - コピー元は `<repo-root>/.config/claude/templates/...` ではなく `~/.claude/templates/...` を使う。`<repo-root>` は `/wt` を呼び出した対象リポジトリ次第で変わり、dotfiles 以外のリポジトリではこのテンプレートを含まないため
-  - `~/.claude` への反映は home-manager 経由(`home.nix` の `home.file ".claude".source = ./.config/claude`)で、`mise run nix:switch` 実行時に `/nix/store` スナップショットへの per-file symlink が生成される方式。テンプレートを追加・変更したら `mise run nix:switch` を実行しないと `~/.claude/templates/` に反映されない。`cp` が `No such file or directory` で失敗したら、まず nix:switch 漏れを疑う
-  - 定型で安全な操作（`git`・`gh`・`mise`・`herdr` の一部サブコマンド、司令塔がタスク指示を置くスクラッチパッドの読み取り）を宣言的に許可し、作業者の permission 往復（A類）を設計で消す。詳細は allowlist テンプレート本体を参照
+  - `~/.claude` への反映は home-manager 経由(`home.nix` の `home.file ".claude".source = ./.config/claude`)で、`mise run nix:switch` 実行時に `/nix/store` スナップショットへの per-file symlink が生成される方式。テンプレートを追加・変更したら `mise run nix:switch` を実行しないと `~/.claude/templates/` に反映されない(詳細: Troubleshooting「allowlist テンプレートの cp 失敗」参照)
+  - 定型で安全な操作(`git`・`gh`・`mise`・`herdr` の一部サブコマンド、司令塔がタスク指示を置くスクラッチパッドの読み取り)を宣言的に許可し、作業者の permission 往復(A類)を設計で消す。詳細は allowlist テンプレート本体を参照
 
-### 4. エージェントの起動（任意）
+### 4. エージェントの起動(任意)
 
 タスク内容が具体的な場合、新しい workspace でエージェントを起動してタスクを渡す:
 
@@ -59,16 +59,16 @@ PROMPT
 )"
 ```
 
-- `--cwd` は必須。省略すると呼び出し元シェルの cwd（リポジトリ本体）を引き継ぎ、worktree 外で作業が始まってしまう
-- `--split down` で pane を上下分割にする（省略時はデフォルトの `right` で左右分割になってしまう）
-- エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする
-- 変換ルール: ブランチ名から prefix（`fix/` 等）を除き、`_` と `/` を `-` に置換して `claude-` を前置する（例: `fix/wt_agent_start_options` → `claude-wt-agent-start-options`）
-- 作業者モデルはデフォルト `claude-sonnet-5`（司令塔=メインセッションが計画とレビュー、作業者が実装を担う分業）。ユーザーが入力内で別モデルを指定した場合はそれに従う
-- `--permission-mode auto` で起動する。定型操作は自動承認され、判断が必要な操作だけが blocked として表面化する（`--dangerously-skip-permissions` は使わない — 監督を全て外すのではなく、エスカレーションのレーンを残すのが目的）
-- それでも blocked が発生した場合、司令塔は代理承認できない（Claude Code が禁止している）。司令塔の責務は「即検知して人間に知らせる」まで（#332 の対話プロトコル参照）
-- auto mode での起動自体がハーネス（auto mode 分類器）に「ユーザーの明示許可がない」として拒否されることがある。その場合は AskUserQuestion 等でユーザーに auto mode 起動の許可を明示的に確認してから再実行する
-
-タスクが曖昧な場合は起動せず、workspace の準備完了だけ報告して終わる。
+**Constraints:**
+- **MUST**: `--cwd` は必須。省略すると呼び出し元シェルの cwd(リポジトリ本体)を引き継ぎ、worktree 外で作業が始まってしまう
+- **MUST**: `--split down` で pane を上下分割にする(省略時はデフォルトの `right` で左右分割になってしまう)
+- **MUST**: エージェント名はセッション全体でユニーク制約があるため、固定名 `claude` ではなくブランチ名由来の名前にする。変換ルール: ブランチ名から prefix(`fix/` 等)を除き、`_` と `/` を `-` に置換して `claude-` を前置する(例: `fix/wt_agent_start_options` → `claude-wt-agent-start-options`)
+- **MUST**: 作業者モデルはデフォルト `claude-sonnet-5`(司令塔=メインセッションが計画とレビュー、作業者が実装を担う分業)。ユーザーが入力内で別モデルを指定した場合はそれに従う
+- **MUST**: `--permission-mode auto` で起動する。定型操作は自動承認され、判断が必要な操作だけが blocked として表面化する
+- **MUST NOT**: `--dangerously-skip-permissions` は使わない(監督を全て外すのではなく、エスカレーションのレーンを残すのが目的)
+- **MUST**: それでも blocked が発生した場合、司令塔は代理承認できない(Claude Code が禁止している)。司令塔の責務は「即検知して人間に知らせる」まで(#332 の対話プロトコル参照)
+- **MUST**: auto mode 起動がハーネス(auto mode 分類器)に拒否された場合、AskUserQuestion 等でユーザーに auto mode 起動の許可を明示的に確認してから再実行する(詳細: Troubleshooting「auto mode 起動の拒否」参照)
+- **MUST NOT**: タスクが曖昧な場合は起動しない。**MUST**: その場合は workspace の準備完了だけ報告して終わる
 
 #### effort の選択基準
 
@@ -76,12 +76,13 @@ PROMPT
 
 | effort | 使いどころ |
 |--------|-----------|
-| medium | 定型・機械的な変更（バージョン bump、typo 修正、設定1行の変更） |
-| high | 通常の実装タスク（迷ったらこれ。Sonnet 5 のデフォルト） |
+| medium | 定型・機械的な変更(バージョン bump、typo 修正、設定1行の変更) |
+| high | 通常の実装タスク(迷ったらこれ。Sonnet 5 のデフォルト) |
 | xhigh | 難しい実装・複数ファイルにまたがる変更・設計判断を含むタスク |
 
-- `low` は under-thinking のリスクがあるため /wt では使わない
-- `medium` 以下では Sonnet 5 が指示を literal に解釈するため、作業指示プロンプトの完了条件を具体的に書くことが特に重要
+**Constraints:**
+- **MUST NOT**: `low` は /wt では使わない(under-thinking のリスクがあるため)
+- **SHOULD**: `medium` 以下では Sonnet 5 が指示を literal に解釈するため、作業指示プロンプトの完了条件を具体的に書く
 
 #### 作業指示プロンプトのテンプレート
 
@@ -108,11 +109,12 @@ PROMPT
 完了したら、変更ファイル・PR の URL・確認した動作を簡潔にまとめて報告する。指示外の気づき（環境の摩擦・想定外の挙動・自分で編み出した回避策）があれば、解決済みであっても必ず報告する（該当なしなら「なし」と明記する）
 ```
 
-背景と完了条件を具体的に書くほど作業品質が安定する。
+**Constraints:**
+- **SHOULD**: 背景と完了条件を具体的に書く(書くほど作業品質が安定する)
 
-### 5. 対話プロトコル（委任後の監視と対話）
+### 5. 対話プロトコル(委任後の監視と対話)
 
-エージェント起動後、司令塔（このセッション）と作業者エージェントの間のやり取りは、以下の4本柱からなる対話プロトコルとして運用する（設計の背景は #332 参照）。ここでは (1) 下り=指示 と (2) 上り=イベント を扱う。(3) 上り=内容 は上記の作業指示プロンプトの「## 報告」欄、(4) 供養 は `/wtclean` 側で扱う。
+エージェント起動後、司令塔(このセッション)と作業者エージェントの間のやり取りは、以下の4本柱からなる対話プロトコルとして運用する(設計の背景は #332 参照)。ここでは (1) 下り=指示 と (2) 上り=イベント を扱う。(3) 上り=内容 は上記の作業指示プロンプトの「## 報告」欄、(4) 供養 は `/wtclean` 側で扱う。
 
 #### (1) 下り=指示
 
@@ -123,14 +125,15 @@ herdr pane send-text <pane-id> "<追加指示のテキスト>"
 herdr pane send-keys <pane-id> Enter
 ```
 
-- `pane send-text` は pane の入力欄にテキストを挿入するだけで、送信（実行）はされない。実機確認済み: `send-text` の直後に `pane read` してもコマンドは未実行のまま入力欄に残っており、続けて `pane send-keys <pane-id> Enter` を送って初めて実行される
-- `<pane-id>` は対象エージェント名から `herdr agent list` で引く（`pane_id` フィールド）
-- 宛先を誤ると、無関係な pane やこの司令塔自身の入力欄にテキストが挿入されてしまう（`agent send` / `pane send-text` はテキストを引数としてそのまま送るだけで、確認や取り消しは挟まらない）。実行前に対象の pane-id / agent 名を必ず確認する
-- pane-id はセッション中に compact されうる非永続 ID（詳細は `.config/claude/skills/herdr/SKILL.md` 参照）。長時間の監視をまたぐ場合は都度 `herdr agent list` で引き直し、古い pane-id を使い回さない
+**Constraints:**
+- **MUST**: pane へのテキスト送信と Enter 送信を分けた2段で行う(詳細: Troubleshooting「send-text は単体では実行されない」参照)
+- **MUST**: `<pane-id>` は対象エージェント名から `herdr agent list` で引く(`pane_id` フィールド)
+- **MUST**: 実行前に対象の pane-id / agent 名を必ず確認する(宛先を誤ると、無関係な pane やこの司令塔自身の入力欄にテキストが挿入されてしまう。`agent send` / `pane send-text` はテキストを引数としてそのまま送るだけで、確認や取り消しは挟まらない)
+- **MUST**: 長時間の監視をまたぐ場合は都度 `herdr agent list` で引き直し、古い pane-id を使い回さない(詳細: Troubleshooting「pane-id は非永続」参照)
 
 #### (2) 上り=イベント
 
-委任直後、作業者の状態が `working` に遷移したことを確認してから、`blocked`（詰まり）と `idle`（完了）の2状態を同時にバックグラウンドで待ち受ける:
+委任直後、作業者の状態が `working` に遷移したことを確認してから、`blocked`(詰まり)と `idle`(完了)の2状態を同時にバックグラウンドで待ち受ける(詳細: Troubleshooting「wait の即時解決」参照):
 
 ```bash
 # gotcha: 対象が既に指定ステータスだと即座に解決してしまうため、working に遷移済みか確認してから仕掛ける
@@ -154,14 +157,45 @@ else
 fi
 ```
 
-- ログファイル名には `<agent-name>` を含める。複数 worktree を並行監視しているときに固定ファイル名だと内容が上書きされてしまうため
-- `wait -n` は bash 組み込みで、バックグラウンドの2ジョブのうち先に終了した方を検知する。ただし `wait -n` 自身はどちらが終了したかを返さないため、直後に `kill -0 "$BLOCKED_PID"`(シグナルを送らず存否だけ確認する)で生死を見て、生きている方=発火しなかった方、と判別してから後処理する。判別できたら `$FIRED_STATUS` を見て、`blocked` ならユーザーに承認を仰ぎ、`idle` なら `herdr agent read "$AGENT_NAME" --source recent --lines 50` で完了報告を確認する。まだ生きている側の wait は用済みなので kill で片付ける
-- `<agent-name>` は手順4でエージェントに付けたユニーク名。`herdr agent wait` / `herdr agent read` は pane-id ではなく agent 名を直接ターゲットにできるため、監視中に pane-id を引き直す必要がない
-- 定期ポーリング（`herdr pane list` 等を一定間隔で呼び続けるループ）は禁止。コストが高いうえ、このプロトコルが解消したいアンチパターンそのもの
-- gotcha（実機確認済み）: `herdr agent wait` は対象が**既に**指定ステータスだと即座に解決する。作業者がまだ `working` に遷移していない段階で `idle` 待ちを仕掛けると、起動直後の未初期化状態を完了と誤検知しかねない
-- `--status done` は使わない。`herdr agent wait` に `done` を渡すとエラーになる（実機確認済みのエラーメッセージ: `done is a UI attention state; use idle for CLI agent completion waits`）。`done` は「人間がまだ見ていない完了」を表す UI 向けの状態で、CLI から作業完了を検知するときは `idle` を使う
-- 似た用途で `herdr wait agent-status <pane-id> --status <...|done|...>` というコマンドもあるが、こちらは pane-id が必須かつ `done` を受け付ける UI 向けのコマンド。CLI 主導のこのプロトコルでは agent 名を直接使える `herdr agent wait <agent-name>` を使う
-- `--timeout`（ミリ秒）は省略可能で、省略すると無期限にブロックする（実機確認済み）。バックグラウンドで放置する分には問題ないが、安全弁として妥当な値を指定してもよい。タイムアウトした場合は同じ2つの wait を仕掛け直す（これは定期ポーリングではなく、イベント待ちの再武装）
+**Constraints:**
+- **MUST**: ログファイル名には `<agent-name>` を含める。複数 worktree を並行監視しているときに固定ファイル名だと内容が上書きされてしまうため
+- **MUST**: `wait -n` は先に終了した方を検知する。ただし `wait -n` 自身はどちらが終了したかを返さないため、直後に `kill -0 "$BLOCKED_PID"`(シグナルを送らず存否だけ確認する)で生死を見て、生きている方=発火しなかった方、と判別してから後処理する。判別できたら `$FIRED_STATUS` を見て、`blocked` ならユーザーに承認を仰ぎ、`idle` なら `herdr agent read "$AGENT_NAME" --source recent --lines 50` で完了報告を確認する
+- **MUST**: `<agent-name>` は手順4でエージェントに付けたユニーク名。`herdr agent wait` / `herdr agent read` は pane-id ではなく agent 名を直接ターゲットにできるため、監視中に pane-id を引き直す必要がない
+- **MUST NOT**: 定期ポーリング(`herdr pane list` 等を一定間隔で呼び続けるループ)は禁止。コストが高いうえ、このプロトコルが解消したいアンチパターンそのもの
+- **MUST NOT**: `--status done` は使わない(詳細: Troubleshooting「herdr agent wait は done を拒否する」参照)
+- **MUST**: 似た用途で `herdr wait agent-status <pane-id> --status <...|done|...>` というコマンドもあるが、こちらは pane-id が必須かつ `done` を受け付ける UI 向けのコマンド。CLI 主導のこのプロトコルでは agent 名を直接使える `herdr agent wait <agent-name>` を使う
+- **MAY**: `--timeout`(ミリ秒)は省略可能で、省略すると無期限にブロックする。バックグラウンドで放置する分には問題ないが、安全弁として妥当な値を指定してもよい
+- **MUST**: タイムアウトした場合は同じ2つの wait を仕掛け直す(これは定期ポーリングではなく、イベント待ちの再武装)
+
+## Examples
+
+```
+/wt CIのキャッシュが壊れてるのを直したい
+/wt nvimにcopilot連携を追加する
+```
+
+## Troubleshooting
+
+### mise trust 忘れ
+mise trust は絶対パス単位で管理されるため、新規 worktree は毎回 untrusted で始まる。忘れると `mise run` が「no tasks defined」で失敗する — #335。
+
+### allowlist テンプレートの cp 失敗
+`~/.claude` への反映は home-manager 経由で、`mise run nix:switch` を実行しないと `~/.claude/templates/` に反映されない。`cp` が `No such file or directory` で失敗したら、まず nix:switch 漏れを疑う。
+
+### auto mode 起動の拒否
+auto mode での起動自体がハーネス(auto mode 分類器)に「ユーザーの明示許可がない」として拒否されることがある。その場合は AskUserQuestion 等でユーザーに auto mode 起動の許可を明示的に確認してから再実行する。
+
+### send-text は単体では実行されない
+`pane send-text` は pane の入力欄にテキストを挿入するだけで、送信(実行)はされない。実機確認済み: `send-text` の直後に `pane read` してもコマンドは未実行のまま入力欄に残っており、続けて `pane send-keys <pane-id> Enter` を送って初めて実行される。
+
+### pane-id は非永続
+pane-id はセッション中に compact されうる非永続 ID(詳細は `.config/claude/skills/herdr/SKILL.md` 参照)。
+
+### wait の即時解決
+gotcha(実機確認済み): `herdr agent wait` は対象が既に指定ステータスだと即座に解決する。作業者がまだ `working` に遷移していない段階で `idle` 待ちを仕掛けると、起動直後の未初期化状態を完了と誤検知しかねない。
+
+### herdr agent wait は done を拒否する
+`herdr agent wait` に `done` を渡すとエラーになる(実機確認済みのエラーメッセージ: `done is a UI attention state; use idle for CLI agent completion waits`)。`done` は「人間がまだ見ていない完了」を表す UI 向けの状態で、CLI から作業完了を検知するときは `idle` を使う。
 
 ## 引数
 

--- a/.config/claude/commands/wtclean.md
+++ b/.config/claude/commands/wtclean.md
@@ -1,23 +1,21 @@
 # Worktree 掃除 (herdr)
 
+## Overview
+
 マージ済み PR に対応する worktree / workspace / ローカルブランチを安全に掃除します。
 `/wt` で作った worktree のライフサイクルの後始末を担う、対になるコマンドです。
 
-## 使い方
+## Parameters
 
-```
-/wtclean
-/wtclean --force   # dry-run をスキップして確認後すぐ削除
-```
+- **`--force`**(任意): 指定すると dry-run をスキップし、確認後すぐに削除を実行する。省略時(デフォルト)は dry-run(削除対象の一覧提示まで)で終了し、実際の削除はユーザーの確認を取ってから行う(実体は末尾の [引数](#引数) セクション参照)
 
-デフォルトは dry-run(削除対象の一覧提示まで)。実際の削除はユーザーの確認を取ってから行う。
-
-## 手順
+## Steps
 
 ### 1. リポジトリの確認
 
-`git rev-parse --show-toplevel` でリポジトリルートを確認する。
-git リポジトリでない場合は中断してユーザーに知らせる。
+**Constraints:**
+- **MUST**: `git rev-parse --show-toplevel` でリポジトリルートを確認する
+- **MUST**: git リポジトリでない場合は中断してユーザーに知らせる
 
 ### 2. マージ済み PR の head ブランチ一覧を取得
 
@@ -25,27 +23,35 @@ git リポジトリでない場合は中断してユーザーに知らせる。
 gh pr list --state merged --limit 50 --json number,headRefName,title
 ```
 
+**Constraints:**
+- **MUST**: 上記コマンドでマージ済み PR の head ブランチ一覧を取得する
+
 ### 3. worktree との突き合わせ
 
-`herdr worktree list` と `git worktree list` の結果を突き合わせて、
-マージ済みブランチに対応する worktree を特定する。
+`herdr worktree list` と `git worktree list` の結果を突き合わせて、マージ済みブランチに対応する worktree を特定する。
 
-- マージ済みブランチに対応する worktree が 1 つもなければ「掃除対象なし」と報告して終了
+**Constraints:**
+- **MUST**: `herdr worktree list` と `git worktree list` の結果を突き合わせて、マージ済みブランチに対応する worktree を特定する
+- **MUST**: マージ済みブランチに対応する worktree が1つもなければ「掃除対象なし」と報告して終了する
 
 ### 4. 各対象の安全チェック
 
-各 worktree について以下をすべて確認する。**1 つでも引っかかったらその worktree はスキップ**し、理由付きで報告リストに回す(削除はしない):
+各 worktree について以下をすべて確認する。1つでも引っかかったらその worktree はスキップし、理由付きで報告リストに回す(削除はしない)。
 
-1. **未コミット変更がないこと**: worktree 内で `git status --short` が空であること
-2. **エージェントが稼働中でないこと**: `herdr agent list` で、その workspace のエージェントが `working` / `blocked` 状態でないこと
-3. **open PR が紐づいていないこと**: `gh pr list --state open --head <branch>` が空であること
+**Constraints:**
+- **MUST**: 未コミット変更がないこと(worktree 内で `git status --short` が空であること)を確認する
+- **MUST**: エージェントが稼働中でないこと(`herdr agent list` で、その workspace のエージェントが `working` / `blocked` 状態でないこと)を確認する
+- **MUST**: open PR が紐づいていないこと(`gh pr list --state open --head <branch>` が空であること)を確認する
+- **MUST**: 1つでも引っかかったらその worktree はスキップし、理由付きで報告リストに回す(削除はしない)
 
 ### 5. 削除対象の提示と確認
 
 削除対象・スキップ対象(理由付き)の一覧をユーザーに提示する。
 
-- dry-run(デフォルト)ではここで終了し、「実行するには確認してね」と伝える
-- ユーザーが削除を承認した場合のみ、次の手順に進む
+**Constraints:**
+- **MUST**: 削除対象・スキップ対象(理由付き)の一覧をユーザーに提示する
+- **MUST**: dry-run(デフォルト)ではここで終了し、「実行するには確認してね」と伝える
+- **MUST**: ユーザーが削除を承認した場合のみ、次の手順に進む
 
 ### 6. 知見の回収(供養)
 
@@ -63,10 +69,13 @@ herdr pane list --workspace <workspace-id>
 herdr pane read <agent-pane-id> --source recent-unwrapped --lines 500
 ```
 
-- 抽出対象: 作業指示テンプレートの「## 報告」内の「気づき」欄(指示外の回避策・環境の摩擦・想定外の挙動)、および permission ブロックやリトライなど、ログ上に残る摩擦の痕跡
-- workspace がすでに閉じていて pane が読めない場合はスキップし、その旨を報告に含める
-- 抽出した内容を worktree ごとに要約し、Issue 化する価値がありそうなものは候補としてユーザーに提示する。この時点では `gh issue create` は実行しない(ユーザーが必要と判断したものだけ、別途 Issue 化する)
-- 気づきがない、または些末な場合は「知見なし」として次に進む
+**Constraints:**
+- **MUST**: 削除が承認されたら、`herdr worktree remove` 実行前に各対象 worktree の pane ログから摩擦・回避策を抽出する
+- **MUST**: 抽出対象は作業指示テンプレートの「## 報告」内の「気づき」欄(指示外の回避策・環境の摩擦・想定外の挙動)、および permission ブロックやリトライなど、ログ上に残る摩擦の痕跡とする
+- **MUST**: workspace がすでに閉じていて pane が読めない場合はスキップし、その旨を報告に含める
+- **MUST**: 抽出した内容を worktree ごとに要約し、Issue 化する価値がありそうなものは候補としてユーザーに提示する
+- **MUST NOT**: この時点では `gh issue create` は実行しない(ユーザーが必要と判断したものだけ、別途 Issue 化する)
+- **MUST**: 気づきがない、または些末な場合は「知見なし」として次に進む
 
 ### 7. 削除の実行
 
@@ -83,17 +92,33 @@ git branch -d <branch>
 git worktree prune
 ```
 
-- `git branch -d` は merged 確認済みなので `-d` を使う。**`-D` は使わない**
-- ローカル main が origin より遅れていると `git branch -d` が「not yet merged to HEAD」警告を出すことがあるが、手順 2 で origin へのマージが確認できているので、その場合はローカル main を更新してから再実行する(それでも `-D` にはエスカレートしない)
-  - 更新方法: main をチェックアウト中のリポジトリでは `git fetch origin main:main` は拒否されるため、`git fetch origin` してから `git merge --ff-only origin/main`(または `git pull --ff-only`)で更新する
+**Constraints:**
+- **MUST**: 承認された各対象について `herdr worktree remove --workspace <workspace-id>` と `git branch -d <branch>` を実行する
+- **MUST**: 最後にまとめて `git worktree prune` を実行する
+- **MUST**: `git branch -d` を使う(merged 確認済みのため)
+- **MUST NOT**: `-D` は使わない
+- **MUST**: `git branch -d` が「not yet merged to HEAD」警告を出した場合はローカル main を更新してから再実行する(それでも `-D` にはエスカレートしない。詳細: Troubleshooting「ローカル main 遅延時の git branch -d 警告」参照)
 
 ### 8. 結果の報告
 
 以下を一覧で報告する:
 
-- 削除したもの(ブランチ名 / worktree パス / workspace ID)
-- スキップしたもの(理由付き: 未コミット変更あり、エージェント稼働中、open PR あり、など)
-- 回収した知見 / Issue 候補(worktree ごとに要約。該当なしなら「知見なし」)
+**Constraints:**
+- **MUST**: 削除したもの(ブランチ名 / worktree パス / workspace ID)を報告する
+- **MUST**: スキップしたもの(理由付き: 未コミット変更あり、エージェント稼働中、open PR あり、など)を報告する
+- **MUST**: 回収した知見 / Issue 候補を報告する(worktree ごとに要約。該当なしなら「知見なし」)
+
+## Examples
+
+```
+/wtclean
+/wtclean --force   # dry-run をスキップして確認後すぐ削除
+```
+
+## Troubleshooting
+
+### ローカル main 遅延時の git branch -d 警告
+ローカル main が origin より遅れていると、`git branch -d` が「not yet merged to HEAD」警告を出すことがある。手順2で origin へのマージは確認できているので、その場合はローカル main を更新してから再実行する(それでも `-D` にはエスカレートしない)。更新方法: main をチェックアウト中のリポジトリでは `git fetch origin main:main` は拒否されるため、`git fetch origin` してから `git merge --ff-only origin/main`(または `git pull --ff-only`)で更新する。
 
 ## 引数
 


### PR DESCRIPTION
## 概要

Issue #357 の実装。`.config/claude/commands/wt.md` と `wtclean.md` を、strands-agents/agent-sop が定義する Agent SOP 形式(Overview / Parameters / Steps + RFC 2119 制約 / Troubleshooting)に再構成した。

- 散文の指示は Sonnet 5 に literal に解釈される一方、曖昧さは 2026-07-05 の既存ウィンドウ誤kill事故(#354)につながった。指示側を「機械的に従える制約」として書ける形式に寄せるのが狙い
- 各手順を `### N. 手順名` + `**Constraints:**`(MUST/SHOULD/MAY/MUST NOT)に分解
- gotcha 群(mise trust 忘れ、send-text の Enter 別送、wait の即時解決、pane-id 非永続、auto mode 分類器の拒否、herdr agent wait の done 拒否、+発見した allowlist テンプレートの cp 失敗)を `## Troubleshooting` に集約し、元の位置には短い参照(`詳細: Troubleshooting「◯◯」参照`)を残した
- `## 使い方` → `## Examples` として Steps の後ろに移動(SOP の Basic Structure に準拠)
- **このリファクタでは内容(ルール・手順・コマンド例)を一切変更していない。構造の変換のみ**
- slash command として機能する構造(`$ARGUMENTS` の実体、作業指示プロンプトの heredoc テンプレート)は完全に温存。`$ARGUMENTS` の実体は末尾の `## 引数` セクションに元の位置のまま残し、冒頭には SOP 形式の `## Parameters` セクションを別途新設(説明文のみ、`$ARGUMENTS` トークンの二重埋め込みは避けた)

## セルフチェック結果

- 全コードブロック(コマンド例)を新旧で機械的に diff し、`## 使い方` → `## Examples` への意図した移動(位置替えのみ)を除いて完全に一致することを確認した(作業指示プロンプトの heredoc テンプレートを含む)
- 手順文中の全ルール文を1文単位で洗い出し、Steps + Constraints への転記漏れがないことを確認した(命名規則、default+override 系のルール、effort 選定基準、対話プロトコルの4本柱、削除の安全チェック等)
- Troubleshooting に集約した7項目それぞれについて、元の位置に参照リンクが残っていることを確認した

## MUST/SHOULD/MAY の割り当てで判断に迷った箇所

原文に「必ず」「禁止」「推奨」などの明示的なキーワードがなく、ニュアンスから判断した箇所:

| 箇所 | 内容 | 割り当て | 判断理由 |
|---|---|---|---|
| wt.md 手順2 | ブランチ名のフォーマット(conventional commit 風、type prefix) | MUST | 命名規則の骨格であり逸脱を想定していない |
| wt.md 手順2 | snake_case・単語数(「〜を目安に」) | SHOULD | 「目安」という言葉が既に許容幅を示す |
| wt.md 手順2 | 迷ったら feat/ か fix/ に寄せる | SHOULD | フォールバックの推奨であり強制ではない |
| wt.md 手順3 | ベースブランチのデフォルト+ユーザー指定時の上書き | MUST | 既定動作を規定する必須ルールと判断 |
| wt.md 手順4 | 作業者モデルのデフォルト+ユーザー指定時の上書き | MUST | 手順3のベースブランチと同型のルールのため一貫性を優先 |
| wt.md 手順4 | 「medium 以下では literal に解釈するため完了条件を具体的に書くことが特に重要」 | SHOULD | 重要性の強調はあるが強制ではない |
| wt.md 手順4 | 「背景と完了条件を具体的に書くほど作業品質が安定する」 | SHOULD | 経験則的なアドバイス |
| wt.md 手順4 | blocked 発生時に司令塔は代理承認しない・責務は検知まで | MUST | Claude Code の制約に基づく責務の境界線であり逸脱不可と判断 |
| wtclean.md 手順6 | 気づきがない/些末な場合は「知見なし」として次に進む | MUST | 条件が満たされた場合に必ず取るべき手順として扱った |

## Closes

Closes #357

## 気づき(環境の摩擦・想定外の挙動・自分で編み出した回避策)

- 変換の最初のドラフトで、日本語の全角括弧(`（）`)を機械的に半角(`()`)に変換してしまい、作業指示プロンプトの heredoc テンプレート(コマンド例)の文言まで変えてしまうミスをした。コードブロックを新旧で抽出して diff する簡易チェック(`awk '/^```/{f=!f;next} f'` で全コードブロックを抜き出して比較)を思いついて実行したところ発覚し、該当箇所を原文の全角括弧に復元した。以後、大きな構造変換をするときはコードブロック単位での機械的 diff を先に仕込んでおくと安全だと分かった
- 6種の gotcha のうち「wait の即時解決」について、Troubleshooting への集約時に元の位置(手順5(2))への短い参照を書き忘れていた。全体のセルフチェック中に気づいて追記した