### PR TITLE
feat(waybar): workspacesを3層構造(作業台/詰め所/引き出し)に合わせて再構成

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -29,20 +29,37 @@
         "tray"
     ],
 
+    // 3層構造(window-rules.conf 冒頭コメント参照)をバー上でも宣言する
+    // Mirror the three-layer workspace design (see window-rules.conf header) in the bar:
+    //   作業台 ws1〜3 = 数字アイコン(persistent-workspacesで常時表示) / Workbench: numeral icons, always shown
+    //   詰め所 ws4〜  = 共通アイコン(default) / Depot: shared "default" icon
+    //   引き出し special = show-special + special-visible-only で開いている時だけ表示 / Drawer: shown only while open
     "hyprland/workspaces": {
-        "format": "{icon}",
+        "format": "{icon}{windows}",
         "on-click": "activate",
         "format-icons": {
-            "1": "",
-            "2": "",
-            "3": "",
-            "4": "",
-            "5": "",
+            "1": "1",
+            "2": "2",
+            "3": "3",
             "urgent": "",
-            "active": "",
+            "special": "",
             "default": ""
         },
-        "sort-by-number": true,
+        "window-rewrite-default": "▪",
+        "window-rewrite": {
+            "class<^firefox$>": "",
+            "class<^code$>": "󰨞",
+            "class<^kitty$>": "",
+            "class<^Alacritty$>": "",
+            "class<^org\\.wezfurlong\\.wezterm$>": "",
+            "class<^spotify$>": ""
+        },
+        "persistent-workspaces": {
+            "*": [1, 2, 3]
+        },
+        "show-special": true,
+        "special-visible-only": true,
+        "sort-by": "number",
         "on-scroll-up": "hyprctl dispatch workspace e+1",
         "on-scroll-down": "hyprctl dispatch workspace e-1"
     },

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -37,22 +37,25 @@
     "hyprland/workspaces": {
         "format": "{icon}{windows}",
         "on-click": "activate",
+        // Icons below are written as literal \uXXXX JSON escapes, not raw PUA glyphs pasted
+        // directly -- raw glyphs silently collapsed to empty strings in this file before
+        // (caught in PR #366 review). Look up glyph names at nerdfonts.com/cheat-sheet.
         "format-icons": {
             "1": "1",
             "2": "2",
             "3": "3",
-            "urgent": "",
-            "special": "",
-            "default": ""
+            "urgent": "\uf071", // nf-fa-exclamation_triangle
+            "special": "\uf052", // nf-fa-eject (drawer: shown only while open)
+            "default": "\uf01c" // nf-fa-inbox (depot)
         },
-        "window-rewrite-default": "▪",
+        "window-rewrite-default": "\u25aa", // U+25AA BLACK SMALL SQUARE (not a Nerd Font glyph)
         "window-rewrite": {
-            "class<^firefox$>": "",
-            "class<^code$>": "󰨞",
-            "class<^kitty$>": "",
-            "class<^Alacritty$>": "",
-            "class<^org\\.wezfurlong\\.wezterm$>": "",
-            "class<^spotify$>": ""
+            "class<^firefox$>": "\uf269", // nf-fa-firefox
+            "class<^code$>": "\udb82\ude1e", // nf-md-microsoft_visual_studio_code
+            "class<^kitty$>": "\uf120", // nf-fa-terminal
+            "class<^Alacritty$>": "\uf120", // nf-fa-terminal
+            "class<^org\\.wezfurlong\\.wezterm$>": "\uf120", // nf-fa-terminal
+            "class<^spotify$>": "\uf1bc" // nf-fa-spotify
         },
         "persistent-workspaces": {
             "*": [1, 2, 3]

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -28,15 +28,34 @@ window#waybar.hidden {
     transition: none;
 }
 
+/* 3層構造の状態別コントラスト(旧: #313244 on #1e1e2e で比率約1.3:1、実質視認不可)*/
+/* Per-layer/state contrast for the three-layer design (old ratio was ~1.3:1, effectively invisible) */
 #workspaces button {
     padding: 0 5px;
-    color: #313244;
+    color: #7f849c;
     min-width: 20px;
 }
 
-#workspaces button.active {
+/* 作業台(persistent-workspacesで常時表示される ws1〜3) */
+#workspaces button.persistent {
     color: #a6adc8;
