### PR TITLE
feat(waybar): Bring型の計器盤 — 借用中の参照ウィンドウを custom/bring で表示

### DIFF
--- a/.config/hypr/scripts/bring_window.sh
+++ b/.config/hypr/scripts/bring_window.sh
@@ -53,6 +53,16 @@ case "$mode" in
     # special workspace 上から実行される場合もあるため id ではなく name を使う
     # Use name, not id, since this may run from a (named) special workspace
     active_ws="$(hyprctl activeworkspace -j | jq -r '.name')"
+    # 計器盤(Waybar custom/bring #422)用に「何をどこから借りたか」を記録する。
+    # 移動の dispatch より先に書くことで、socket2 の movewindow イベントが
+    # 購読側に届いた時点で状態ファイルが確定していることを保証する。
+    # Record what was borrowed and from where, for the Waybar gauge (#422).
+    # Written *before* dispatching the move so the state file is already
+    # settled when the movewindow event reaches the socket2 subscriber.
+    hyprctl clients -j | jq -c --arg addr "$address" --arg dest "$active_ws" '
+      .[] | select(.address == $addr) |
+      {address, class, title, origin_ws: .workspace.name, dest_ws: $dest}
+    ' > "${XDG_RUNTIME_DIR:-/tmp}/bring_state.json"
     hyprctl dispatch movetoworkspacesilent "${active_ws},address:${address}"
     hyprctl dispatch focuswindow "address:${address}"
     ;;

--- a/.config/hypr/scripts/bring_window.sh
+++ b/.config/hypr/scripts/bring_window.sh
@@ -59,10 +59,16 @@ case "$mode" in
     # Record what was borrowed and from where, for the Waybar gauge (#422).
     # Written *before* dispatching the move so the state file is already
     # settled when the movewindow event reaches the socket2 subscriber.
+    # temp + mv で書き込みをアトミックにする(同一ディレクトリ内の rename は
+    # アトミックなので、読み手が書きかけの JSON を観測することがない)
+    # Write via temp + mv so the update is atomic (same-directory rename),
+    # ensuring readers never observe a truncated JSON file.
+    state_file="${XDG_RUNTIME_DIR:-/tmp}/bring_state.json"
     hyprctl clients -j | jq -c --arg addr "$address" --arg dest "$active_ws" '
       .[] | select(.address == $addr) |
       {address, class, title, origin_ws: .workspace.name, dest_ws: $dest}
