### PR TITLE
fix(alacritty): Windows側で透過を無効化し描画破損を解消

### DIFF
--- a/.config/alacritty/windows.toml
+++ b/.config/alacritty/windows.toml
@@ -8,3 +8,10 @@
 # Enter the default WSL distro (Arch) and start fish + herdr, same as native
 program = "wsl.exe"
 args = ["--cd", "~", "--", "/usr/bin/fish", "--login", "--command", "herdr"]
+
+[window]
+# Windows では DWM 合成 + 透過が OpenGL 描画破損 (背後ウィンドウの写り込み・
+# 文字欠け) を誘発するため透過を無効化する
+# Transparency triggers OpenGL rendering corruption on Windows (ghosting of
+# windows behind, missing glyphs) via DWM composition, so disable it
+opacity = 1.0


### PR DESCRIPTION
## [optional body]

WSL 上の Windows ネイティブ Alacritty で、背後のウィンドウ内容が写り込む・文字がまばらにしか描画されないという描画破損が発生していた。

原因は `opacity = 0.8` の透過設定が Windows の DWM 合成 + OpenGL (WGL) と干渉し、差分再描画時にバックバッファが保持されず未初期化領域 (=他ウィンドウのピクセル) が露出していたこと。

対応として `windows.toml` の Windows 限定上書きに `[window] opacity = 1.0` を追加。`lib.recursiveUpdate` によるマージのため `title` 等の既存キーは維持され、Hyprland (native Linux) 側の透過 0.8 には影響しない。

`mise run nix:switch` で `%APPDATA%\alacritty\alacritty.toml` への配布と反映を確認済み。

## [optional footer(s)]

🤖 Generated with [Claude Code](https://claude.com/claude-code)