-    background: rgba(166, 173, 200, 0.2);
+}
+
+/* 未使用の作業台スロット(persistentかつ空) */
+#workspaces button.empty {
+    color: #6c7086;
+}
+
+/* 引き出し(special)が開いている間だけ表示される */
+#workspaces button.special {
+    color: #f9e2af;
+    background: rgba(249, 226, 175, 0.12);
+    border-radius: 10px;
+}
+
+#workspaces button.active {
+    color: #1e1e2e;
+    background: #cba6f7;
     border-radius: 10px;
 }
 


### PR DESCRIPTION
## 概要
waybar の `hyprland/workspaces` を、`window-rules.conf` で宣言済みの3層構造(作業台 ws1〜3 / 詰め所 ws4〜 / 引き出し special)に合わせて再構成し、非アクティブボタンの視認性を改善する。

Closes #363

## 変更内容
- `config.jsonc`
  - `format-icons` で作業台 ws1〜3 を数字アイコン(`"1"`,`"2"`,`"3"`)に変更。Waybar の icon 選択優先順位(urgent > active > 名前一致 > visible > empty > persistent > default)を確認した上で、数字が active/persistent/empty のどの状態でも維持されるよう設計
  - `persistent-workspaces: {"*": [1,2,3]}` で作業台を常時表示に
  - `show-special: true` + `special-visible-only: true` で引き出し(special)を開いている時だけ表示
  - `sort-by-number`(このバージョンの waybar 0.15.0 には存在しないキーで無効だった)を正しい `sort-by: "number"` に修正
  - `window-rewrite` を追加し、firefox / code / kitty・Alacritty・wezterm(terminal) / spotify の滞在アプリをアイコンで可視化(作業台の中身の可視化)。それ以外のアプリは `window-rewrite-default: "▪"` にフォールバック
- `style.css`
  - `#workspaces button` の非アクティブ色を `#313244 on #1e1e2e`(コントラスト比 約1.3:1、実質視認不可)から `#7f849c`(比 約4.4:1)に変更
  - `.persistent`(作業台) / `.empty`(未使用スロット) / `.special`(引き出し・開いている間) の状態別に視認可能な色を追加(比はそれぞれ約7.4:1 / 3.4:1 / 12.9:1)
  - `.active` は暗色テキスト on 明るい背景の反転ハイライトに変更(比 約8.1:1)
  - `.urgent` は既存のまま(比 約5.1:1、元から十分だったため維持)

## 確認したこと
- `sed -E 's#//.*$##' config.jsonc | jq .` で有効な JSON であることを確認
- Waybar 本体のソース(`workspace.cpp` の `selectString()`)を読み、icon 選択の優先順位を確認した上で設計
- `man 5 waybar-hyprland-workspaces` で `show-special` / `special-visible-only` / `persistent-workspaces` / `window-rewrite` が waybar 0.15.0(このマシンにインストール済みのバージョン)でサポートされていることを確認
- 各色の組み合わせについて WCAG のコントラスト比を計算し、非アクティブ系はいずれも旧設定(約1.3:1)より大きく改善していることを確認(概算値は上記)

## 判断に迷った点・見送った点
- `window-rewrite` は slack / discord / obsidian / claude-desktop 用の Nerd Font ブランドアイコンを追加しなかった。正確なコードポイントをこの場で目視確認できず、誤ったグリフ(文字化け)を入れるリスクを避けるため、Waybar公式ドキュメントに実例がある firefox / code / terminal 系 と、既存configで使用実績のある spotify のみに絞った。他のアプリは汎用フォールバック `▪`(Nerd Font非依存のプレーンUnicode)で表示される
- 引き出し(special)は obsidian / claude で別アイコンにせず、共通の `special` アイコン1種にした。Issue の完了条件は「開閉状態が見えること」であり、どちらが開いているかの区別は必須要件ではないため
- ライブの waybar プロセスは再起動・リロードしていない(実際の見た目の確認は司令塔/ユーザー側にお願いします)

## 気づいたこと(指示外)
- 旧設定の `"sort-by-number": true` は waybar 0.15.0 の hyprland/workspaces モジュールには存在しないキーで、ずっと無効(黙って無視されていた)可能性が高い。今回 `sort-by: "number"` に修正した