### PR TITLE
feat(desktop): Phase 3 — native Arch を Alacritty から WezTerm へ統一

### DIFF
--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -7,7 +7,7 @@ $mainMod = SUPER
 
 ### システム管理 ###
 # パッケージ管理
-bind = $mainMod SHIFT, P, exec, alacritty -e paru
+bind = $mainMod SHIFT, P, exec, wezterm start -- paru
 # 通知制御
 bind = $mainMod, N, exec, ~/.config/hypr/scripts/notifications.sh toggle
 bind = $mainMod SHIFT, N, exec, ~/.config/hypr/scripts/notifications.sh clear
@@ -17,8 +17,8 @@ bind = $mainMod SHIFT, V, exec, cliphist list | wofi --dmenu | cliphist decode |
 # bind = $mainMod, M, exec, alacritty -e btm
 
 ### アプリケーションの起動 ###
-# ターミナル（Alacritty）
-bind = $mainMod, RETURN, exec, alacritty
+# ターミナル（WezTerm）
+bind = $mainMod, RETURN, exec, wezterm
 # ブラウザ（Vivaldi）
 bind = $mainMod, I, exec, vivaldi-stable
 # ファイルマネージャー（Nautilus）

--- a/.config/hypr/window-rules.conf
+++ b/.config/hypr/window-rules.conf
@@ -60,6 +60,7 @@ windowrule = match:class ^(slack)$, opacity 0.9 0.9
 windowrule = match:class ^(spotify)$, opacity 0.9 0.9
 windowrule = match:class ^(Emacs)$, opacity 0.95 0.95
 windowrule = match:class ^(neovide)$, opacity 0.95 0.95
+# WezTerm が native Arch のメインターミナル（Phase 3, #393）。Alacritty ルールは併存期間中のフォールバックとして残す
 windowrule = match:class ^(org.wezfurlong.wezterm)$, opacity 0.9 0.9
 # NOTE: Alacritty のクラス名は大文字始まり（正規表現は大文字小文字を区別する）
 windowrule = match:class ^(Alacritty)$, opacity 0.9 0.9

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -183,7 +183,7 @@ nix/modules/
 ├── neovim.nix      # Neovim + LSP + formatters
 ├── dev-tools.nix   # 開発ツール（docker, kubectl, awscli）
 ├── fonts.nix       # フォント
