### PR TITLE
fix(ci): cache-nix-actionのキャッシュ凍結を解消し、実行のたびに最新の /nix store で保存し直す

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -161,6 +161,21 @@ jobs:
       # の状態にして、実行のたびに最新の /nix store 内容で保存し直させる。
       # 削除には actions: write 権限が要る (ジョブ側 permissions で付与済み)。
       #
+      # purge は push イベントのみで有効化する。理由は2つ:
+      # 1. キャッシュは作成された ref (= refs/heads/main) のスコープでしか
+      #    削除できない (GitHub Actions のキャッシュ削除APIの仕様)。実際に
+      #    #368 のPR自身の pull_request ラン (refs/pull/370/merge) で
+      #    purge-primary-key: always が 404 Not Found で失敗するのを確認済み
+      #    ―― つまり pull_request イベントでは同一リポジトリのPRであっても
+      #    purge は原理的に成功しない。
+      # 2. fork からの pull_request ランでは GITHUB_TOKEN が (permissions
+      #    の宣言に関わらず) read-only に強制されるため、actions: write を
+      #    要求する削除APIはそもそも呼び出す前提が成立しない。
+      # cache-nix-action 自身は削除失敗を内部で catch してログに出すだけで
+      # ジョブを失敗させない (purgeCacheByKey の実装参照)ため安全側ではあるが、
+      # 上記1により pull_request では成功する見込みが全く無い呼び出しなので、
+      # 無駄なAPI呼び出しと403ログを避けるために push イベント限定にする。
+      #
       # When there's a primary-key hit, cache-nix-action skips saving in its
       # post (save) phase. Since the key only changes when *.nix/flake.lock
       # change, a cache saved once in an incomplete state stayed frozen
@@ -170,6 +185,21 @@ jobs:
       # sees "no cache matching primary-key" and re-saves with this run's
       # current /nix store contents. Purging needs actions: write (granted
       # via the job-level `permissions` above).
+      #
+      # purge only runs on push events, for two reasons:
+      # 1. A cache can only be deleted from the ref that owns it
+      #    (refs/heads/main here) — a GitHub Actions cache API restriction.
+      #    We confirmed on this very PR's own pull_request run
+      #    (refs/pull/370/merge) that purge-primary-key: always 404s even
+      #    for a same-repo PR, so purging can never succeed on
+      #    pull_request events regardless of fork vs. same-repo.
+      # 2. On pull_request runs from forks, GITHUB_TOKEN is forced
+      #    read-only regardless of the `permissions` we declare, so the
+      #    delete call couldn't get actions: write anyway.
+      # cache-nix-action already catches delete failures internally and
+      # only logs them (see purgeCacheByKey), so this was never going to
+      # fail the job — but per (1) it can also never succeed here, so we
+      # skip the doomed API call (and its log noise) entirely on PR runs.
       - name: Restore Nix cache
         uses: nix-community/cache-nix-action@v6
         with:
@@ -179,7 +209,7 @@ jobs:
             /nix
             ~/.cache/nix
           nix: false
-          purge: true
+          purge: ${{ github.event_name == 'push' }}
           purge-primary-key: always
 
       # Fix /nix ownership and remove installer artifacts for fresh installation
@@ -259,6 +289,40 @@ jobs:
       # `doCheck = false` override) — only the cache-nix-action install/
       # gc-max-store-size design change would touch that, and it's out of
       # scope here (see PR description for the full rustup investigation).
+      # sqlite3 は ubuntu-latest ランナーにプリインストールされているはずだが、
+      # 前提を無条件に信用せず存在チェックする。continue-on-error: true で
+      # このステップの失敗がジョブ全体を止めないようにしている一方、それだけだと
+      # 「sqlite3 が無くて静かにスキップされた」のか「本当に checkpoint が
+      # 成功した」のかが通常のログからは区別しづらい。checkpoint はキャッシュの
+      # 実効性を左右する要なので、欠落/失敗を ::warning:: アノテーションで
+      # 必ず可視化する (Job Summary / Files changed に出るのでログを開かなくても
+      # 気づける)。sqlite3 が無い場合はまず apt でのインストールを試み、
+      # それでも無ければ warning を出して諦める。
+      #
+      # sqlite3 should already be preinstalled on ubuntu-latest runners, but
+      # don't take that for granted — check explicitly. continue-on-error:
+      # true keeps this step from blocking the job, but on its own that
+      # makes "sqlite3 was missing so this silently no-op'd" indistinguishable
+      # from "the checkpoint actually ran". Since the checkpoint is load-
+      # bearing for cache quality, surface any miss/failure as a ::warning::
+      # annotation (visible in the Job Summary / Files changed tab without
+      # opening the raw log). Try installing sqlite3 via apt first if it's
+      # missing; only warn-and-give-up if that also fails.
       - name: Checkpoint Nix store database before caching
         continue-on-error: true
