### PR TITLE
improve(wofi): ランチャーの視認性を改善(サイズ・フォント・配色)

### DIFF
--- a/.config/wofi/config
+++ b/.config/wofi/config
@@ -1,5 +1,5 @@
-width=600
-height=400
+width=700
+height=550
 location=center
 show=drun
 prompt=Applications
@@ -11,7 +11,7 @@ orientation=vertical
 content_halign=fill
 insensitive=true
 allow_images=true
-image_size=24
+image_size=32
 gtk_dark=true
 term=alacritty
 layer=overlay

--- a/.config/wofi/style.css
+++ b/.config/wofi/style.css
@@ -1,4 +1,4 @@
-/* Hyprlandのテーマに合わせたWofi設定 */
+/* Hyprlandのテーマに合わせたWofi設定(Catppuccin Mocha, waybarと配色統一) */
 window {
     margin: 5px;
     padding: 5px;
@@ -6,12 +6,12 @@ window {
     border-radius: 12px;
     background-color: rgba(30, 30, 46, 0.95);
     font-family: "JetBrainsMono Nerd Font", "Noto Sans CJK JP";
-    font-size: 14px;
+    font-size: 16px;
 }
 
 #input {
-    margin: 5px;
-    padding: 8px 12px;
+    margin: 6px;
+    padding: 10px 14px;
     border: none;
     color: #cdd6f4;
     background-color: #313244;
@@ -44,15 +44,16 @@ window {
 }
 
 #entry {
-    margin: 2px 0;
-    padding: 8px 12px;
+    margin: 4px 2px;
+    padding: 12px 16px;
     border-radius: 8px;
     background-color: transparent;
     transition: all 0.2s ease;
 }
 
+/* 選択中の行はアクセントカラーの塗りつぶしで一目でわかるようにする */
 #entry:selected {
-    background-color: #313244;
+    background-color: #cba6f7;
     outline: none;
 }
 
@@ -65,12 +66,14 @@ window {
     margin-left: 10px;
 }
 
+/* 選択行の背景(#cba6f7)に対してコントラストが出るよう文字色を反転 */
 #text:selected {
-    color: #cba6f7;
+    color: #1e1e2e;
+    font-weight: bold;
 }
 
 #img {
-    margin-right: 8px;
+    margin-right: 10px;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
## 概要
wofi(アプリランチャー)の視認性をフォント・行間・ウィンドウサイズ・配色の観点で改善する。

## 変更内容
- **ウィンドウサイズ**: 600x400 → 700x550 に拡大し、候補一覧を見渡しやすくした
- **フォント**: サイズを14px → 16pxに拡大。フォントファミリー自体(JetBrainsMono Nerd Font + Noto Sans CJK JP)は既にwaybarと統一済みだったため変更なし
- **行間**: `#entry` の padding を 8px 12px → 12px 16px、margin を 2px 0 → 4px 2px に拡大し、候補をスキャンしやすくした
- **選択行のコントラスト**: `#entry:selected` の背景を surface0(#313244、hoverと紛らわしい濃さ)から mauve(#cba6f7)の塗りつぶしに変更し、`#text:selected` の文字色を濃色(#1e1e2e)+太字にした。選択中の行が一目でわかるようになった
- **アイコン表示(allow_images)**: 既に有効化されていたためそのまま維持。`image_size` を 24 → 32 に拡大し、実機で deepin/Papirus アイコンテーマにより正しく描画されることを確認した

## 採否メモ(allow_images)
Issue には「有効化を検討する」とあったが、現状の `.config/wofi/config` で既に `allow_images=true` になっていた。実機確認でアイコンが正しく表示されることを確認できたため、そのまま維持し `image_size` のみ行の拡大に合わせて調整した。

## 確認したこと
worktree内の config/style.css を `-c`/`-s` で明示指定して自分で wofi を起動し(PIDを捕捉)、実際のHyprlandセッション上でスクリーンショットを撮って見た目を確認した。確認後は捕捉したPIDのみ終了済み。
- 選択行(例: Discord)が mauve背景+濃色太字で一目で判別できる
- アイコンが崩れず表示される
- 日本語アプリ名も含め文字が潰れず読める

Closes #364