### PR TITLE
feat(skills): herdr を介した四者会話プロトコル herdr-chat を追加

### DIFF
--- a/.config/skills/herdr-chat/SKILL.md
+++ b/.config/skills/herdr-chat/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: herdr-chat
+description: |
+  herdr を介して、ユーザー・Claude Code・Copilot CLI・copilot-quorum の四者が
+  pane 越しに対話するためのプロトコル。相手 pane の見つけ方、宛先プレフィックス付き
+  メッセージ形式、送信・応答待ちの手順、ループ防止の原則を定める。
+  ユーザーが「Copilot と相談して」「quorum に合議させて」「他のエージェントに聞いて」
+  「隣の pane と話して」などと言った時、または他エージェントからの宛先付きメッセージ
+  (【from→to】形式)を pane 上で検知した時に使う。
+  司令塔↔作業者プロトコル(herdr スキルの `agent send` / 上り報告)とは別物 — あちらは
+  上下関係の報告経路、こちらは対等な対話。既存プロトコルは変更しない。
+---
+
+# herdr-chat — 四者会話プロトコル
+
+herdr の pane を介して、ユーザー・Claude Code・Copilot CLI・copilot-quorum が
+対等な立場で会話するためのプロトコル。前提として herdr スキルの基本操作
+(`pane list` / `pane send-text` / `pane send-keys` / `wait output` など)を理解していること。
+
+## 参加者モデル
+
+| 参加者 | 実体 | 役割 |
+|---|---|---|
+| ユーザー | 任意の pane に直接入力 | 最優先。全エージェントはユーザー入力を最優先で扱う |
+| Claude Code | pane (多くは `commander-*` または agent 名付き) | 対話 + herdr 操作のハブ |
+| Copilot CLI | `herdr agent start` した pane | 対等な対話相手 |
+| copilot-quorum | Agent REPL pane | 合議が欲しい論点を投げる「合議体」。単独モデルの応答ではなく Quorum→Peer Review→Synthesis の結論を返す |
+
+## 1. 参加者の発見
+
+会話を始める前に、必ず `herdr agent list` と `herdr pane list --workspace <ws>` で
+相手 pane を特定する。**宛先を推測でメッセージを送らない** — pane id はセッションごとに
+変わりうるため、送信直前に毎回確認する。
+
+```bash
+herdr agent list
+herdr pane list --workspace <workspace_id>
+```
+
+- `agent` フィールドが `claude` のものは herdr がエージェント検知している。Copilot CLI /
+  copilot-quorum は `agent: null` / `agent_status: unknown` になるため、`name` フィールド
+  (`herdr agent start <name> ...` で付けた名前)で区別する。名前を付けずに起動された pane は
+  `cwd` や直近の `agent read` の内容で人間側が判断してから送る
+- **宛先誤送信の防止**: 送信直前に対象 pane を `herdr agent read <target>` で読み、
+  想定した相手(Copilot のプロンプト、quorum の `solo>` 入力欄など)が実際にそこにいるか
+  確認してから `send-text` する。特に同一 workspace 内に複数の作業用 pane がある場合、
+  pane id の取り違えは容易に起こる
+- 自分自身の workspace 外の pane(他ユーザー・他司令塔のもの)には触れない
+
+## 2. メッセージ形式
+
+宛先プレフィックスを本文の先頭に付ける:
+
+```
+【<from>→<to>】<本文>
+```
+
+`from` / `to` は次のいずれか: `claude` / `copilot` / `quorum` / `user`
+
+例:
+```
+【claude→copilot】このコードのレビューをお願いします
+【copilot→claude】レビューしました。src/foo.rs:42 が気になります
+【claude→quorum】キャッシュ戦略をLRUにするかTTLにするか合議してください
+【quorum→claude】Quorum結論: TTL推奨(理由は3点)
+```
+
+ユーザーが pane に直接入力する場合、プレフィックスは省略されうる。プレフィックスの
+有無に関わらず、pane への直接入力は常にユーザー入力として最優先で扱う([5](#5-ユーザー最優先の原則)節)。
+
+## 3. 送信: 2段構え
+
+`pane send-text` は挿入のみで実行されない。必ず `send-keys <pane-id> Enter` を続ける:
+
+```bash
+herdr pane send-text <pane_id> "【claude→copilot】疎通確認です"
+herdr pane send-keys <pane_id> Enter
+```
+
+## 4. 応答待ち: `wait output` + 応答マーカー
+
+**自己エコーの罠**: 送信文に含まれる文字列で `wait output` すると、応答より先に
+自分の入力行のエコーにマッチする。応答待ちは応答マーカー込みのパターンで行う
+(相手ごとの応答マーカーは [6](#6-参加者ごとの起動方法と応答マーカー) の一覧表を参照)。
+
+```bash
+herdr wait output <pane_id> --match "● " --timeout 30000
+herdr agent read <pane_id>
+```
+
+**複数ターンでのラベル使い回しの罠**(copilot-quorum で実測): `Agent:` のような
+固定ラベルは会話が進むと画面内に複数回出現する。2ターン目以降に単純にラベルだけで
+`--match` すると、直前ターンの古い応答に即マッチしてしまい、新しい応答を待たない。
+2ターン目以降は、応答本文にのみ出現する一意なトークンを相手への質問文で指定させ
+(例: 「回答には一意な合言葉を含めてください」)、そのトークン文字列自体でマッチする。
+トークンを送信文(自分の入力エコー行)に含めないこと — 含めると自己エコーの罠に戻る。
+
+## 5. ユーザー最優先の原則
+
+ユーザーからの直接入力(プレフィックスの有無に関わらず、pane 上での直接入力)を検知したら、
+進行中の他エージェントとの対話より優先してそれを処理する。他エージェントとの対話中に
+ユーザー入力が割り込んだ場合、対話を打ち切ってユーザーの用件に応答してよい。
+
+## 6. ループ防止の原則
+
+四者会話は自動転送や無条件応答を許すと容易に無限ループする。以下を厳守する:
+
+- **自分宛にのみ応答する**: pane 上のメッセージを読み、宛先プレフィックスが
+  `→<自分>` になっているものにのみ応答する。宛先が他者宛のメッセージは読んでも
+  反応しない(黙って無視する)
+- **受信メッセージの自動転送を禁止する**: 受け取った内容をそのまま他の pane に
+  右から左へ転送しない。他者に伝える必要がある場合は、自分の判断を通した要約・
+  言い換えとして送る
+- **応答は1メッセージにつき1回**: 同じ受信メッセージに対して複数回応答しない。
+  応答済みかどうか、直前に自分がそのメッセージへ返信済みでないかを確認してから送る
+- 上記を満たしていても会話が3往復以上続きそうな場合は、一度ユーザーに状況を報告し
+  継続の是非を確認する(合議や長考が必要な論点は quorum に投げる判断も含めて)
+
+## 7. 参加者ごとの起動方法と応答マーカー
+
+| 参加者 | 起動コマンド | 応答マーカー | 終了方法 | 備考 |
+|---|---|---|---|---|
+| Claude Code | `herdr agent start <name> --workspace <ws> --split <right\|down> -- claude` | herdr の `agent_status`(`idle`/`working`)で検知可能。文字列で待つ場合はプロンプト行 `>` | pane 内で `/exit` または pane close | Claude 同士は `wait agent-status` が使える(herdr が正式にエージェント検知する) |
+| Copilot CLI | `herdr agent start <name> --workspace <ws> --split down -- copilot` | `● `(行頭。応答本文の先頭に付く) | 入力欄に `/exit` + Enter | herdr はエージェント検知しない(`agent=null`/`agent_status=unknown`)。`wait output` のパターンマッチで代替する |
+| copilot-quorum | `herdr agent start <name> --workspace <ws> --split down -- copilot-quorum --no-quorum` | `Agent:` ラベル行(初回のみ。2ターン目以降は [4](#4-応答待ち-wait-output--応答マーカー) のトークン方式を使う) | `send-keys <pane_id> C-c`(pane ごと片付く。実測確認済み) | 引数なし起動で Agent REPL。`--no-quorum` で合議レビューをスキップ(軽い疎通確認向け)。`/discuss` でアドホック合議、省略時 `--ensemble` で全問合議になる。応答完了は画面上部ステータスが `Planning`→`Ready` に変化し、`System: Agent completed` の直後に `Agent:` ラベルが出る |
+
+### copilot-quorum プローブの実測ログ(2026-07-11, w2W:p3 で実施)
+
+```
+起動: herdr agent start quorum-probe --workspace w2W --split down -- copilot-quorum --no-quorum
+送信: herdr pane send-text w2W:p3 "疎通確認です。「プローブOK-qz9」とだけ一言返してください。"
+      herdr pane send-keys w2W:p3 Enter
+1ターン目応答(5秒後): Agent: プローブOK-qz9  ← ラベル `Agent:` で初検出
+2ターン目: 同じ「Agent:」でwait outputすると直前ターンの行に即マッチ(新規性なし) ← 罠を確認
+終了: herdr pane send-keys w2W:p3 C-c → pane 自体が消滅(pane list から w2W:p3 が消える)
+```
+
+## 8. セットアップ
+
+### Copilot CLI に herdr コマンドの実行を許可する
+
+Copilot CLI のツール許可は `~/.copilot/permissions-config.json` の
+`locations.<絶対パス>.tool_approvals` に永続化される。対話モードで `herdr ...` の
+実行時に「常に許可」を選ぶと、そのロケーション(cwd の絶対パス)に対して自動的に
+`{"kind": "commands", "commandIdentifiers": ["herdr"]}` が書き込まれる。
+
+このファイルは **Nix では管理しない**。理由:
+
+- キーが worktree ごとに異なる絶対パスであり、worktree を作るたびにエントリが増える
+  動的な性質を持つ。home.nix のような宣言的シードと相性が悪い
+- Copilot CLI 自身が対話操作で書き換える実行時状態ファイルであり、シードで固定内容を
+  書くと CLI 側の管理と競合しうる
+
+**運用手順**: 新しい worktree で Copilot CLI から herdr コマンドを初めて実行する際は、
+対話プロンプトで一度「常に許可」を選ぶ(以後そのディレクトリでは自動承認される)。
+非対話的に起動する場合は `copilot --allow-tool='shell(herdr:*)'` をセッション起動時に
+明示する。無理に自動化しない。

--- a/.config/skills/herdr-chat/SKILL.md
+++ b/.config/skills/herdr-chat/SKILL.md
@@ -92,8 +92,16 @@ herdr agent read <pane_id>
 固定ラベルは会話が進むと画面内に複数回出現する。2ターン目以降に単純にラベルだけで
 `--match` すると、直前ターンの古い応答に即マッチしてしまい、新しい応答を待たない。
 2ターン目以降は、応答本文にのみ出現する一意なトークンを相手への質問文で指定させ
-(例: 「回答には一意な合言葉を含めてください」)、そのトークン文字列自体でマッチする。
-トークンを送信文(自分の入力エコー行)に含めないこと — 含めると自己エコーの罠に戻る。
+(例: 「回答には一意な合言葉 `<トークン>` を含めてください」)、**応答側にしか出ない
+プレフィックス(`Agent:` など)とトークンの複合パターン**で `--match --regex` する:
+
+```bash
+herdr wait output <pane_id> --match "Agent:.*<トークン>" --timeout 30000 --regex
+```
+
+トークン単体でのマッチは避ける — トークンだけだと質問文中の記載や入力エコー行にも
+一致しうる。トークン自体は送信文(質問文)に含めてよいが、マッチは必ず応答側の
+プレフィックス込みの複合パターンで行うこと。
 
 ## 5. ユーザー最優先の原則
 
@@ -120,11 +128,11 @@ herdr agent read <pane_id>
 
 | 参加者 | 起動コマンド | 応答マーカー | 終了方法 | 備考 |
 |---|---|---|---|---|
-| Claude Code | `herdr agent start <name> --workspace <ws> --split <right\|down> -- claude` | herdr の `agent_status`(`idle`/`working`)で検知可能。文字列で待つ場合はプロンプト行 `>` | pane 内で `/exit` または pane close | Claude 同士は `wait agent-status` が使える(herdr が正式にエージェント検知する) |
+| Claude Code | `herdr agent start <name> --workspace <ws> --split down（または right） -- claude` | herdr の `agent_status`(`idle`/`working`)で検知可能。文字列で待つ場合はプロンプト行 `>` | pane 内で `/exit` または pane close | Claude 同士は `wait agent-status` が使える(herdr が正式にエージェント検知する) |
 | Copilot CLI | `herdr agent start <name> --workspace <ws> --split down -- copilot` | `● `(行頭。応答本文の先頭に付く) | 入力欄に `/exit` + Enter | herdr はエージェント検知しない(`agent=null`/`agent_status=unknown`)。`wait output` のパターンマッチで代替する |
 | copilot-quorum | `herdr agent start <name> --workspace <ws> --split down -- copilot-quorum --no-quorum` | `Agent:` ラベル行(初回のみ。2ターン目以降は [4](#4-応答待ち-wait-output--応答マーカー) のトークン方式を使う) | `send-keys <pane_id> C-c`(pane ごと片付く。実測確認済み) | 引数なし起動で Agent REPL。`--no-quorum` で合議レビューをスキップ(軽い疎通確認向け)。`/discuss` でアドホック合議、省略時 `--ensemble` で全問合議になる。応答完了は画面上部ステータスが `Planning`→`Ready` に変化し、`System: Agent completed` の直後に `Agent:` ラベルが出る |
 
-### copilot-quorum プローブの実測ログ(2026-07-11, w2W:p3 で実施)
+### copilot-quorum プローブの実測ログ(2026-07-11 JST, w2W:p3 で実施)
 
 ```
 起動: herdr agent start quorum-probe --workspace w2W --split down -- copilot-quorum --no-quorum

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -100,7 +100,7 @@ dotfiles/
 
 | Directory | Description |
 |-----------|-------------|
-| `skills/` | ツール中立な共有スキル層。各サブディレクトリに `SKILL.md`(frontmatter は `name`/`description` のみ)。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方にマウントし、単一ソースからのドリフトを構造的に防ぐ(Issue #404) |
+| `skills/` | ツール中立な共有スキル層。各サブディレクトリに `SKILL.md`(frontmatter は `name`/`description` のみ)。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方にマウントし、単一ソースからのドリフトを構造的に防ぐ(Issue #404)。`context`/`create-issue`/`pr`/`release-note`/`formal`/`daily`/`session-log`/`herdr-chat`(ユーザー・Claude・Copilot・copilot-quorum の四者会話プロトコル、Issue #409)の8スキル |
 | `claude/skills/` | Claude Code 専用スキル。`herdr`(環境固有)、`wt`/`wtclean`(Claude の人格・herdr 前提)。旧 `claude/commands/` はスキル形式に統合済み(Claude Code はスキルをスラッシュコマンドとしても呼べる) |
 | `copilot/` | GitHub Copilot CLI 設定。実体は `~/.copilot/`(`~/.config/copilot` ではない)。スキルは `skills/` からマウントされる共有分のみで、Copilot 固有のスキルディレクトリは持たない |
 

--- a/home.nix
+++ b/home.nix
@@ -86,6 +86,7 @@
     ".claude/skills/formal" = { source = ./.config/skills/formal; recursive = true; };
     ".claude/skills/daily" = { source = ./.config/skills/daily; recursive = true; };
     ".claude/skills/session-log" = { source = ./.config/skills/session-log; recursive = true; };
+    ".claude/skills/herdr-chat" = { source = ./.config/skills/herdr-chat; recursive = true; };
 
     # mise global config (tools available outside project dirs, e.g. claude via node)
     # mise グローバル設定（プロジェクト外でも使うツール。claude は node 経由）
@@ -108,6 +109,7 @@
     ".copilot/skills/formal" = { source = ./.config/skills/formal; recursive = true; };
     ".copilot/skills/daily" = { source = ./.config/skills/daily; recursive = true; };
     ".copilot/skills/session-log" = { source = ./.config/skills/session-log; recursive = true; };
+    ".copilot/skills/herdr-chat" = { source = ./.config/skills/herdr-chat; recursive = true; };
     # Global copilot-instructions for GitHub Copilot (VS Code, etc.)
     ".github/copilot-instructions.md".source = ./.config/copilot/copilot-instructions.md;
 


### PR DESCRIPTION
## 概要

Issue #409 の実装。ユーザー・Claude Code・Copilot CLI・copilot-quorum の四者が
herdr の pane を介して対等に対話するための共有スキル `herdr-chat` を新設する。

## 変更内容

- `.config/skills/herdr-chat/SKILL.md` を新規作成
  - 参加者(相手 pane)の発見方法と宛先誤送信の防止手順
  - `【from→to】` 宛先プレフィックス形式のメッセージ規約
  - 送信の2段構え(`send-text` → `send-keys Enter`)
  - `wait output` + 応答マーカーによる応答待ち、自己エコー回避
  - ループ防止の原則(自分宛にのみ応答/自動転送禁止/1メッセージ1応答)
  - ユーザー最優先の原則
  - 参加者ごとの起動方法・応答マーカー一覧表
- `home.nix` に `.claude/skills/herdr-chat` / `.copilot/skills/herdr-chat` の2エントリを追加(既存8スキルと同じパターン)
- `docs/reference/directory-structure.md` の共有スキル一覧を更新

## quorum プローブの実測結果

自分の workspace (w2W) 内に pane を作り、`copilot-quorum --no-quorum` で
Agent REPL を起動して2往復プローブした。

- 起動: `herdr agent start <name> --workspace w2W --split down -- copilot-quorum --no-quorum`(引数なし相当なので REPL になる)
- 応答マーカー: `Agent:` ラベル行(Copilot CLI の `● ` とは異なる形式)。応答完了は画面上部ステータスが `Planning`→`Ready` に変化し、`System: Agent completed` の直後に現れる
- **新たに発見した罠**: `Agent:` ラベルは会話が進むと画面内に複数回出現するため、2ターン目以降に単純にラベルだけで `wait output --match "Agent:"` すると**直前ターンの古い応答に即マッチ**してしまい、新しい応答を待たない(実測で確認)。対策として、質問文で「回答には一意な合言葉を含めて」と指示し、そのトークン文字列自体でマッチする方式を SKILL.md に明記した
- 終了: `send-keys <pane_id> C-c` で pane 自体が片付く(pane list から消えることを確認済み)。プローブに使った pane はプローブ完了後に自動で片付いている

## Copilot 側 herdr 許可の調査結果

Copilot CLI のツール許可(`shell(herdr:*)` 等)は `~/.copilot/permissions-config.json` の
`locations.<絶対パス>.tool_approvals` に永続化される方式だった。対話モードで一度
「常に許可」を選ぶと自動的に書き込まれる(実際 `/home/archie/dotfiles` には既に `herdr` が
承認済みとして記録されていた)。

このファイルは home.nix では管理しない判断をした:
- キーが worktree ごとに異なる絶対パスであり、Nix の宣言的シードと相性が悪い
- Copilot CLI 自身が対話操作で動的に書き換える実行時状態ファイルであり、固定内容の
  シードは CLI 側の管理と競合しうる

運用手順として、新しい worktree では初回に対話で「常に許可」を選ぶか、非対話起動時は
`copilot --allow-tool='shell(herdr:*)'` を明示することを SKILL.md のセットアップ節に記載した。

## nix:switch 後に必要な実機検証(四者会話シナリオ)

このブランチでは `nix:switch` を実行していない(worktree 作業の制約)。マージ後の
`nix:switch` 後に以下を確認する必要がある:

- [ ] `copilot skill list` 等で `herdr-chat` が Copilot CLI 側にも表示されること
- [ ] Claude Code と Copilot CLI の pane 間で `【claude→copilot】`/`【copilot→claude】` の
      往復が実際に成立すること(自己エコー罠の回避を含む)
- [ ] copilot-quorum を会話に参加させ、`【claude→quorum】` で合議論点を投げて
      `【quorum→claude】` の結論が返ること(トークン方式での応答待ちを含む)
- [ ] ユーザーがどの pane から書き込んでも、ユーザー最優先の原則が正しく機能すること
- [ ] ループ防止の原則(自分宛のみ応答/自動転送禁止)が実際の3者以上の会話で破綻しないこと

## ビルド確認

- `mise run nix:check` 成功
- `mise run nix:build` 成功
- `readlink -f result/home-files/.claude/skills/herdr-chat/SKILL.md` と
  `readlink -f result/home-files/.copilot/skills/herdr-chat/SKILL.md` が同一 store パス
  (`/nix/store/00f2ws06wq1pcfpvy0srw0ka5sqnj9sa-hm_herdrchat/SKILL.md`)を指すことを確認

## 制約・指示外の気づき

- 迷った大きな設計判断: `docs/reference/directory-structure.md` の共有スキル行は元々個別スキル名を
  列挙していなかったため、今回 `herdr-chat` を含む8スキル名を列挙する形に変更した(過去のコミットパターンに
  厳密に従うなら列挙しない選択肢もあった)
- 指示外の気づき: `~/.copilot/config.json` に平文の GitHub OAuth トークン(`gho_...`)が
  保存されていることに気づいた。これは Copilot CLI 自身の仕様であり本 Issue のスコープ外だが、
  home.nix の activation script で config.json をシードする際にこのファイルを誤って git 管理下に
  置かないよう注意が必要(現状のシード方式は「存在しない場合のみコピー」なので安全だが、念のため報告)

Closes #409