### PR TITLE
feat(claude): Claude Code hooks 起点のエージェント状態トースト通知

### DIFF
--- a/.config/claude/scripts/agent_toast.sh
+++ b/.config/claude/scripts/agent_toast.sh
@@ -25,7 +25,7 @@ if command -v jq >/dev/null 2>&1 && [ -n "$hook_json" ]; then
   message="$(printf '%s' "$hook_json" | jq -r '.message // empty' 2>/dev/null || true)"
 fi
 
-cwd_base="$(basename "$PWD" 2>/dev/null || true)"
+cwd_base="$(basename "${PWD:-$(pwd)}" 2>/dev/null || true)"
 pane_id="${HERDR_PANE_ID:-}"
 
 case "$event" in
@@ -59,9 +59,10 @@ if [ -n "${WAYLAND_DISPLAY:-}" ]; then
   fi
 fi
 
-# WSL2 環境: OSC 9 エスケープを /dev/tty へ(未検証経路)
-# WSL2: OSC 9 escape sequence to /dev/tty (UNVERIFIED path — no WSL test rig
-# available at implementation time). Silently give up if /dev/tty can't be opened.
+# WSL2 環境: OSC 777 notify エスケープを /dev/tty へ(未検証経路)
+# WSL2: OSC 777 notify escape sequence to /dev/tty (UNVERIFIED path — no WSL
+# test rig available at implementation time). Silently give up if /dev/tty
+# can't be opened.
 is_wsl=0
 if [ -n "${WSL_DISTRO_NAME:-}" ]; then
   is_wsl=1
@@ -69,7 +70,15 @@ elif grep -qi microsoft /proc/version 2>/dev/null; then
   is_wsl=1
 fi
 if [ "$is_wsl" -eq 1 ]; then
-  { printf '\033]9;%s\007' "$title: $body" > /dev/tty; } 2>/dev/null || true
+  # エスケープシーケンス注入対策: title/body に制御文字(\000-\037, \177)が
+  # 混入していると端末側で意図しないシーケンスとして解釈されうるため、
+  # /dev/tty へ書く前に tr で除去する。
+  # Security: title/body may contain control characters (\000-\037, \177)
+  # that the terminal could interpret as injected escape sequences, so strip
+  # them with tr before writing to /dev/tty.
+  safe_title="$(printf '%s' "$title" | tr -d '\000-\037\177' || true)"
+  safe_body="$(printf '%s' "$body" | tr -d '\000-\037\177' || true)"
+  { printf '\033]777;notify;%s;%s\033\\' "$safe_title" "$safe_body" > /dev/tty; } 2>/dev/null || true
 fi
 
 # herdr 内なら画面内通知も併発(コアの通知経路とは独立、失敗しても無視)

--- a/.config/claude/scripts/agent_toast.sh
+++ b/.config/claude/scripts/agent_toast.sh
@@ -54,7 +54,9 @@ fi
 # Wayland 環境: notify-send 経由で通知デーモン(mako 等)に出す
 # Wayland: notify-send to the running notification daemon (mako).
 if [ -n "${WAYLAND_DISPLAY:-}" ]; then
-  command -v notify-send >/dev/null 2>&1 && notify-send "$title" "$body" || true
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "$title" "$body" || true
+  fi
 fi
 
 # WSL2 環境: OSC 9 エスケープを /dev/tty へ(未検証経路)
@@ -73,7 +75,9 @@ fi
 # herdr 内なら画面内通知も併発(コアの通知経路とは独立、失敗しても無視)
 # Inside herdr, also fire its in-app notification — best-effort, never fatal.
 if [ "${HERDR_ENV:-}" = "1" ]; then
-  command -v herdr >/dev/null 2>&1 && herdr notification show "$title" --sound "$sound" >/dev/null 2>&1 || true
+  if command -v herdr >/dev/null 2>&1; then
+    herdr notification show "$title" --sound "$sound" >/dev/null 2>&1 || true
+  fi
 fi
 
 exit 0

--- a/.config/claude/scripts/agent_toast.sh
+++ b/.config/claude/scripts/agent_toast.sh
@@ -78,7 +78,7 @@ if [ "$is_wsl" -eq 1 ]; then
   # them with tr before writing to /dev/tty.
   safe_title="$(printf '%s' "$title" | tr -d '\000-\037\177' || true)"
   safe_body="$(printf '%s' "$body" | tr -d '\000-\037\177' || true)"
-  { printf '\033]777;notify;%s;%s\033\\' "$safe_title" "$safe_body" > /dev/tty; } 2>/dev/null || true
+  { printf '\033]777;notify;%s;%s\007' "$safe_title" "$safe_body" > /dev/tty; } 2>/dev/null || true
 fi
 
 # herdr 内なら画面内通知も併発(コアの通知経路とは独立、失敗しても無視)

