### PR TITLE
fix(nix): nixpkgs bump 追随 — mysql80/neofetch/nodePackages 廃止と copilot-cli sourceRoot 衝突を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,13 @@
                   url = "https://github.com/github/copilot-cli/releases/download/v${copilotVersion}/github-copilot-${copilotVersion}-linux-x64.tgz";
                   hash = "sha256-4Af5u4K5xg76RCLu3jHY1+IxWMosu7d8fmwJy0zgwB4=";
                 };
+                # nixpkgs 側の derivation が npm tarball 前提の sourceRoot = "package" を
+                # 設定するようになったが、GitHub Release アセットはルート直下にファイルを
+                # 置くため上書きして戻す (fetchzip の展開ディレクトリ名は "source")。
+                # The nixpkgs derivation now sets sourceRoot = "package" for the npm
+                # tarball layout; the GitHub release asset is flat, so point back at
+                # the fetchzip output directory ("source").
+                sourceRoot = "source";
                 # 同梱ネイティブバイナリ (.node, ripgrep) を patchelf する
                 # Patch the bundled native binaries for the Nix store.
                 nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.autoPatchelfHook ];

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -52,7 +52,7 @@ in
 
     # Database tools
     postgresql # PostgreSQL client
-    mysql80 # MySQL client
+    mysql84 # MySQL client (8.4 LTS; mysql80 は 2026-04-30 EOL で nixpkgs から削除 / mysql80 removed from nixpkgs after its 2026-04-30 EOL)
     sqlite # SQLite
 
     # Language runtimes

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -123,7 +123,7 @@ in
     screen # Terminal multiplexer
     direnv # Directory-based environment management
     asciinema # Terminal recorder
-    neofetch # System information
+    fastfetch # System information (neofetch は上流メンテ停止で nixpkgs から削除 / neofetch removed from nixpkgs as unmaintained upstream)
     # tldr is provided by tealdeer in rust-tools.nix
   ];
 

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -22,10 +22,12 @@
       # Language servers (LSP)
       lua-language-server
       nil # Nix LSP
-      nodePackages.typescript-language-server
-      nodePackages.vscode-langservers-extracted # HTML, CSS, JSON, ESLint
-      nodePackages.yaml-language-server
-      nodePackages.bash-language-server
+      # NOTE: nodePackages 名前空間は nixpkgs から廃止されたためトップレベル名で参照
+      # The nodePackages namespace was removed from nixpkgs; use top-level names
+      typescript-language-server
+      vscode-langservers-extracted # HTML, CSS, JSON, ESLint
+      yaml-language-server
+      bash-language-server
       # NOTE: python3 (デフォルト版) を使うことでバイナリキャッシュに乗せる（3.11 指名はソースビルドに落ちる）
       # Use default python3 to hit cache.nixos.org; pinning 3.11 forces source builds
       python3Packages.python-lsp-server
@@ -38,7 +40,7 @@
       # Formatters
       stylua # Lua formatter
       nixpkgs-fmt # Nix formatter
-      nodePackages.prettier # JS/TS/CSS/HTML formatter
+      prettier # JS/TS/CSS/HTML formatter
       black # Python formatter
       rustfmt # Rust formatter
       shfmt # Shell script formatter
@@ -46,7 +48,7 @@
       # Linters
       shellcheck # Shell script linter
       statix # Nix linter
-      nodePackages.eslint # JavaScript linter
+      eslint # JavaScript linter
 
       # Tree-sitter CLI
       tree-sitter


### PR DESCRIPTION
## 概要

flake.lock 自動更新 (#373) で nixpkgs が進んだ結果、home-manager の switch が3連鎖で失敗するようになったのを修正する。

## 変更内容

| 対象 | 症状 | 修正 |
|------|------|------|
| `nix/modules/dev-tools.nix` | `mysql80` が 2026-04-30 EOL で nixpkgs から削除 | `mysql84` (8.4 LTS、直系後継) に置き換え |
| `nix/modules/dev-tools.nix` | `neofetch` が上流メンテ停止で削除 | `fastfetch` (コミュニティ標準の後継) に置き換え |
| `nix/modules/neovim.nix` | `nodePackages` 名前空間が nixpkgs から廃止 | 6パッケージをトップレベル名に移行 (typescript-language-server / vscode-langservers-extracted / yaml-language-server / bash-language-server / prettier / eslint) |
| `flake.nix` | copilot-cli overlay の unpack が `chmod: cannot access 'package'` で失敗 | `sourceRoot = "source"` を明示。nixpkgs 側 derivation が npm tarball 前提の `sourceRoot = "package"` を設定するようになったが、overlay が使う GitHub Release アセットはフラット構造のため衝突していた |

## 検証

- `mise run nix:switch` が activation まで完走することを実機 (arch-native) で確認済み
- herdr `server reload-config` も diagnostics なしで applied (#379 のキーバインド反映と合わせて確認)

## 学び

flake.lock 更新 PR の CI (flake check + Docker 内 build & activate) が緑でも、EOL 削除パッケージの評価エラーは手元の home.nix 構成に依存して発現する。lock bump 直後は手元 switch での答え合わせが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPT3sYsKpjyTcFbhTuoJAa
