### PR TITLE
docs(skills): /wt 手順6でマージ時に --delete-branch を付けないよう明記

### DIFF
--- a/.config/claude/skills/wt/SKILL.md
+++ b/.config/claude/skills/wt/SKILL.md
@@ -288,6 +288,7 @@ gh api graphql -f query='
 - **MUST**: 未解決の review thread が0件なら、required checks の完了を待つ
 - **MUST**: 複数 PR を直列にマージする場合、1本マージするたびに残りの PR が base 更新で BEHIND に戻る玉突きを前提にループを設計する(全PRを一度に判定してから順にマージ、ではなく「1本マージ→残りのステータスを再取得→次を判定」を繰り返す)
 - **MUST NOT**: `mergeStateStatus` が `CLEAN` になる前にマージを実行しない
+- **MUST NOT**: マージ時に `--delete-branch` を付けない。worktree が生存中はローカルブランチ削除が必ず失敗して紛らわしいため、ブランチ削除(リモート含む)は `/wtclean` の領分とする
 
 ### 7. 自己更新(Self-update)
 


### PR DESCRIPTION
## 概要
Issue #398 対応。/wt 運用でのマージ時、`gh pr merge --delete-branch` が worktree 生存中は毎回ローカルブランチ削除に失敗し、紛らわしいエラー出力になっていた。

Issue の diff 案どおり、`.config/claude/skills/wt/SKILL.md` 手順6「PR のマージ世話」の Constraints に以下を1本追記した:

> **MUST NOT**: マージ時に `--delete-branch` を付けない。worktree が生存中はローカルブランチ削除が必ず失敗して紛らわしいため、ブランチ削除(リモート含む)は `/wtclean` の領分とする

## 注記(パス読み替え)
Issue 本文は対象パスを `.config/claude/commands/wt.md` と記載しているが、`commands/` は既に廃止済みのため、実際の対象は `.config/claude/skills/wt/SKILL.md` の該当箇所とした。

## スコープ外
Issue 補足にある「リモートブランチ削除の扱い(`/wtclean` 側で `git push origin --delete` するか、GitHub の Automatically delete head branches 設定に寄せるか)」は本 PR では触れない。`/wtclean` 側の将来課題とする。

## 確認
- `git diff` で今回の1行追記のみが変更されていることを確認
- `mise run nix:check` 成功
- `mise run nix:build` 成功

Closes #398