### PR TITLE
feat(skills): wtclean 供養に worker 子 session-log ノートの規約を追加

### DIFF
--- a/.config/claude/skills/wtclean/SKILL.md
+++ b/.config/claude/skills/wtclean/SKILL.md
@@ -79,6 +79,8 @@ herdr pane read <agent-pane-id> --source recent-unwrapped --lines 500
 - **MUST**: 抽出対象は作業指示テンプレートの「## 報告」内の「気づき」欄(指示外の回避策・環境の摩擦・想定外の挙動)、および permission ブロックやリトライなど、ログ上に残る摩擦の痕跡とする
 - **MUST**: workspace がすでに閉じていて pane が読めない場合はスキップし、その旨を報告に含める
 - **MUST**: 抽出した内容を worktree ごとに要約し、Issue 化する価値がありそうなものは候補としてユーザーに提示する
+- **MAY**: worker の開発過程に記録価値がある場合(非自明な設計判断・戦略が奏功した・規範文書を根拠にした境界判断など)、session-log スキルの流儀で子ノートを作成してよい。命名は `ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`(`ClaudeCodeSession-` プレフィックスを維持し .base ビューのフィルタを壊さない)、frontmatter に `parent: "[[<司令塔セッションノート名>]]"` を付け、本文冒頭に親への wikilink を置く
+- **MUST NOT**: 全 worker に子ノートを作らない。記録価値で厳選する(摩擦の抽出だけで足りるものはメモリ/Issue 候補のみ)
 - **MUST**: 提示した候補のうち Issue 化を進めるものは自己更新プロトコル(`/wt` 手順7「自己更新(Self-update)」参照)に渡す。司令塔はそこでフィルター(再発しうる・タスク横断的)を適用し、対象の知見を diff 案付きの Issue として起案する
 - **MUST NOT**: この時点では `gh issue create` は実行しない(ユーザーが必要と判断したものだけ、別途 Issue 化する)
 - **MUST**: 気づきがない、または些末な場合は「知見なし」として次に進む

--- a/.config/claude/skills/wtclean/SKILL.md
+++ b/.config/claude/skills/wtclean/SKILL.md
@@ -79,7 +79,7 @@ herdr pane read <agent-pane-id> --source recent-unwrapped --lines 500
 - **MUST**: 抽出対象は作業指示テンプレートの「## 報告」内の「気づき」欄(指示外の回避策・環境の摩擦・想定外の挙動)、および permission ブロックやリトライなど、ログ上に残る摩擦の痕跡とする
 - **MUST**: workspace がすでに閉じていて pane が読めない場合はスキップし、その旨を報告に含める
 - **MUST**: 抽出した内容を worktree ごとに要約し、Issue 化する価値がありそうなものは候補としてユーザーに提示する
-- **MAY**: worker の開発過程に記録価値がある場合(非自明な設計判断・戦略が奏功した・規範文書を根拠にした境界判断など)、session-log スキルの流儀で子ノートを作成してよい。命名は `ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`(`ClaudeCodeSession-` プレフィックスを維持し .base ビューのフィルタを壊さない)、frontmatter に `parent: "[[<司令塔セッションノート名>]]"` を付け、本文冒頭に親への wikilink を置く
+- **MAY**: worker の開発過程に記録価値がある場合(非自明な設計判断・戦略が奏功した・規範文書を根拠にした境界判断など)、session-log スキルの流儀で子ノートを作成してよい。命名は `ResearchNotes/ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`(`ClaudeCodeSession-` プレフィックスを維持し .base ビューのフィルタを壊さない)、frontmatter に `parent: "[[<司令塔セッションノート名>]]"` を付け、本文冒頭に親への wikilink を置く
 - **MUST NOT**: 全 worker に子ノートを作らない。記録価値で厳選する(摩擦の抽出だけで足りるものはメモリ/Issue 候補のみ)
 - **MUST**: 提示した候補のうち Issue 化を進めるものは自己更新プロトコル(`/wt` 手順7「自己更新(Self-update)」参照)に渡す。司令塔はそこでフィルター(再発しうる・タスク横断的)を適用し、対象の知見を diff 案付きの Issue として起案する
 - **MUST NOT**: この時点では `gh issue create` は実行しない(ユーザーが必要と判断したものだけ、別途 Issue 化する)