-        run: sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'
+        run: |
+          if ! command -v sqlite3 >/dev/null 2>&1; then
+            echo "::warning::sqlite3 not found on this runner; attempting to install it so the Nix store DB WAL checkpoint can run."
+            sudo apt-get update -qq && sudo apt-get install -y -qq sqlite3 || true
+          fi
+
+          if ! command -v sqlite3 >/dev/null 2>&1; then
+            echo "::warning::sqlite3 is unavailable even after the install attempt - skipping the WAL checkpoint. This run's cache may leave newly built store paths stranded in db.sqlite-wal (see the comment above this step for background)."
+            exit 0
+          fi
+
+          if sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'; then
+            echo "Checkpointed /nix/var/nix/db/db.sqlite successfully."
+          else
+            echo "::warning::WAL checkpoint of /nix/var/nix/db/db.sqlite failed - this run's cache may not include this run's latest valid-path registrations."
+          fi

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -114,6 +114,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, build-image, check]
     if: needs.changes.outputs.code == 'true'
+    # cache-nix-action の purge (キャッシュ削除 API 呼び出し) には actions: write が要る。
+    # 明示すると他スコープは既定で none になるため、既存の checkout / ghcr pull に
+    # 必要な権限も合わせて列挙する (#368)。
+    # cache-nix-action's purge (a cache-delete API call) needs actions: write.
+    # Declaring `permissions:` resets every other scope to none, so we must
+    # also list what checkout / the ghcr pull already relied on (#368).
+    permissions:
+      contents: read
+      packages: read
+      actions: write
     steps:
       # Free up disk space BEFORE pulling the large Docker image
       - name: Free disk space
@@ -141,6 +151,25 @@ jobs:
 
       # Restore Nix cache for /nix/store build artifacts
       # Note: nix: false is required because Nix is not installed yet
+      #
+      # 同じ primary-key で HIT した場合、cache-nix-action は post (保存) 側で
+      # 保存自体をスキップする仕様がある。*.nix / flake.lock を変更しない限り
+      # key は変わらないため、一度不完全な状態で保存されたキャッシュがそのまま
+      # 凍結し続けていた (#368)。purge-primary-key: always で「同じ key の古い
+      # キャッシュ」を Post Restore フェーズ (= このジョブの全ステップ完了後) で
+      # 必ず削除させ、直後の save 判定を「primary-key に一致するキャッシュなし」
+      # の状態にして、実行のたびに最新の /nix store 内容で保存し直させる。
+      # 削除には actions: write 権限が要る (ジョブ側 permissions で付与済み)。
+      #
+      # When there's a primary-key hit, cache-nix-action skips saving in its
+      # post (save) phase. Since the key only changes when *.nix/flake.lock
+      # change, a cache saved once in an incomplete state stayed frozen
+      # forever (#368). purge-primary-key: always forces the action to purge
+      # the existing same-key cache during the Post Restore phase (after all
+      # of this job's steps finish), so the subsequent save check always
+      # sees "no cache matching primary-key" and re-saves with this run's
+      # current /nix store contents. Purging needs actions: write (granted
+      # via the job-level `permissions` above).
       - name: Restore Nix cache
         uses: nix-community/cache-nix-action@v6
         with:
@@ -150,6 +179,8 @@ jobs:
             /nix
             ~/.cache/nix
           nix: false
+          purge: true
+          purge-primary-key: always
 
       # Fix /nix ownership and remove installer artifacts for fresh installation
       # - Restore root ownership (cache restores as runner user)
@@ -193,3 +224,41 @@ jobs:
               ./result/activate
               echo "=== Home Manager activation completed successfully ==="
             '