-├── desktop.nix     # GUI 設定群（hypr, waybar, alacritty 等）— native profile のみ
+├── desktop.nix     # GUI 設定群（hypr, waybar, wezterm, alacritty 等）— native profile のみ
 └── wsl.nix         # WSL 固有（Obsidian vault symlink, WezTerm/Alacritty 配布）— wsl profile のみ
 ```
 
@@ -222,8 +222,10 @@ Windows 側へ配布する成果物として扱う（`nix/modules/wsl.nix`）。
 WezTerm は `conpty.dll` / `OpenConsole.exe` を同梱し ConPTY 実装を自前で持つため
 この問題を踏まない。原則（ピクセルは host）はそのままに emulator だけを替える最小修正。
 設定は `wezterm.lua` 1枚が両マシン共通の真実（Lua の実行時 OS 分岐が Alacritty 時代の
-base + windows.toml ビルド時マージを置き換え）。Windows 版 Alacritty は併存期間中
-フォールバックとして設定配布を維持する。
+base + windows.toml ビルド時マージを置き換え）。Windows 側での安定運用確認を経て、
+native Arch (Hyprland) のメインターミナルも Alacritty から WezTerm へ統一した
+（Phase 3, [#393](https://github.com/music-brain88/dotfiles/issues/393)）。
+Alacritty は両マシンとも併存期間中フォールバックとして設定配布を維持する。
 
 ### profile の構造
 

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -63,7 +63,8 @@ dotfiles/
 | `bash/` | Bash 設定 (bashrc, bash_profile) - Fish へのブートストラップ用 |
 | `fish/` | Fish shell 設定 (config.fish, functions/, conf.d/) |
 | `tmux/` | Tmux 設定 (tmux.conf) |
-| `alacritty/` | Alacritty ターミナル設定 |
+| `wezterm/` | WezTerm ターミナル設定 (`wezterm.lua`、native Arch と Windows で共通)。native Arch のメインターミナル(Phase 3, #393) |
+| `alacritty/` | Alacritty ターミナル設定 (併存期間中のフォールバック) |
 | `starship/` | Starship プロンプト設定 |
 
 ### Editor
@@ -130,8 +131,8 @@ Home Manager の設定をモジュール化。
 | `neovim.nix` | Neovim + LSP + formatters |
 | `dev-tools.nix` | 開発ツール (Docker, AWS CLI, kubectl, etc.) |
 | `fonts.nix` | フォント |
-| `desktop.nix` | GUI 設定群 (hypr, waybar, alacritty, wofi, mako, mpd, ncmpcpp, fontconfig) — native profile のみ |
-| `wsl.nix` | WSL 固有: Obsidian vault symlink と Windows 側 Alacritty 設定の配布 — wsl profile のみ |
+| `desktop.nix` | GUI 設定群 (hypr, waybar, wezterm, alacritty, wofi, mako, mpd, ncmpcpp, fontconfig) — native profile のみ |
+| `wsl.nix` | WSL 固有: Obsidian vault symlink と Windows 側 WezTerm/Alacritty 設定の配布 — wsl profile のみ |
 
 profile 分割の設計意図は [architecture.md の Per-Host Profiles](../explanation/architecture.md#per-host-profiles) を参照。
 

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -242,7 +242,7 @@ Hyprlandの設定は `.config/hypr/keybinds.conf` で定義されています。
 
 | Keybind | Description | 説明 |
 |---------|-------------|------|
-| `Super + Enter` | Open terminal (Alacritty) | ターミナルを開く |
+| `Super + Enter` | Open terminal (WezTerm) | ターミナルを開く |
 | `Super + D` | Application launcher (Wofi) | アプリランチャー |
 | `Super + Space` | Application launcher (Wofi) | アプリランチャー（代替） |
 | `Super + I` | Open browser (Vivaldi) | ブラウザを開く |

--- a/home.nix
+++ b/home.nix
@@ -34,7 +34,7 @@
     EDITOR = "nvim";
     VISUAL = "nvim";
     BROWSER = "firefox";
-    TERMINAL = "alacritty";
+    TERMINAL = "wezterm";
     # SSL certificates (use system certs instead of Nix store)
     SSL_CERT_DIR = "/etc/ssl/certs";
     SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt";

--- a/nix/modules/desktop.nix
+++ b/nix/modules/desktop.nix
@@ -22,10 +22,17 @@
       recursive = true;
     };
 
-    # Alacritty config (WSL では Windows 側 Alacritty に配布する。nix/modules/wsl.nix 参照)
-    # Alacritty config (on WSL this is deployed to the Windows side; see nix/modules/wsl.nix)
+    # Alacritty config (併存期間中のフォールバック。WSL では Windows 側 Alacritty に配布する。nix/modules/wsl.nix 参照)
+    # Alacritty config (fallback during the WezTerm migration; on WSL this is deployed to the Windows side, see nix/modules/wsl.nix)
     ".config/alacritty" = {
       source = ../../.config/alacritty;
+      recursive = true;
+    };
+
+    # WezTerm config (native Arch のメインターミナル。wezterm.lua は両マシン共通の真実、Windows 側は wsl.nix が配布)
+    # WezTerm config (primary terminal on native Arch; wezterm.lua is the single source of truth shared with Windows, distributed there by wsl.nix)
+    ".config/wezterm" = {
+      source = ../../.config/wezterm;
       recursive = true;
     };
 


### PR DESCRIPTION
## 概要

Issue #393 の Phase 3。Windows 側 (PR #389) での安定運用確認を経て、native Arch (Hyprland) のメインターミナルも Alacritty から WezTerm へ移行する。`wezterm.lua` 1枚が両マシン共通の真実になる。

## 変更内容

- `nix/modules/desktop.nix`: `.config/wezterm` の symlink を追加（既存の recursive ディレクトリパターンに合わせた）
- `.config/hypr/keybinds.conf`:
  - `Super+Enter`（ターミナル起動）: `alacritty` → `wezterm`
  - `Super+Shift+P`（paru 起動）: `alacritty -e paru` → `wezterm start -- paru`
- `.config/hypr/window-rules.conf`: `org.wezfurlong.wezterm` の opacity ルールは Wayland 移行時 (#172) から既に Alacritty と併記済みだったため、移行の由来がわかるようコメントのみ補足。ルール自体の変更なし
- `home.nix`: `TERMINAL` 環境変数を `alacritty` → `wezterm`
- Alacritty は両マシンとも併存期間中のフォールバックとして設定配布を維持（削除しない）
- docs 更新: `architecture.md` / `directory-structure.md` / `keybindings.md` に Phase 3 実施を反映

## 事前調査で確認したこと

- `wezterm.lua` に `window_decorations` や `enable_wayland` のカスタムはなく、Wayland ネイティブ実行時のデフォルト app_id `org.wezfurlong.wezterm` がそのまま使える
- `window-rules.conf` の wezterm 向け opacity ルールは今回新規追加ではなく、Wayland 移行コミット (4b16334, #172) の時点で既に存在していた。今回は Alacritty ルールとの併存関係を明示するコメントを添えただけ

## マージ前に必要な作業

**このリポジトリのスコープ外だが、マージ前に native Arch 機で `pacman -S wezterm` の実行が必要**（`pacman -Q wezterm` で未導入を確認済み。WezTerm は Nix ではなく pacman 管理のパッケージ）。

## 検証

- [x] `mise run nix:check` — pass
- [x] `mise run nix:build` — pass（`result/home-files/.config/wezterm/wezterm.lua` が正しく symlink されることを確認済み）
- [ ] 実機確認（マージ後、司令塔とユーザーが実施）

## マージ後の実機確認手順

1. `pacman -S wezterm`（未導入の場合）
2. `mise run nix:switch`
3. Hyprland をリロード（`hyprctl reload`、または Hyprland セッションを再ログイン）
4. `Super+Enter` で WezTerm が起動すること、fish + herdr が自動起動すること
5. `Super+Shift+P` で WezTerm 上に paru が起動すること
6. WezTerm ウィンドウに opacity 0.9 が適用されていること（window-rules.conf の透過設定）

## スコープ外（別タスク）

Issue #393 の最終項目「Windows 版 Alacritty フォールバックの引退」（`windows.toml` + `wsl.nix` のマージ・配布機構の削除）は、native/Windows 双方の移行完了確認後の別タスクとして扱う。

Closes #393