### PR TITLE
feat(session-log): add distilled_to to frontmatter skeleton

### DIFF
--- a/.config/claude/skills/session-log/SKILL.md
+++ b/.config/claude/skills/session-log/SKILL.md
@@ -60,6 +60,7 @@ date: YYYY-MM-DD
 tags:
   - <プロジェクト名やテーマのケバブケース 3〜6個>
 type: research-note
+distilled_to:
 source: Claude Code session (<モデル名>) on <machine>
 context: <personal | work — 出自の判定に従う>
 machine: <arch-native | wsl>


### PR DESCRIPTION
## 概要

session-log スキルが生成するセッションノートのフロントマターに `distilled_to:` を追加する。

## 背景

2026-07-10 の vault 側の設計宣言(`MOC-ObsidianWorkflow` の「蒸留状態の宣言」)で、蒸留状態と作業状態を別の軸に分離した:

- **蒸留状態** = `distilled_to` プロパティが担う(空 = 未蒸留、Permanent Note へのリンク = 蒸留済み)。ResearchNotes / LiteratureNotes(Clip) 共通の規約
- **作業状態** = `status`(draft / in-progress / done)。蒸留状態を status に載せない

ResearchNotes 既存108件には移行スクリプトで `distilled_to` を注入済み(vault commit `50d0d77`)。このPRで、session-log が今後生成するノートも生まれた瞬間から規約に乗り、`ResearchNotes.base` の「蒸留待ち」ビューにバックフィル無しで拾われるようになる。

## 変更内容

- スケルトンの `type: research-note` 直下に `distilled_to:` を1行追加(それのみ)

## 反映

マージ後に `nix:switch`(home-manager switch)が必要。`~/.claude/skills/` は nix store への per-file symlink のため、rebuild まで稼働中のスキルは旧スケルトンのまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173xaf9SQ1jCdHoY6RSvgFy