### PR TITLE
feat(wsl): Windows 側ターミナルを WezTerm へ移行し ConPTY 描画破損を根治

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -1,0 +1,80 @@
+-- WezTerm 設定 — native Arch と Windows (WSL2) をこの1枚で賄う。
+-- Alacritty の base + windows.toml のビルド時マージは、Lua の実行時分岐で置き換える。
+-- WezTerm config — a single file for both native Arch and Windows (WSL2).
+-- Runtime branching replaces Alacritty's build-time base + windows.toml merge.
+
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+local is_windows = wezterm.target_triple:find('windows') ~= nil
+
+-- ---------------------------------------------------------------------------
+-- 見た目 / Appearance (Alacritty で使っていた One Dark 系パレットを踏襲)
+-- ---------------------------------------------------------------------------
+config.colors = {
+  foreground = '#abb2bf',
+  background = '#1e2127',
+  ansi = {
+    '#1e2127', -- black
+    '#e06c75', -- red
+    '#98c379', -- green
+    '#d19a66', -- yellow
+    '#61afef', -- blue
+    '#c678dd', -- magenta
+    '#56b6c2', -- cyan
+    '#828791', -- white
+  },
+  brights = {
+    '#5c6370', -- bright black
+    '#e06c75', -- bright red
+    '#98c379', -- bright green
+    '#d19a66', -- bright yellow
+    '#61afef', -- bright blue
+    '#c678dd', -- bright magenta
+    '#56b6c2', -- bright cyan
+    '#e6efff', -- bright white
+  },
+}
+
+config.font = wezterm.font 'HackGen35 Console NF'
+config.font_size = 14.0
+config.window_background_opacity = 0.8
+
+-- タブ・ペイン管理は herdr が担うため、WezTerm 自身のタブバーは出さない
+-- herdr owns tabs/panes, so hide WezTerm's own tab bar
+config.enable_tab_bar = false
+config.window_padding = { left = 0, right = 0, top = 0, bottom = 0 }
+
+-- ---------------------------------------------------------------------------
+-- シェル / Shell (herdr は既存セッションへ自動アタッチするため分岐不要)
+-- ---------------------------------------------------------------------------
+if is_windows then
+  -- 既定の WSL ディストロ (Arch) に入り、native と同じく fish + herdr を起動する
+  -- Enter the default WSL distro (Arch) and start fish + herdr, same as native
+  config.default_prog =
+    { 'wsl.exe', '--cd', '~', '--', '/usr/bin/fish', '--login', '--command', 'herdr' }
+else
+  config.default_prog = { '/usr/bin/fish', '--login', '--command', 'herdr' }
+end
+
+-- ---------------------------------------------------------------------------
+-- キーバインド / Keybindings
+-- コピー/ペースト (Ctrl+Shift+C/V)・フォントサイズ (Ctrl+0/=/-)・
+-- 新規ウィンドウ (Ctrl+Shift+N) は WezTerm の既定が Alacritty 設定と一致するため定義しない
+-- Copy/paste, font size and new-window defaults already match the old
+-- Alacritty bindings, so only the differences are declared here
+-- ---------------------------------------------------------------------------
+config.keys = {
+  -- Claude Code 等の改行 (ESC + CR)。既定では Alt+Enter がフルスクリーン切替に
+  -- 取られるため明示バインドで上書きし、Linux と同一挙動にする
+  -- Newline (ESC + CR) for Claude Code etc. Alt+Enter defaults to fullscreen
+  -- toggle, so override it explicitly to match Linux behavior
+  { key = 'Enter', mods = 'ALT', action = wezterm.action.SendString '\x1b\r' },
+  { key = 'F11', action = wezterm.action.ToggleFullScreen },
+}
+
+-- 日本語 IME (Windows はネイティブ IME、native Arch は fcitx5)
+-- Japanese IME (native Windows IME on Windows, fcitx5 on Arch)
+config.use_ime = true
+
+return config

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -184,7 +184,7 @@ nix/modules/
 ├── dev-tools.nix   # 開発ツール（docker, kubectl, awscli）
 ├── fonts.nix       # フォント
 ├── desktop.nix     # GUI 設定群（hypr, waybar, alacritty 等）— native profile のみ
