### PR TITLE
fix(fonts): 絵文字フォント noto-fonts-color-emoji を追加

### DIFF
--- a/nix/modules/fonts.nix
+++ b/nix/modules/fonts.nix
@@ -11,5 +11,9 @@
 
     # System UI font (serif) - for documents and reading
     source-han-serif
+
+    # Color emoji font - fallback for emoji glyphs in terminal and desktop
+    # 絵文字フォールバック用 (WezTerm の確認オーバーレイ 🛑 等が豆腐になるのを防ぐ)
+    noto-fonts-color-emoji
   ];
 }


### PR DESCRIPTION
## [optional body]
WezTerm で `Alt+F4` (Hyprland `killactive`) を押すたびに missing glyph 警告
(`No fonts contain glyphs for these codepoints: \u{1f6d1}`) が出ていた。

原因は、閉じる確認オーバーレイ(`window_close_confirmation = "AlwaysPrompt"` 既定)に
含まれる 🛑 (U+1F6D1) を描画できないこと:

- `HackGen35 Console NF` は絵文字グリフを持たない
- システムに絵文字フォントが1つも入っておらず(`fc-list | grep -i emoji` が空)、
  WezTerm の fontconfig フォールバックも失敗していた

`nix/modules/fonts.nix` の `home.packages` に `noto-fonts-color-emoji` を追加して、
🛑 を含む絵文字全般がカラー表示されるようにする。Claude Code 等の絵文字を出す
CLI の豆腐表示も同時に解消される。

検証:
- `mise run nix:build` が成功、`noto-fonts-color-emoji-2.051` がクロージャに含まれることを確認

## [optional footer(s)]
Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)