+
+      # コンテナ内の nix build はホストの nix-daemon を経由しない
+      # (Dockerfile が `--init none` でデーモン無しインストールしているため、
+      # コンテナ側は /nix を直接叩くローカルストアとして nix を使う)。
+      # 一方ホスト側では nix-installer-action が起動した nix-daemon が
+      # 同じ db.sqlite をジョブの間ずっと開いたままにしている。SQLite の
+      # WAL は「最後の接続が閉じたとき」に自動 checkpoint される仕様のため、
+      # コンテナ側プロセスが終了しても「最後の接続」にならず、今回のビルドで
+      # 新規登録された valid path が db.sqlite-wal に取り残ったままになりうる。
+      # cache-nix-action は nix: false だとこの checkpoint 処理をしない
+      # (restore/save 双方で db.sqlite の面倒を見るのは nix: true の場合のみ)
+      # ため、保存前にここで明示的に checkpoint し、次回リストア時に
+      # 「ビルド済みなのに未登録」(→ rustup 等の再ビルド) が起きないようにする。
+      # rustup が cache.nixos.org にあるのに毎回ビルドされる件は、そもそも
+      # flake.nix のオーバーレイ (doCheck = false) で本家と異なる派生物に
+      # なっている分は解消されないが、それ以外の「本来キャッシュ可能なのに
+      # 再ビルドされていた」分はこれで解消されるはず (#368、詳細はPR本文参照)。
+      #
+      # The containerized `nix build` never talks to the host's nix-daemon
+      # (the Dockerfile installs Nix with `--init none`, so the container
+      # uses /nix as a local store directly). Meanwhile the host's
+      # nix-daemon (started by nix-installer-action) keeps its own
+      # connection to the same db.sqlite open for the entire job. SQLite's
+      # WAL is checkpointed automatically "when the last connection
+      # closes" — since the container's exit is never the *last* one, new
+      # valid-path registrations from this run's build can be stranded in
+      # db.sqlite-wal and never reach db.sqlite. cache-nix-action only
+      # handles this checkpoint/merge dance when `nix: true` (not our case,
+      # see the Restore Nix cache step above), so we force a checkpoint
+      # here before the cache is saved. This doesn't help the handful of
+      # packages that are unavoidably rebuilt because flake.nix overlays
+      # them away from the stock nixpkgs derivation (e.g. rustup's
+      # `doCheck = false` override) — only the cache-nix-action install/
+      # gc-max-store-size design change would touch that, and it's out of
+      # scope here (see PR description for the full rustup investigation).
+      - name: Checkpoint Nix store database before caching
+        continue-on-error: true
+        run: sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'

--- a/docs/explanation/cicd-evolution.md
+++ b/docs/explanation/cicd-evolution.md
@@ -134,6 +134,20 @@ Docker: nix build 実行
 3. Install Nix（キャッシュがなければインストール）
 ```
 
+### Phase 6: キャッシュ凍結問題 (#368)
+
+**問題**: 21分のジョブのうち16分が毎回のソースビルド（skim / rustup / github-copilot-cli / neovimラッパー）。primary-key は HIT しているのに、ビルド成果物が一向にキャッシュに反映されない。
+
+**根本原因1 — 保存スキップの凍結**: `cache-nix-action` は primary-key が HIT すると post (保存) フェーズで保存自体をスキップする仕様。key は `hashFiles('**/*.nix', 'flake.lock')` から生成されるため、*.nix / flake.lock を触らない限り同じ key が使われ続け、一度不完全な状態で保存されたキャッシュが未来永劫更新されない状態になっていた。
+
+**解決1**: `purge: true` + `purge-primary-key: always` を追加。Post Restore フェーズ（全ステップ完了後）で同じ key の古いキャッシュを毎回削除させ、直後の save 判定を「primary-key に一致するキャッシュなし」にして必ず保存し直させる（purge → save の順序はツール内部の仕様どおり）。purge には `actions: write` 権限が要るため、`verify-docker` ジョブに `permissions` を明示。
+
+**根本原因2 — rustup 等が (見かけ上) 再ビルドされ続ける件**: 2件のヒント。
+1. `flake.nix` のオーバーレイが `rustup`（`doCheck = false`）や `github-copilot-cli`（カスタム `src`）を本家 nixpkgs の派生物と異なるハッシュに変えている。これらは cache.nixos.org 上の「stock」な rustup 等とは別物なので、原理的にバイナリキャッシュから取得できず、初回ビルドは避けられない（`skim` の Hydra カバレッジ欠如は既知の別問題 #369）。
+2. それとは別に、`Dockerfile` はコンテナ内 Nix を `--init none`（デーモンなし）でインストールしている。コンテナの `nix build` はホストの nix-daemon を経由せず `/nix` を直接叩くローカルストアとして使う一方、ホスト側では `nix-installer-action` が起動した nix-daemon が同じ `db.sqlite` をジョブの間ずっと開いたままにしている。SQLite の WAL は「最後の接続が閉じたとき」に自動 checkpoint される仕様のため、コンテナ側プロセスの終了は「最後の接続」にならず、ビルドで新規登録された valid path が `db.sqlite-wal` に取り残ったまま `nix: false` の cache-nix-action（DBマージ処理をしない設定）でキャッシュされてしまう可能性がある。
+
+**対応2（仮説ベース）**: ビルド後・保存前に `sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'` を明示実行し、WAL の内容を本体ファイルへ確実に反映させてから保存させるステップを追加。ただし nix-installer 側のソース調査（`ProvisionNix` / `MoveUnpackedNix`）では DB を明示的に破棄する処理は見当たらず、この checkpoint 忘れ説は状況証拠からの仮説にとどまる。マージ後のダミーPRでの2回目計測で「26 derivations will be built」の内訳が縮むかどうかを見て検証する（詳細は #368 の PR 本文）。
+
 ---
 
 ## 📝 Lessons Learned