--- a/.config/claude/scripts/agent_toast.sh
+++ b/.config/claude/scripts/agent_toast.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# agent_toast.sh - Claude Code hook からエージェント状態の OS トースト通知を出す
+# Fires an OS toast notification from Claude Code hooks (Notification / Stop).
+#
+# Usage: agent_toast.sh <notification|stop>
+# stdin: hook が渡す JSON (message フィールド等を含む、任意)
+#
+# 設計方針: hook はエージェント本体を絶対にブロックしない。
+# 各行 fail-silent (`|| true`) を徹底しつつ set -euo pipefail と両立させる。
+# Design: this hook must never block the agent. Every external/fallible call
+# ends in `|| true` so the composite exit status stays 0 even under `set -e`.
+set -euo pipefail
+
+event="${1:-}"
+
+# stdin の hook JSON を読む(パイプが無ければ待たずにスキップ)
+# Read hook JSON from stdin, skipping without blocking when nothing is piped.
+hook_json=""
+if [ ! -t 0 ]; then
+  hook_json="$(cat || true)"
+fi
+
+message=""
+if command -v jq >/dev/null 2>&1 && [ -n "$hook_json" ]; then
+  message="$(printf '%s' "$hook_json" | jq -r '.message // empty' 2>/dev/null || true)"
+fi
+
+cwd_base="$(basename "$PWD" 2>/dev/null || true)"
+pane_id="${HERDR_PANE_ID:-}"
+
+case "$event" in
+  notification)
+    title="Claude: 承認待ち"
+    sound="request"
+    ;;
+  stop)
+    title="Claude: 完了"
+    sound="done"
+    ;;
+  *)
+    title="Claude"
+    sound="done"
+    ;;
+esac
+
+body="$cwd_base"
+if [ -n "$pane_id" ]; then
+  body="$body (pane: $pane_id)"
+fi
+if [ -n "$message" ]; then
+  body="$body — $message"
+fi
+
+# Wayland 環境: notify-send 経由で通知デーモン(mako 等)に出す
+# Wayland: notify-send to the running notification daemon (mako).
+if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+  command -v notify-send >/dev/null 2>&1 && notify-send "$title" "$body" || true
+fi
+
+# WSL2 環境: OSC 9 エスケープを /dev/tty へ(未検証経路)
+# WSL2: OSC 9 escape sequence to /dev/tty (UNVERIFIED path — no WSL test rig
+# available at implementation time). Silently give up if /dev/tty can't be opened.
+is_wsl=0
+if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+  is_wsl=1
+elif grep -qi microsoft /proc/version 2>/dev/null; then
+  is_wsl=1
+fi
+if [ "$is_wsl" -eq 1 ]; then
+  { printf '\033]9;%s\007' "$title: $body" > /dev/tty; } 2>/dev/null || true
+fi
+
+# herdr 内なら画面内通知も併発(コアの通知経路とは独立、失敗しても無視)
+# Inside herdr, also fire its in-app notification — best-effort, never fatal.
+if [ "${HERDR_ENV:-}" = "1" ]; then
+  command -v herdr >/dev/null 2>&1 && herdr notification show "$title" --sound "$sound" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -10,5 +10,27 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/agent_toast.sh notification"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/scripts/agent_toast.sh stop"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/agent_toast.sh notification"
+            "command": "bash $HOME/.claude/scripts/agent_toast.sh notification"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/agent_toast.sh stop"
+            "command": "bash $HOME/.claude/scripts/agent_toast.sh stop"
           }
         ]
       }


### PR DESCRIPTION
## 概要

Claude Code の hooks(`Notification` / `Stop`)を発生源に、エージェント状態(承認待ち / 完了)を OS トースト通知として出す。herdr socket 購読ではなく hooks を発生源にすることで、herdr への結合を持たない可搬な設計にした。

## 変更内容

- `.config/claude/scripts/agent_toast.sh`(新規、実行権限付き)
  - 第1引数でイベント種別(`notification` | `stop`)を受け取り、stdin の hook JSON から `message` を読む(あれば通知本文に付加)
  - Wayland環境(`$WAYLAND_DISPLAY`)→ `notify-send` で通知(mako到達)
  - WSL2環境(`$WSL_DISTRO_NAME` あり or `/proc/version` に `microsoft`)→ OSC 9 エスケープを `/dev/tty` へ printf(**未検証経路**。`/dev/tty` が開けない場合は静かに諦める)
  - `HERDR_ENV=1` のときは追加で `herdr notification show` も併発(失敗しても無視)
  - 全経路 fail-silent 設計。外部コマンド不在・エラーでもエージェント本体をブロックせず必ず exit 0
- `.config/claude/settings.json`
  - `Notification` hook → `~/.claude/scripts/agent_toast.sh notification`
  - `Stop` hook → `~/.claude/scripts/agent_toast.sh stop`

## 動作確認

- `jq . .config/claude/settings.json` → OK
- `bash -n agent_toast.sh` → OK
- 直接起動での Wayland 経路検証:
  ```
  echo '{"message":"test"}' | .config/claude/scripts/agent_toast.sh notification
  echo '{}' | .config/claude/scripts/agent_toast.sh stop
  ```
  `makoctl history` で "Claude: 承認待ち" / "Claude: 完了" の到達を確認済み
- WSL2の OSC 9 経路は実機がなく未検証(コードレビュー可能な形で実装済み)

## 保留事項(Issue側で追跡)

- WSL2 実機での OSC 9 経路検証
- herdr pane 内から外側 WezTerm への OSC 9 貫通可否

Refs #392