-    ' > "${XDG_RUNTIME_DIR:-/tmp}/bring_state.json"
+    ' > "${state_file}.tmp"
+    mv "${state_file}.tmp" "$state_file"
     hyprctl dispatch movetoworkspacesilent "${active_ws},address:${address}"
     hyprctl dispatch focuswindow "address:${address}"
     ;;

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -8,7 +8,8 @@
     "modules-left": [
         "hyprland/workspaces",
         "hyprland/submap",
-        "hyprland/window"
+        "hyprland/window",
+        "custom/bring"
     ],
     "modules-center": [
         "clock",
@@ -71,6 +72,20 @@
         "format": " {}",
         "max-length": 50,
         "separate-outputs": true
+    },
+
+    // Bring 型の計器盤(#422): bring_window.sh(Super+Y)で借りている参照ウィンドウを表示。
+    // 常駐スクリプトが Hyprland socket2 を購読して随時1行出力する(interval なし)。
+    // 操作はここに持たせない — 表示のみ(操作系は Super+Y / Super+Shift+Y のまま)。
+    // Bring-style gauge (#422): shows the reference window borrowed via Super+Y.
+    // The long-running script subscribes to Hyprland socket2 and streams JSON lines
+    // (no interval). Display only; control stays on the Super+Y keybinds.
+    "custom/bring": {
+        "format": "{}",
+        "return-type": "json",
+        "max-length": 45,
+        "exec": "~/.config/waybar/scripts/bring_status.sh",
+        "escape": true
     },
 
     "hyprland/language": {

--- a/.config/waybar/scripts/bring_status.sh
+++ b/.config/waybar/scripts/bring_status.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Waybar 計器盤モジュール custom/bring (#422)
+# bring_window.sh(Super+Y)が記録した「現在の参照ウィンドウ」を表示する常駐スクリプト。
+# Hyprland socket2 のイベント購読で駆動し、窓の移動・クローズの瞬間に表示を更新する
+# (ポーリングなし)。操作系は一切持たない — Waybar は状態表示のみ(Bring 型の計器盤)。
+# Waybar gauge module custom/bring (#422): long-running script that displays the
+# "current reference window" recorded by bring_window.sh (Super+Y). Driven by
+# Hyprland socket2 event subscription — updates the instant a window moves or
+# closes, no polling. Display only; all control stays on Super+Y (Bring-style).
+
+set -euo pipefail
+
+state_file="${XDG_RUNTIME_DIR:-/tmp}/bring_state.json"
+sock="${XDG_RUNTIME_DIR}/hypr/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock"
+
+# グリフは raw で書かず ANSI-C の \uXXXX エスケープで書く(不可視文字の罠 — PR #366)
+# Write the glyph as an ANSI-C \uXXXX escape, never raw (invisible-char trap, PR #366)
+icon=$'\uf0c6' # nf-fa-paperclip
+
+# Waybar の return-type: json 形式で1行出力する(text が空だとモジュール非表示)
+# Emit one line in Waybar's return-type: json format (empty text hides the module)
+emit_json() {
+  jq -cn --arg text "$1" --arg tooltip "$2" --arg class "$3" \
+    '{text: $text, tooltip: $tooltip, class: $class}'
+}
+
+# 状態ファイルと実際のウィンドウ一覧を突き合わせて、計器盤の表示を1回分出力する
+# Cross-check the state file against the live window list and emit one reading
+emit() {
+  # まだ何も借りていない(状態ファイルなし/空) → 非表示
+  # Nothing borrowed yet (state file absent/empty) -> hide the module
+  if [ ! -s "$state_file" ]; then
+    emit_json "" "" ""
+    return
+  fi
+
+  local address class title origin_ws dest_ws cur_ws
+  address="$(jq -r '.address' "$state_file")"
+  class="$(jq -r '.class' "$state_file")"
+  title="$(jq -r '.title' "$state_file")"
+  origin_ws="$(jq -r '.origin_ws' "$state_file")"
+  dest_ws="$(jq -r '.dest_ws' "$state_file")"
+
+  # 参照ウィンドウの現在地(閉じられていたら空文字になる)。
+  # hyprctl の一時的な失敗で常駐スクリプトごと死なないよう失敗は空扱いにする
+  # (set -e 下では $() 内の失敗も伝播するため)。
+  # Where the reference window is right now (empty string if it was closed).
+  # Treat hyprctl failures as empty so a transient error can't kill the gauge
+  # (under set -e, failures inside $() propagate to the assignment).
+  cur_ws="$(hyprctl clients -j 2>/dev/null | jq -r --arg addr "$address" '
+    .[] | select(.address == $addr) | .workspace.name
+  ' || true)"
+
+  # 判定は3状態: 閉じられた=非表示 / 借り先にいる=active / よそへ移動した=stray
+  # tooltip は貸出カード形式で「誰を・どこから借りたか」を出す
+  # Three states: closed = hidden / at the borrow destination = active /
+  # wandered off elsewhere = stray. Tooltip reads like a lending card.
+  if [ -z "$cur_ws" ]; then
+    # 参照ウィンドウが閉じられた → 非表示
+    emit_json "" "" ""
+  elif [ "$cur_ws" = "$dest_ws" ]; then
+    # 参照ウィンドウが借り先にいる → active
+    emit_json "$icon $title" "$class ← ws:$origin_ws" "active"
+  else
+    # 参照ウィンドウがよそ(借り元含む)へ移動した → stray
+    emit_json "$icon $title" "$class ← ws:$origin_ws(今は ws:$cur_ws)" "stray"
+  fi
+}
+
+# 起動直後に現在値を1回出す(Waybar 再起動時に前回の状態を復元するため)
+# Emit once at startup so a Waybar restart restores the current reading
+emit
+
+# socket2 を購読し、計器盤に関係するイベントの時だけ再評価する。
+# nc は libressl 版(dev-tools.nix の netcat)。-U: unix socket、-d: stdin を読まない。
+# Subscribe to socket2 and re-evaluate only on events that can change the gauge.
+# nc is the libressl flavor (netcat in dev-tools.nix); -U unix socket, -d no stdin.
+nc -Ud "$sock" | while IFS= read -r line; do
+  case "$line" in
+    movewindow*|closewindow*|workspace*) emit ;;
+  esac
+done

--- a/.config/waybar/scripts/bring_status.sh
+++ b/.config/waybar/scripts/bring_status.sh
@@ -12,7 +12,11 @@
 set -euo pipefail
 
 state_file="${XDG_RUNTIME_DIR:-/tmp}/bring_state.json"
-sock="${XDG_RUNTIME_DIR}/hypr/${HYPRLAND_INSTANCE_SIGNATURE}/.socket2.sock"
+# set -u 下でも Hyprland セッション外(env 欠落)で即死しないようデフォルトを与える。
+# ソケット実在チェックは下の起動ガード参照。
+# Default the vars so `set -u` doesn't kill us outside a Hyprland session;
+# the socket existence guard below handles the rest.
+sock="${XDG_RUNTIME_DIR:-/tmp}/hypr/${HYPRLAND_INSTANCE_SIGNATURE:-}/.socket2.sock"
 
 # グリフは raw で書かず ANSI-C の \uXXXX エスケープで書く(不可視文字の罠 — PR #366)
 # Write the glyph as an ANSI-C \uXXXX escape, never raw (invisible-char trap, PR #366)
@@ -35,12 +39,22 @@ emit() {
     return
   fi
 
-  local address class title origin_ws dest_ws cur_ws
-  address="$(jq -r '.address' "$state_file")"
-  class="$(jq -r '.class' "$state_file")"
-  title="$(jq -r '.title' "$state_file")"
-  origin_ws="$(jq -r '.origin_ws' "$state_file")"
-  dest_ws="$(jq -r '.dest_ws' "$state_file")"
+  local state address class title origin_ws dest_ws cur_ws
+
+  # 壊れた・書きかけの状態ファイルは「未借用」と同じ扱いにする
+  # (パース失敗で set -e が常駐スクリプトごと落とすのを防ぐ)
+  # Treat a corrupt/partial state file the same as "nothing borrowed"
+  # (so a parse failure can't take down the resident gauge via set -e)
+  if ! state="$(jq -c . "$state_file" 2>/dev/null)"; then
+    emit_json "" "" ""
+    return
+  fi
+
+  address="$(jq -r '.address' <<<"$state")"
+  class="$(jq -r '.class' <<<"$state")"
+  title="$(jq -r '.title' <<<"$state")"
+  origin_ws="$(jq -r '.origin_ws' <<<"$state")"
+  dest_ws="$(jq -r '.dest_ws' <<<"$state")"
 
   # 参照ウィンドウの現在地(閉じられていたら空文字になる)。
   # hyprctl の一時的な失敗で常駐スクリプトごと死なないよう失敗は空扱いにする
@@ -67,6 +81,15 @@ emit() {
     emit_json "$icon $title" "$class ← ws:$origin_ws(今は ws:$cur_ws)" "stray"
   fi
 }
+
+# 起動ガード: Hyprland セッション外(ソケット不在)では計器盤を非表示にして正常終了。
+# クラッシュ扱いにせず、単に「表示するものがない」として振る舞う。
+# Startup guard: outside a Hyprland session (no socket), hide the gauge and exit
+# cleanly — behave as "nothing to display" rather than crashing.
+if [ ! -S "$sock" ]; then
+  emit_json "" "" ""
+  exit 0
+fi
 
 # 起動直後に現在値を1回出す(Waybar 再起動時に前回の状態を復元するため)
 # Emit once at startup so a Waybar restart restores the current reading

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -211,3 +211,23 @@ window#waybar.hidden {
     border-radius: 10px;
     background: #1e1e2e;
 }
+
+/* Bring 計器盤: いま借りている参照ウィンドウ (#422) */
+/* Bring gauge: the reference window currently borrowed (#422) */
+#custom-bring {
+    padding: 0 10px;
+    margin: 5px 0;
+    background: #1e1e2e;
+    border-radius: 10px;
+    color: #cdd6f4;
+}
+
+/* 参照が手元(借りてきた先の ws)にいる / reference is still at hand */
+#custom-bring.active {
+    color: #a6e3a1;
+}
+
+/* 参照がよそへ移動した・迷子 / reference wandered off elsewhere */
+#custom-bring.stray {
+    color: #6c7086;
+}


