### PR TITLE
ci(docs-lint): lychee の除外リストに nix.dev を追加する

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -79,8 +79,13 @@ jobs:
       # moves to a new file — anchor links must still be checked by hand.
       # nixos.org は DDoS 対策で GitHub ランナーの IP を遮断することがあり、
       # リンクが生きていても Connection failed になるため除外する。
+      # nix.dev も同じ NixOS 財団系インフラのため同様の遮断が起きる
+      # (実例: PR #411 で Connection reset by peer、リトライ5回でも回復せず)。
       # nixos.org intermittently blocks GitHub runner IPs (DDoS protection),
       # so valid links fail with "Connection failed" — exclude the domain.
+      # nix.dev shares the same NixOS Foundation infra and hits the same
+      # blocking (seen in PR #411: Connection reset by peer, unrecovered
+      # after 5 retries) — exclude it too.
       #
       # --max-retries / --retry-wait-time: GitHub 側の一時的な 5xx を
       # リトライで吸収する (実例: run 28885785093、rerun 一発で pass — #375)。
@@ -100,6 +105,7 @@ jobs:
             --no-progress
             --exclude-path result
             --exclude '^https://nixos\.org'
+            --exclude '^https://nix\.dev'
             --max-retries 5
             --retry-wait-time 5
             --accept '100..=103,200..=299,500..=599'

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -104,8 +104,8 @@ jobs:
           args: >-
             --no-progress
             --exclude-path result
-            --exclude '^https://nixos\.org'
-            --exclude '^https://nix\.dev'
+            --exclude '^https://nixos\.org(/|$)'
+            --exclude '^https://nix\.dev(/|$)'
             --max-retries 5
             --retry-wait-time 5
             --accept '100..=103,200..=299,500..=599'


### PR DESCRIPTION
## 概要
`docs-lint.yml` の Link Checker（lychee）の除外リストに `nix.dev` を追加する。

## 背景
2026-07-11、PR #411 の CI で `docs/README.md` 内の `https://nix.dev/` へのリンクチェックが `Network error: Connection reset by peer (os error 104)` で失敗した（PR は `docs/README.md` に触れておらず、無関係な flaky 失敗。failed job の再実行で通過した）。`--max-retries 5 --retry-wait-time 5` でも回復しておらず、瞬断ではなくランナー IP 遮断の可能性が高い。

既に `nixos.org` が同じ理由（DDoS 対策で GitHub ランナーの IP を遮断することがある）で除外されており、`nix.dev` は同じ NixOS 財団系インフラのため同様の対応を行う。

## 変更内容
- Link Checker の args に `--exclude '^https://nix\.dev'` を追加
- 既存の nixos.org 除外コメント（日英併記）に nix.dev への言及を追加

Closes #412