-└── wsl.nix         # WSL 固有（Obsidian vault symlink, Alacritty 配布）— wsl profile のみ
+└── wsl.nix         # WSL 固有（Obsidian vault symlink, WezTerm/Alacritty 配布）— wsl profile のみ
 ```
 
 ### 分離の基準
@@ -209,10 +209,21 @@ nix/modules/
 
 ### 所有権境界: 「ピクセルは host、プロセスは WSL」
 
-WSL 環境では terminal emulator（Alacritty）は Windows ネイティブアプリのまま使う。
+WSL 環境では terminal emulator は Windows ネイティブアプリ（**WezTerm**）を使う。
 日本語 IME・HiDPI・クリップボードなど GUI 統合は host OS が最も安定するため、
-dotfiles の所有権は「シェルから内側」に限定し、Windows 側の `alacritty.toml` は
-`nix:switch` 時に配布する成果物として扱う（`nix/modules/wsl.nix`）。
+dotfiles の所有権は「シェルから内側」に限定し、設定は `nix:switch` 時に
+Windows 側へ配布する成果物として扱う（`nix/modules/wsl.nix`）。
+
+**emulator の選定経緯（2026-07）**: 当初の Windows 版 Alacritty は ConPTY の画面更新を
+取りこぼす未解決バグ（[alacritty/alacritty#8057](https://github.com/alacritty/alacritty/issues/8057)）
+があり、herdr の画面切り替えで描画破損が発生した。WSLg + Linux 版 Alacritty への移行も
+検証したが、未解決 upstream バグ 3 件への回避策の積み上げとなり体験品質で不採用
+（切り分けと知見は [PR #383](https://github.com/music-brain88/dotfiles/pull/383) 参照）。
+WezTerm は `conpty.dll` / `OpenConsole.exe` を同梱し ConPTY 実装を自前で持つため
+この問題を踏まない。原則（ピクセルは host）はそのままに emulator だけを替える最小修正。
+設定は `wezterm.lua` 1枚が両マシン共通の真実（Lua の実行時 OS 分岐が Alacritty 時代の
+base + windows.toml ビルド時マージを置き換え）。Windows 版 Alacritty は併存期間中
+フォールバックとして設定配布を維持する。
 
 ### profile の構造
 
@@ -222,7 +233,8 @@ dotfiles の所有権は「シェルから内側」に限定し、Windows 側の
 - **`archie-wsl`**（wsl）: 共通モジュール + `wsl.nix`
   - `~/Documents/Obsidian` → Windows 側 vault への symlink を activation で生成（Claude Cowork / Obsidian Sync が vault の実体を Windows 側に要請するため）。これによりスキル群（session-log 等）はパス変更なしで両環境動作する
   - **vault 配置規約**: Obsidian Sync が同期するのは vault の中身と名前だけで、ローカルの置き場所は各端末で選ぶもの。この dotfiles では「Windows ホストでは `%USERPROFILE%\Documents\music.brain88` に配置する」を運用規約とし、`wsl.nix` はその規約をコード化している（見つからない場合は警告して skip、activation は落ちない）
-  - Windows 側 Alacritty 設定を base + `windows.toml` 差分のマージで生成し `%APPDATA%` へ配布（Windows でも fish + herdr が自動起動）
+  - WezTerm 設定（`wezterm.lua`、両マシン共通）を `%USERPROFILE%\.config\wezterm\` へ配布（Windows でも fish + herdr が自動起動）
+  - フォールバック用に Windows 側 Alacritty 設定も base + `windows.toml` 差分のマージで生成し `%APPDATA%` へ配布
 
 ---
 

--- a/nix/modules/wsl.nix
+++ b/nix/modules/wsl.nix
@@ -55,10 +55,36 @@ in
     fi
   '';
 
-  # Alacritty は「ピクセルは host」方針で Windows ネイティブのまま。
+  # WezTerm は「ピクセルは host」方針で Windows ネイティブ。設定は Lua 1枚が
+  # 両マシン共通の真実で、switch 時に Windows 側へ配布してドリフトを防ぐ
+  # (WezTerm は設定ファイルを自動リロードする)。
+  # WezTerm runs Windows-native ("pixels belong to the host"). One Lua file is
+  # the shared truth for both machines; deploy it on switch to prevent drift
+  # (WezTerm auto-reloads its config file).
+  home.activation.deployWeztermConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${winEnvSnippet}
+    win_home_raw="$(win_env USERPROFILE)"
+    win_home=""
+    if [ -n "$win_home_raw" ]; then
+      win_home="$(/usr/bin/wslpath "$win_home_raw" 2>/dev/null || true)"
+    fi
+    if [ -z "$win_home" ]; then
+      echo "wsl.nix: could not resolve %USERPROFILE%; skipping WezTerm config deploy" >&2
+    else
+      target="$win_home/.config/wezterm/wezterm.lua"
+      mkdir -p "$win_home/.config/wezterm"
+      if ! ${pkgs.diffutils}/bin/cmp -s ${../../.config/wezterm/wezterm.lua} "$target"; then
+        cp -f ${../../.config/wezterm/wezterm.lua} "$target"
+        chmod 644 "$target"
+        echo "wsl.nix: deployed WezTerm config to $target"
+      fi
+    fi
+  '';
+
+  # Alacritty (Windows 版) は WezTerm 移行の併存期間中フォールバックとして残す。
   # 設定だけを switch 時に配布してドリフトを防ぐ (live_config_reload で即反映)。
-  # Alacritty stays Windows-native ("pixels belong to the host").
-  # Only the config is deployed on switch to prevent drift (live_config_reload applies it).
+  # The Windows-native Alacritty stays as a fallback during the WezTerm
+  # transition. Only the config is deployed on switch to prevent drift.
   home.activation.deployAlacrittyConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${winEnvSnippet}
     appdata_raw="$(win_env APPDATA)"


### PR DESCRIPTION
## [optional body]

### 経緯

Windows 版 Alacritty は ConPTY の画面更新を取りこぼす未解決バグ (alacritty/alacritty#8057) があり、herdr の画面切り替えで前画面の文字が残る描画破損が発生していた。

WSLg + Linux 版 Alacritty への移行 (#383) も検証したが、未解決 upstream バグ 3 件 (alacritty#8057 / wslg#1386 / mesa 26 の d3d12 検出失敗) への回避策の積み上げとなり、体験品質 (ウィンドウ管理・描画・IME) で不採用。知見は #383 と session-log に保存済み。

### 対応

**「ピクセルは host」原則はそのままに、emulator だけを WezTerm に替える最小修正。**

- WezTerm は `conpty.dll` / `OpenConsole.exe` を同梱し ConPTY 実装を自前で持つため、alacritty#8057 を踏まない (インストール先 `C:\Program Files\WezTerm\` で同梱を確認)
- IME・HiDPI・クリップアップは Windows ネイティブのまま
- `wezterm.lua` 1枚が両マシン共通の真実。Lua の実行時 OS 分岐 (`wezterm.target_triple`) が Alacritty 時代の base + `windows.toml` ビルド時マージ機構を置き換える
- キーバインド・カラーパレット (One Dark)・フォント (HackGen35 Console NF)・opacity 0.8 は Alacritty 設定から踏襲。既定が一致するもの (Ctrl+Shift+C/V、Ctrl+0/=/-、Ctrl+Shift+N) は定義せず、差分 (Alt+Enter → ESC+CR、F11 フルスクリーン) のみ宣言
- `wsl.nix` が `%USERPROFILE%\.config\wezterm\wezterm.lua` へ switch 時に配布 (WezTerm は設定を自動リロード)
- Windows 版 Alacritty は併存期間中フォールバックとして配布を維持

### 検証

- winget で WezTerm 20240203-110809 をインストール
- `mise run nix:switch` で設定配布を確認
- WezTerm ウィンドウ起動 + WSL 内コマンド実行を確認 (marker 方式)
- herdr 実運用での描画安定性はこの PR の運用期間で評価する

### ロードマップ

- **Phase 2**: herdr ガシガシの実運用テスト。万一破損が出たら `wezterm-mux-server` で ConPTY 完全バイパス (Windows/WSL のバージョン一致が必要になるため、必要になるまで温存)
- **Phase 3**: 気に入ったら native Arch も Alacritty → WezTerm へ移行し、`wezterm.lua` を単一の真実に昇格 (tmux → herdr と同じ併存移行パターン)

## [optional footer(s)]

Refs: https://github.com/alacritty/alacritty/issues/8057
Refs: #383 (WSLg 移行の検証と不採用の経緯)

🤖 Generated with [Claude Code](https://claude.com/claude-code)