### PR TITLE
fix(hypr): focus_on_activate を有効化し Web Clipper のクリップ0バイト問題を解消

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -126,6 +126,11 @@ master {
 misc {
     force_default_wallpaper = -1 # Set to 0 or 1 to disable the anime mascot wallpapers
     disable_hyprland_logo = false # If true disables the random hyprland logo / anime girl background. :(
+    # obsidian:// URI 経由の Web Clipper 連携のため、アクティベーション要求時にフォーカスを渡す
+    # (Wayland では非フォーカスウィンドウはクリップボードを読めず、クリップ本文が空になる)
+    # NOTE: allow apps to take focus on activation; required for Obsidian Web Clipper
+    #       (unfocused windows cannot read the clipboard on Wayland → empty clip body)
+    focus_on_activate = true
     # NOTE: v0.55 で misc:vfr は debug: 配下に移動（本番設定では触らない。VFR はデフォルトで有効）
     # NOTE: misc:vfr moved to debug: in v0.55; VFR is on by default and should not be set in prod
 }

--- a/.config/obsidian-web-clipper/clip-v1.json
+++ b/.config/obsidian-web-clipper/clip-v1.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "0.1.0",
+  "name": "Clip-v1",
+  "behavior": "create",
+  "noteNameFormat": "Clip-{{date|date:\"YYYYMMDD\"}}-{{title|safe_name}}",
+  "path": "Zettelkasten/LiteratureNotes",
+  "context": "",
+  "properties": [
+    { "name": "date", "value": "{{date|date:\"YYYY-MM-DD\"}}", "type": "date" },
+    { "name": "created", "value": "{{date|date:\"HH:mm\"}}", "type": "text" },
+    { "name": "type", "value": "literature", "type": "text" },
+    { "name": "source", "value": "web-clip", "type": "text" },
+    { "name": "url", "value": "{{url}}", "type": "text" },
+    { "name": "author", "value": "{{author}}", "type": "text" },
+    { "name": "published", "value": "{{published|date:\"YYYY-MM-DD\"}}", "type": "text" },
+    { "name": "read_at", "value": "", "type": "text" },
+    { "name": "status", "value": "unread", "type": "text" },
+    { "name": "distilled_to", "value": "", "type": "multitext" },
+    { "name": "tags", "value": "note-type/literature,source/web,{{date|date:\"YYYY-MM\"}}", "type": "multitext" },
+    { "name": "aliases", "value": "", "type": "multitext" }
+  ],
+  "triggers": [],
+  "noteContentFormat": "# {{title}}\n\n## Why I Clipped\n<!-- なぜ気になった？一言でOK。クリップ時点の「自分の言葉」がここに残る -->\n\n\n## Summary\n<!-- 記事の要点1-3文。クラウディアが補助可（あくまで叩き台） -->\n\n\n## Highlights\n<!-- ブラウザでハイライトすると自動で入る。読みながら追記もOK -->\n{{highlights}}\n\n## My Thoughts\n<!-- 読了後、自分の考え・批評・疑問。ここを書いたら status: read + read_at 記入 -->\n\n\n## Next Action\n<!-- この記事から派生するアクション（調査開始ならResearch Note作成、なければ空でOK） -->\n- [ ] \n\n---\n\n## Distillation\n<!-- 週次レビュー用。Permanent Noteに蒸留したら status: distilled にして\n     distilled_to にリンクを追加。蒸留対象でなければ read のままでOK -->\n\n### What I Really Understood\n<!-- 記事の要約じゃなく、自分が本当に理解したこと -->\n\n\n---\n\n## Related Notes\n- [[]]\n\n---\n\n## Article\n<!-- クリップした本文（オフライン読了用の原文アーカイブ） -->\n{{content}}\n"
+}


### PR DESCRIPTION
## 概要

Closes #371

Obsidian Web Clipper (OWC) のクリップが、タイトル・パスは正しいのに本文0バイトで着地する問題を修正します。

## 原因と修正

- OWC の転送は2系統: タイトル/パスは `obsidian://` URI、**本文はクリップボード経由**
- Hyprland デフォルトの `misc:focus_on_activate = false` ではアクティベートされた Obsidian にフォーカスが渡らず、**Wayland の仕様で非フォーカスウィンドウはクリップボードを読めない**ため本文だけ喪失していた
- `misc:focus_on_activate = true` を意図コメント(日英)付きで追加。再クリップで 16,814 bytes のノート着地を実機検証済み

## あわせて追加

- `.config/obsidian-web-clipper/clip-v1.json`: OWC テンプレのインポート用正本(SoT)。OWC は設定をファイルから読めないため home-manager symlink 対象外の純粋な意図の記録

## トレードオフ

- グローバルにフォーカス奪取を許可することになる。実害が出た場合は `windowrule = suppressevent activate` で該当アプリのみオプトアウトする方針(YAGNI で先回りはしない)
- 未検証の周辺ケース: Obsidian 未起動状態からのクリップ(special:obsidian への silent 着地との相互作用)。問題があれば別 Issue とする

## 備考

- 本PRは `.nix` / `flake.lock` を変更しないため、#368(PR #370)のキャッシュ修正の**効果測定1回目**を兼ねる(mainのpushラン 28749772196 で purge→save の成功を確認済み。本PRのCIが完全キャッシュを復元する最初のラン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pgn161TRb3PKn7jz2P174B