### PR DESCRIPTION
## [optional body]

Waybar を Bring 型ワークフローの計器盤にする(操作は既存の Super+Y のまま、Waybar は状態表示のみ)。

### 変更内容
- **`bring_window.sh`**: bring 成功時に「何をどこから借りたか」(address / class / title / origin_ws / dest_ws)を `$XDG_RUNTIME_DIR/bring_state.json` に記録。移動 dispatch より**先**に書くことで socket2 イベント到達時点の状態確定を保証(レース回避)
- **`waybar/scripts/bring_status.sh`(新規)**: Hyprland socket2 を `nc -U`(libressl 版、dev-tools.nix 宣言済み → 追加パッケージなし)で購読する常駐スクリプト。movewindow / closewindow / workspace イベントのたびに状態ファイルと `hyprctl clients` を突き合わせて再評価。ポーリングなし
- **`config.jsonc`**: `custom/bring` モジュールを modules-left に追加(常駐 exec、interval なし)
- **`style.css`**: `#custom-bring` の状態別スタイル

### 表示の3状態
| 状態 | 表示 |
|------|------|
| 参照が借り先 ws にいる | `active`(緑)`<icon> <title>`、tooltip は貸出カード `class ← ws:借り元` |
| 参照がよそへ移動 | `stray`(灰)tooltip に現在地を併記(戻し忘れの可視化) |
| 参照が閉じられた / 未借用 | モジュール非表示 |

### 検証
- `bash -n` 構文チェック、JSONC は jq で構文検証
- ライブセッションで `emit()` を4ケース(未借用 / 閉窓 / active / stray)スモークテスト済み(読み取りのみ、dispatch なし)
- socket2 イベントループの実地確認は未実施(ウィンドウ操作を伴うため)。`mise run nix:switch` 後に Super+Y で実地確認を推奨
- Nerd Font グリフは raw 直書きせず ANSI-C `\uXXXX` エスケープで記述し hex dump 検証済み(PR #366 の罠回避)

## [optional footer(s)]

Closes #422
Refs #346 (Bring/Go 型ウィンドウピッカー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF8GX12s7zRRN9pGKgDBXs