### PR TITLE
refactor(labels): align taxonomy with conventional commits

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,83 +12,108 @@ template: |
 categories:
   - title: '🚀 Features'
     labels:
-      - 'feature'
-      - 'enhancement'
+      - 'feat'
     collapse-after: 10
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
-      - 'bugfix'
-      - 'bug'
     collapse-after: 10
+  - title: '⚡ Performance'
+    labels:
+      - 'perf'
+    collapse-after: 5
   - title: '🔧 Refactoring'
     labels:
       - 'refactor'
-      - 'refactoring'
     collapse-after: 5
   - title: '📚 Documentation'
     labels:
-      - 'documentation'
       - 'docs'
+    collapse-after: 5
+  - title: '🧪 Tests'
+    labels:
+      - 'test'
+    collapse-after: 5
+  - title: '🏗️ Build'
+    labels:
+      - 'build'
     collapse-after: 5
   - title: '🔨 CI/CD'
     labels:
       - 'ci'
-      - 'ci/cd'
+    collapse-after: 5
+  - title: '🎨 Styles'
+    labels:
+      - 'style'
     collapse-after: 5
   - title: '🧹 Chores'
     labels:
       - 'chore'
-      - 'maintenance'
+    collapse-after: 5
+  - title: '⏪ Reverts'
+    labels:
+      - 'revert'
     collapse-after: 5
 
 # Auto-label PRs based on title patterns (conventional commits)
 autolabeler:
-  - label: 'feature'
+  - label: 'feat'
     title:
-      - '/^feat(\(.+\))?:/i'
-      - '/^Feat\//i'
-      - '/^Feature\//i'
+      - '/^feat(?:\([^)]+\))?!?:/i'
   - label: 'fix'
     title:
-      - '/^fix(\(.+\))?:/i'
-      - '/^Fix\//i'
+      - '/^fix(?:\([^)]+\))?!?:/i'
+  - label: 'perf'
+    title:
+      - '/^perf(?:\([^)]+\))?!?:/i'
   - label: 'docs'
     title:
-      - '/^docs(\(.+\))?:/i'
-      - '/^Docs\//i'
+      - '/^docs(?:\([^)]+\))?!?:/i'
   - label: 'refactor'
     title:
-      - '/^refactor(\(.+\))?:/i'
-      - '/^Refactor\//i'
+      - '/^refactor(?:\([^)]+\))?!?:/i'
+  - label: 'test'
+    title:
+      - '/^test(?:\([^)]+\))?!?:/i'
+  - label: 'build'
+    title:
+      - '/^build(?:\([^)]+\))?!?:/i'
   - label: 'ci'
     title:
-      - '/^ci(\(.+\))?:/i'
-      - '/^CI\//i'
+      - '/^ci(?:\([^)]+\))?!?:/i'
   - label: 'chore'
     title:
-      - '/^chore(\(.+\))?:/i'
-      - '/^Chore\//i'
-      - '/^Backup\//i'
+      - '/^chore(?:\([^)]+\))?!?:/i'
+  - label: 'style'
+    title:
+      - '/^style(?:\([^)]+\))?!?:/i'
+  - label: 'revert'
+    title:
+      - '/^revert(?:\([^)]+\))?!?:/i'
+  - label: 'breaking'
+    title:
+      - '/^(?:feat|fix|perf|docs|refactor|test|build|ci|chore|style|revert)(?:\([^)]+\))?!:/i'
 
 # Version resolver based on labels
 version-resolver:
   major:
     labels:
-      - 'major'
       - 'breaking'
   minor:
     labels:
-      - 'feature'
-      - 'enhancement'
+      - 'feat'
   patch:
     labels:
       - 'fix'
-      - 'bugfix'
+      - 'perf'
       - 'docs'
-      - 'chore'
       - 'refactor'
+      - 'test'
+      - 'build'
       - 'ci'
+      - 'chore'
+      - 'style'
+      - 'revert'
   default: patch
 
 exclude-labels:


### PR DESCRIPTION
## [optional body]

- Release Drafter のカテゴリ・自動ラベル・バージョン判定を Conventional Commits の型へ統一
- `perf` / `test` / `build` / `style` / `revert` を含む全型を分類対象に追加
- `type(scope)!:` 形式を認識し、`breaking` ラベルで major version を判定
- 全 Issue/PR には新ラベルを併記済み。旧ラベルはこの設定が main に反映された後で削除する

## [optional footer(s)]

Refs #378