@@ -145,6 +159,8 @@ Docker: nix build 実行
 | **GCは慎重に** | Nix storeのGCはキャッシュ破損のリスクあり。サイズ制限より完全性を優先 |
 | **ステップ順序が重要** | キャッシュ復元は依存するツールのインストール前に行う |
 | **ユーザー一致** | コンテナのユーザーとHome Manager設定のユーザーを一致させる |
+| **同一keyでも凍結に注意** | primary-key HIT時は保存がスキップされる。設計上「毎回更新」したいなら purge-primary-key: always が要る |
+| **オーバーレイはバイナリキャッシュを無効化する** | `overrideAttrs` で派生物を変えると、そのパッケージは本家の binary cache から二度と取得できなくなる |
 
 ---
 
@@ -165,6 +181,7 @@ Docker: nix build 実行
 - [#216](https://github.com/music-brain88/dotfiles/issues/216) - magic-nix-cache問題
 - [#228](https://github.com/music-brain88/dotfiles/issues/228) - GCによるキャッシュ破損
 - [#233](https://github.com/music-brain88/dotfiles/issues/233) - ステップ順序問題
+- [#368](https://github.com/music-brain88/dotfiles/issues/368) - キャッシュ凍結問題・rustup再ビルド調査
 
 ---
 

--- a/docs/reference/ci-cd-pipeline.md
+++ b/docs/reference/ci-cd-pipeline.md
@@ -91,6 +91,17 @@ CI環境特有の問題（サンドボックス、ネットワーク制限）を
 
 詳細は [Evolution History - Phase 3](../explanation/cicd-evolution.md#phase-3-magic-nix-cache-の限界-216) を参照。
 
+### Cache Update Strategy (purge → save)
+
+`cache-nix-action` は primary-key が HIT すると保存自体をスキップする仕様のため、
+何もしないと「一度保存された不完全なキャッシュ」が key が変わるまで凍結する。
+`verify-docker` では `purge: true` + `purge-primary-key: always` を指定し、
+Post Restore フェーズ（全ステップ完了後）で同じ key の古いキャッシュを毎回削除させてから
+保存させることで、実行のたびに最新の `/nix` store 内容で更新されるようにしている。
+purge の実行には `actions: write` 権限が必要（ジョブの `permissions` で付与）。
+
+詳細・rustup再ビルド調査は [Evolution History - Phase 6](../explanation/cicd-evolution.md#phase-6-キャッシュ凍結問題-368) を参照。
+
 ---
 
 ## 🔗 Related Documentation


### PR DESCRIPTION
## 概要

Closes #368

`verify-docker` ジョブの `cache-nix-action` が primary-key HIT のたびに保存をスキップする仕様のため、一度不完全な状態で保存されたキャッシュが `*.nix` / `flake.lock` を変更しない限り凍結し続け、毎回 skim / rustup / github-copilot-cli / neovim ラッパー等のソースビルド (~16分) が再発していた問題を解消します。

## 変更内容

### 1. purge → save でキャッシュを毎回更新 (`.github/workflows/nix.yml`)

`Restore Nix cache` ステップに `purge: true` + `purge-primary-key: always` を追加しました。

- `cache-nix-action` の仕様 (README): Post Restore フェーズで
  1. `purge-primary-key: always` により、同じ primary-key の既存キャッシュを**必ず**削除
  2. その時点で「primary-key に一致するキャッシュがない」状態になるため、save 条件を満たし、このジョブの `/nix` を新しいキャッシュとして保存
- purge には GitHub の cache 削除 API を叩く権限 (`actions: write`) が必要なため、`verify-docker` ジョブに `permissions:` を明示しました (`contents: read` / `packages: read` は既存の checkout・ghcr pull が暗黙に使っていた権限を維持するために合わせて列挙)。

これにより、*.nix / flake.lock を変更しないPRでも、ビルドで新しく作られた store パスが次回実行時にはキャッシュ経由で復元され、substitution・ビルドがほぼゼロになるはずです（理屈: primary-key は不変 → 毎回 purge → 毎回このジョブの `/nix` を保存 → 次回はその「最新の」/nix を復元するので、前回ビルドした分は今度は「もう /nix/store にある」ため build/fetch 対象から外れる）。

### 2. rustup 等が毎回ソースビルドされる件の調査 (同ファイルに仮説と対応を追記)

Issue に記載の「rustup-1.28.2 は cache.nixos.org にあるのに毎回ビルドされる」という謎について、ソースコードとCIログを読んで次のことがわかりました。

**(a) 一部は仕様どおりで直しようがない**
`flake.nix` のオーバーレイが `rustup`（`doCheck = false`）と `github-copilot-cli`（GitHub Releaseからの独自 `src`）を本家 nixpkgs とは異なる派生物に変えています。オーバーレイで attrs を変えると derivation のハッシュも変わるため、これらは原理的に cache.nixos.org 上の「stock」な rustup 等とは別物であり、バイナリキャッシュからは絶対に取得できません（初回ビルドは避けられない）。Issue で「path-info で HIT を確認した」rustup は、おそらくこのオーバーレイを通していない stock 版を見ていたと考えられます。なお `skim` の Hydra カバレッジ欠如は既知の別問題 (#369) です。

**(b) それとは別に、本来キャッシュされるべきものが毎回消えている疑い**
`nix-community/cache-nix-action` の README には「`nix: true` のとき、restore 前後で `/nix/var/nix/db/db.sqlite` をコピーしてマージし、`db.sqlite-wal` / `db.sqlite-shm` を除去する」という DB マージ機能が明記されています。現在の `Restore Nix cache` ステップは（Nix未インストールの段階で実行するため）`nix: false` で、このDBマージ処理を一切行いません。

さらに `Dockerfile` を確認したところ、コンテナ内 Nix は `--init none`（デーモンなし）でインストールされており、コンテナの `nix build` はホストの nix-daemon を経由せず `/nix` を直接叩くローカルストアとして動作します。一方ホスト側では `nix-installer-action` が起動した nix-daemon が同じ `db.sqlite` をジョブの間ずっと開いたままにしています。SQLite の WAL は「最後の接続が閉じたとき」に自動 checkpoint される仕様のため、コンテナ側プロセスの終了は「最後の接続」にならず、ビルドで新規登録された valid path が `db.sqlite-wal` に取り残ったまま（nix:false のcache-nix-actionでは何もケアされずに）キャッシュされてしまう可能性があります。次回リストア時にこの WAL が正しく反映されないと、ディスク上に store パスの実体があっても Nix のDBには「未登録」に見え、再ビルドが起きます。

ただし `nix-installer` のソース (`ProvisionNix` / `MoveUnpackedNix`) を読んだ限り、DB自体を明示的に破棄する処理は見当たらず、この「checkpoint忘れ」説は状況証拠からの仮説にとどまります（100%の確証には至っていません）。対応として、ビルド後・保存前に明示的に `sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'` を実行するステップを追加しました（`continue-on-error: true` でジョブ全体をブロックしないようにしています）。

**検証手順**: この仮説が正しいかは、本PRマージ後、*.nix を一切変更しないダミーPRを立てて2回連続でCIを回し、2回目の `nix build` のログで「XX derivations will be built」の内訳から rustup / github-copilot-cli / neovim 系ラッパーが消えるか（または明らかに減るか）を確認することで判定できます。もし変化がなければ、この checkpoint 仮説は外れており、より踏み込んだ対応（例: Install Nix を Restore の前に移し `nix: true` で正式なDBマージ機能を使う）が必要になりますが、これは `Restore Nix cache` を Install Nix より前に持ってくる必要があり、過去に踏んだ地雷 (#233: tar展開がroot所有の既存ファイルと衝突して失敗) を再現するリスクがあるため、今回は見送りました。

## ⚠️ 本PR自体のCIランで判明した追加の注意点(重要)

このPR (`refs/pull/370/merge`) 自体の verify-docker ジョブは成功しましたが、`Post Restore Nix cache` ログで次の挙動を確認しました。

```
Trying to save a new cache with the key "nix-docker-Linux-...".
Purging the cache with the key "nix-docker-Linux-..." because of "purge-primary-key: always".
Failed to delete the cache.
HttpError: Not Found - .../rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
Cache hit occurred on the "primary-key".
Not collecting garbage.
Not saving a new cache.
```

`gh api repos/.../actions/caches` で確認すると、既存キャッシュの `ref` は `refs/heads/main` (2026-07-04作成) でした。GitHub Actions のキャッシュ削除APIは**キャッシュを作成した ref のスコープ内でしか削除できません**。PRラン (`refs/pull/370/merge`) は base ブランチのキャッシュを**読み取り(restore)は継承**できますが、**削除はできない**ため、`purge-primary-key: always` は 404 で失敗し、その結果「primary-key に一致するキャッシュがまだある」ままなので save もスキップされました。

これは cache-nix-action や本PRの実装の不具合ではなく、GitHub Actions のキャッシュのref scoping仕様そのものによる制約です。実務上の影響は:

- **push イベント (= mainへのマージ) のときだけ** ref が `refs/heads/main` と完全一致するため、purge → save が実際に機能します。
- **pull_request イベント (マージ前のPRチェック)** では、base ブランチから継承したキャッシュを purge できないため、常に「purge失敗 (無害) → save スキップ」になります。つまり **同一PRを何度re-runしても、PRの間だけではキャッシュは更新されません**。

したがって、完了条件にある「このPR自体のCIラン(1回目=保存側)」を厳密に読むと、**本PRが実際に main のキャッシュを更新できるのは、本PRがmainにマージされてpushイベントが発火した回になります**。ダミーPRでの2回目計測も、「①本PR (または設定のみ変更したダミーPR) をmainにマージ → pushトリガーのrunでpurge→saveが成功することを確認 → ②そのあとに新しく開いたPRのCIが速くなっているか」という順序で検証する必要があります(同一PR内で単純に2回runしても効果は見えません)。この制約はIssue本文の「マージ後に検証」という想定と矛盾しないため、設計自体は変更していません。

## 完了条件チェック

- [x] cache-nix-action の purge 系オプションを README/ソースで確認し、同一keyでも更新される構成にした
- [x] rustup の謎を調査(一部は overlay による原理的な非対象、一部は WAL checkpoint 仮説として対応・仮説明記)
- [x] .nix/flake.lock を変更しないPRで substitution・ビルドがほぼゼロになる設計であることを上記で説明
- [x] このPR自体のCIラン(1回目)を `gh run view --log` で確認 → 上記のとおり、PRランはref scopingの制約でpurge失敗→save skipという想定内の挙動。実際の保存はmainへのマージ(pushイベント)時に発生する設計であることを確認・明記
- [x] 実測の検証手順(ダミーPRでの2回目計測方法、ref scopingの制約を踏まえた正しい手順)を本文に明記

## 制約への対応

- Docker構成やcachix導入などの大きな設計変更はせず、既存のstep順序・required checks構成は維持しています
- 既存のGitHub Actionsキャッシュは削除していません（パージはワークフロー内の仕組みに任せています）