--- a/.config/skills/session-log/SKILL.md
+++ b/.config/skills/session-log/SKILL.md
@@ -90,6 +90,14 @@ machine: <arch-native | wsl>
 - <URL、[[wikilink]] を積極的に(既存ノート名と繋ぐ)>
 ```
 
+### 親子ノート(worker セッションの供養)
+
+/wtclean の供養から worker の開発過程を昇格させる場合は子ノートとする(実例: `ResearchNotes/ClaudeCodeSession-20260710-Worker-ButtonTokenConvergence.md`):
+- 命名: `ResearchNotes/ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`
+- frontmatter に `parent: "[[親ノート名]]"` を追加し、本文冒頭の引用ブロックに親への wikilink を置く
+- 視点の分離: 親 = 司令塔(何を委任しどう判断したか)/ 子 = worker(どう作ったか)
+- デイリーノートの New Note Links には親子両方を載せる
+
 ### 3. 記録の原則
 
 - LLM 出力の羅列ではなく、「ユーザーとの対話で生まれた判断・設計・学び」を残す

--- a/.config/skills/session-log/SKILL.md
+++ b/.config/skills/session-log/SKILL.md
@@ -90,7 +90,7 @@ machine: <arch-native | wsl>
 - <URL、[[wikilink]] を積極的に(既存ノート名と繋ぐ)>
 ```
 
-### 親子ノート(worker セッションの供養)
+#### 親子ノート(worker セッションの供養)
 
 /wtclean の供養から worker の開発過程を昇格させる場合は子ノートとする(実例: `ResearchNotes/ClaudeCodeSession-20260710-Worker-ButtonTokenConvergence.md`):
 - 命名: `ResearchNotes/ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`


### PR DESCRIPTION
## 概要

Issue #400 の実装。`/wtclean` の供養（手順6）で worker の開発過程そのものに記録価値があるケースを、session-log の子ノートとして司令塔セッションノートと親子リンクで残せるようにする。

## 変更内容

1. `.config/claude/skills/wtclean/SKILL.md`（手順6「知見の回収(供養)」の Constraints）
   - **MAY**: 記録価値がある場合、命名規則 `ClaudeCodeSession-YYYYMMDD-Worker-<TopicSlug>.md`・`parent` frontmatter・親への wikilink を伴う子ノート作成を許可
   - **MUST NOT**: 全 worker に子ノートを作らない（記録価値で厳選）
2. `.config/skills/session-log/SKILL.md`（フォーマット節、手順2の後ろ）
   - 「親子ノート（worker セッションの供養）」節を追加
   - 命名・parent frontmatter と冒頭 wikilink・視点の分離（親=司令塔／子=worker）・デイリーノートには親子両方、を明記
   - 実例 `ResearchNotes/ClaudeCodeSession-20260710-Worker-ButtonTokenConvergence.md` への参照を追加

## Issue 記載パスからの読み替え

Issue #400 は 2026-07-10 起票で、その後 #405/#407（マージ済み）でスキル構成が変わったため、Issue 本文の diff パスを以下に読み替えて適用した:
- `.config/claude/commands/wtclean.md` → `.config/claude/skills/wtclean/SKILL.md`（commands/ は廃止済み）
- `.config/claude/skills/session-log/SKILL.md` → `.config/skills/session-log/SKILL.md`（共有スキル層へ移動済み。Copilot CLI からも読まれる tool-neutral な文体を踏襲）

## 確認事項

- `git diff` で追記のみ（既存行の変更・削除なし）であることを機械的に確認済み
- `mise run nix:check` 通過
- `mise run nix:build` 通過（SKILL.md は home.nix 経由でマウントされるファイルのため）

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)