### PR TITLE
feat(gpg): 複数端末での署名鍵運用をmiseタスク化 + Bitwarden連携でゼロタッチ転送

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -76,3 +76,63 @@ description = "Backup installed Arch Linux packages"
 # .backup/ は gitignore 済みのため fresh clone に存在しない → mkdir -p が必須
 # .backup/ is gitignored and absent in fresh clones, so mkdir -p is required
 run = "mkdir -p .backup/pacman && sudo pacman -Qne > .backup/pacman/pkglist.txt"
+
+# =============================================================================
+# GPG Tasks — 複数端末での署名鍵運用 / Multi-machine signing key management
+# 手順の解説: docs/how-to/manage-gpg-keys.md
+# =============================================================================
+
+[tasks."gpg:status"]
+description = "Show GPG signing key expiry and warn when renewal is near"
+run = """
+set -euo pipefail
+key=$(git config user.signingkey)
+gpg --list-keys --keyid-format long "$key"
+# 主キー・サブキーのうち最も早い期限 (epoch秒) を取り出す
+# Pick the soonest expiry (epoch seconds) across primary key and subkeys
+soonest=$(gpg --list-keys --with-colons "$key" | awk -F: '$1=="pub" || $1=="sub" {print $7}' | sort -n | head -1)
+days=$(( ($soonest - $(date +%s)) / 86400 ))
+# 期限が3日以内の場合は警告を表示する
+if [ "$days" -le 3 ]; then
+  echo "WARNING: GPG key $key expires in $days days. Consider extending the expiry and re-exporting the bundle."
+fi
+"""
+
+[tasks."gpg:export"]
+description = "Export transfer bundle (public key + secret subkeys + ownertrust) to .backup/gpg"
+run = """
+set -euo pipefail
+key=$(git config user.signingkey)
+out=.backup/gpg
+mkdir -p "$out"
+chmod 700 "$out"
+gpg --export --armor "$key" > "$out/public.asc"
+# 秘密鍵はサブキーのみ。主キーの秘密鍵はバンドルに含めない
+# Secret subkeys only — the primary secret key never enters the bundle
+gpg --export-secret-subkeys --armor "$key" > "$out/secret-subkeys.asc"
+gpg --export-ownertrust > "$out/ownertrust.txt"
+echo "Bundle written to $out/ — transfer it securely (e.g. scp) and delete it after import."
+"""
+
+[tasks."gpg:import"]
+description = "Import transfer bundle from .backup/gpg with ownertrust (new machine setup)"
+run = """
+set -euo pipefail
+src=.backup/gpg
+gpg --import "$src/public.asc"
+gpg --import "$src/secret-subkeys.asc"
+gpg --import-ownertrust "$src/ownertrust.txt"
+gpg --list-secret-keys --keyid-format long
+"""
+
+[tasks."gpg:extend"]
+description = "Extend key expiry (primary +5y, subkeys +2y) and re-export the bundle"
+run = """
+set -euo pipefail
+key=$(git config user.signingkey)
+fpr=$(gpg --list-keys --with-colons "$key" | awk -F: '$1=="fpr" {print $10; exit}')
+gpg --quick-set-expire "$fpr" 5y
+gpg --quick-set-expire "$fpr" 2y '*'
+mise run gpg:export
+echo "Expiry extended. Re-register public.asc on GitHub, then run 'mise run gpg:import' on other machines."
+"""

--- a/.mise.toml
+++ b/.mise.toml
@@ -115,14 +115,47 @@ echo "Bundle written to $out/ — transfer it securely (e.g. scp) and delete it 
 """
 
 [tasks."gpg:import"]
-description = "Import transfer bundle from .backup/gpg with ownertrust (new machine setup)"
+description = "Import transfer bundle from .backup/gpg with ownertrust (fetches from Bitwarden if absent)"
 run = """
 set -euo pipefail
 src=.backup/gpg
+item=${GPG_BW_ITEM:-gpg-bundle}
+if [ ! -d "$src" ]; then
+  bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
+  item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
+  mkdir -p "$src"
+  chmod 700 "$src"
+  for f in public.asc secret-subkeys.asc ownertrust.txt; do
+    bw get attachment "$f" --itemid "$item_id" --output "$src/$f"
+  done
+fi
+
 gpg --import "$src/public.asc"
 gpg --import "$src/secret-subkeys.asc"
 gpg --import-ownertrust "$src/ownertrust.txt"
 gpg --list-secret-keys --keyid-format long
+"""
+
+[tasks."gpg:bw:push"]
+description = "Upload the exported bundle to Bitwarden as attachments (item: $GPG_BW_ITEM or 'gpg-bundle')"
+run = """
+set -euo pipefail
+item=${GPG_BW_ITEM:-gpg-bundle}
+src=.backup/gpg
+[ -d "$src" ] || { echo "No bundle at $src — run 'mise run gpg:export' first." >&2; exit 1; }
+# ロック中ならこの場で解錠 (マスターパスワードを対話入力)。シェル側の export は不要
+# Self-unlock when the vault is locked — no shell-specific export needed
+bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
+item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
+for f in public.asc secret-subkeys.asc ownertrust.txt; do
+  # 同名の既存添付は置き換える / Replace an existing attachment of the same name
+  old=$(bw get item "$item" | jq -r --arg n "$f" '.attachments[]? | select(.fileName==$n) | .id')
+  [ -n "$old" ] && bw delete attachment "$old" --itemid "$item_id"
+  bw create attachment --file "$src/$f" --itemid "$item_id" > /dev/null
+  echo "pushed: $f"
+done
+bw sync > /dev/null
+echo "Bundle attached to Bitwarden item '$item'. You can now delete $src/."
 """
 
 [tasks."gpg:extend"]

--- a/.mise.toml
+++ b/.mise.toml
@@ -87,10 +87,12 @@ description = "Show GPG signing key expiry and warn when renewal is near"
 run = """
 set -euo pipefail
 key=$(git config user.signingkey)
+[ -n "$key" ] || { echo "git config user.signingkey is not set" >&2; exit 1; }
 gpg --list-keys --keyid-format long "$key"
-# 主キー・サブキーのうち最も早い期限 (epoch秒) を取り出す
-# Pick the soonest expiry (epoch seconds) across primary key and subkeys
-soonest=$(gpg --list-keys --with-colons "$key" | awk -F: '$1=="pub" || $1=="sub" {print $7}' | sort -n | head -1)
+# 主キー・サブキーのうち最も早い期限 (epoch秒) を取り出す。無期限の鍵は除外
+# Pick the soonest expiry (epoch seconds) across primary key and subkeys; skip no-expiry keys
+soonest=$(gpg --list-keys --with-colons "$key" | awk -F: '($1=="pub" || $1=="sub") && $7 != "" {print $7}' | sort -n | head -1)
+[ -n "$soonest" ] || { echo "No expiry set on any key."; exit 0; }
 days=$(( ($soonest - $(date +%s)) / 86400 ))
 # 期限が3日以内の場合は警告を表示する
 if [ "$days" -le 3 ]; then
@@ -103,6 +105,10 @@ description = "Export transfer bundle (public key + secret subkeys + ownertrust)
 run = """
 set -euo pipefail
 key=$(git config user.signingkey)
+[ -n "$key" ] || { echo "git config user.signingkey is not set" >&2; exit 1; }
+# 秘密鍵を含むファイルを 600 で作る (ディレクトリ 700 との多層防御)
+# Create key files as 600 — defence in depth on top of the 700 directory
+umask 077
 out=.backup/gpg
 mkdir -p "$out"
 chmod 700 "$out"
@@ -163,6 +169,7 @@ description = "Extend key expiry (primary +5y, subkeys +2y) and re-export the bu
 run = """
 set -euo pipefail
 key=$(git config user.signingkey)
+[ -n "$key" ] || { echo "git config user.signingkey is not set" >&2; exit 1; }
 fpr=$(gpg --list-keys --with-colons "$key" | awk -F: '$1=="fpr" {print $10; exit}')
 gpg --quick-set-expire "$fpr" 5y
 gpg --quick-set-expire "$fpr" 2y '*'

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -9,3 +9,4 @@
 - [customize-keybindings.md](./customize-keybindings.md) — キーバインドの追加・変更
 - [daily-workflow-commands.md](./daily-workflow-commands.md) — 日常的によく使うコマンド集
 - [troubleshoot-fonts.md](./troubleshoot-fonts.md) — フォント関連のトラブルシューティング
+- [manage-gpg-keys.md](./manage-gpg-keys.md) — GPG鍵の複数端末運用(新端末セットアップ・期限延長)

--- a/docs/how-to/manage-gpg-keys.md
+++ b/docs/how-to/manage-gpg-keys.md
@@ -40,16 +40,33 @@ mise run gpg:export
 
 ### 2. 新端末へ安全に転送
 
+**方法A: Bitwarden 経由(推奨)**
+
 ```bash
-# 例: scp で転送(公開チャネルにアップロードしない)
+# 転送元: バンドルを vault にアップロード(既存添付は自動で置き換え)
+mise run gpg:bw:push
+```
+
+事前準備(初回のみ): Bitwarden に `gpg-bundle` という名前のセキュアノートを作成しておく(アイテム名は環境変数 `GPG_BW_ITEM` で変更可)。添付ファイル機能を使うため Bitwarden Premium が必要。
+
+> **⚠️ 運用ルール:** GPGのパスフレーズを同じアイテム(またはvault)に保存しないこと。バンドルの秘密サブキーはパスフレーズで保護されており、これが二重ロックとして機能する。
+
+**方法B: scp で直接転送**
+
+```bash
 scp -r .backup/gpg new-machine:~/dotfiles/.backup/
 ```
 
 ### 3. 新端末でインポート
 
 ```bash
-mise run gpg:import
+# Bitwarden 経由の場合は先にログイン(端末ごとに初回のみ)
+bw login
+
+mise run gpg:import   # .backup/gpg/ が無ければ Bitwarden から自動取得
 ```
+
+> **Note:** vault がロック中の場合、タスクがその場でマスターパスワードを聞いてくる(自己解錠)。シェルごとの `BW_SESSION` の export は不要。
 
 インポート後、`sec#`(`#` 付き)と表示されれば「主キーの秘密鍵はこの端末に無い」状態で正常です。
 

--- a/docs/how-to/manage-gpg-keys.md
+++ b/docs/how-to/manage-gpg-keys.md
@@ -1,0 +1,118 @@
+# Manage GPG Keys / GPG鍵の複数端末運用
+
+> **Diátaxis:** 🔧 How-to
+
+コミット署名用GPG鍵を複数端末で運用するための手順です。新端末セットアップ、有効期限の延長、主キーのオフライン保管をカバーします。タスクコマンドの一覧は [mise-tasks.md](../reference/mise-tasks.md) を参照してください。
+
+---
+
+## 鍵構成の考え方 / Key Layout
+
+この運用は「主キー + サブキー」構成を前提としています:
+
+```
+sec  ed25519 [SC]  ← 主キー: 証明(Certify)専用。サブキーの発行・失効に使う
+ssb  cv25519 [E]   ← 暗号化サブキー: 日常の暗号化
+ssb  ed25519 [S]   ← 署名サブキー: コミット署名の実体
+```
+
+- **各端末に配るのはサブキーの秘密鍵だけ**。主キーの秘密鍵は信頼できる1箇所(オフラインのUSB等)に保管する
+- 端末が漏洩してもサブキーだけ失効(revoke)すれば、主キーと鍵のアイデンティティは守られる
+- git の `user.signingkey` には主キーIDを指定すればよい。GPGが自動的に有効な署名サブキーを選んで署名する
+
+---
+
+## 新端末セットアップ / New Machine Setup
+
+### 1. 転送元(既存端末)でバンドルを作成
+
+```bash
+mise run gpg:export
+```
+
+`.backup/gpg/` に以下が生成される(`.backup/` は gitignore 対象):
+
+| File | Contents |
+|------|----------|
+| `public.asc` | 公開鍵(主キー + 全サブキー) |
+| `secret-subkeys.asc` | **サブキーのみ**の秘密鍵(パスフレーズで保護されたまま) |
+| `ownertrust.txt` | trust設定(これがあると「trustを毎回設定し直す」作業が消える) |
+
+### 2. 新端末へ安全に転送
+
+```bash
+# 例: scp で転送(公開チャネルにアップロードしない)
+scp -r .backup/gpg new-machine:~/dotfiles/.backup/
+```
+
+### 3. 新端末でインポート
+
+```bash
+mise run gpg:import
+```
+
+インポート後、`sec#`(`#` 付き)と表示されれば「主キーの秘密鍵はこの端末に無い」状態で正常です。
+
+### 4. 転送済みバンドルを削除
+
+```bash
+rm -rf .backup/gpg   # 両端末で
+```
+
+---
+
+## 有効期限の延長 / Extending Expiry
+
+期限切れが近づいたら(`mise run gpg:status` が警告したら)、**主キーの秘密鍵がある端末で**:
+
+```bash
+mise run gpg:extend
+```
+
+これで主キー +5年、サブキー +2年に延長され、バンドルが再エクスポートされます。その後:
+
+1. **GitHub に公開鍵を再登録**: Settings → SSH and GPG keys で旧鍵を削除し、`public.asc` の内容を再登録(GitHubは期限情報を自動更新しない)
+2. **他端末に公開鍵を配布**: バンドルを転送して `mise run gpg:import`(期限延長は公開鍵の更新だけで反映される。秘密鍵の再転送は不要)
+
+> **Note:** 期限延長は秘密鍵の作り直しではありません。署名済みコミットの検証にも影響しません。
+
+---
+
+## 主キーのオフライン保管 / Offline Primary Key
+
+サブキー運用の仕上げとして、日常端末から主キーの秘密鍵を取り除きます。
+
+```bash
+# 1. まず主キーを含む完全バックアップを安全な場所へ(USB等・暗号化推奨)
+gpg --export-secret-keys --armor "$(git config user.signingkey)" > /path/to/usb/master-full.asc
+
+# 2. 検証: バックアップが本当にインポート可能か、一時キーリングで確認
+GNUPGHOME=$(mktemp -d) gpg --import /path/to/usb/master-full.asc
+
+# 3. 主キーの秘密鍵だけをこの端末から削除(grip指定)
+grip=$(gpg --list-secret-keys --with-keygrip "$(git config user.signingkey)" | awk '/Keygrip/{print $3; exit}')
+gpg-connect-agent "DELETE_KEY $grip" /bye
+
+# 4. 確認: sec が sec# になっていればOK
+gpg --list-secret-keys
+```
+
+主キーが必要になるのは「サブキーの追加・失効」「期限延長」「他人の鍵への署名」のときだけです。その際はUSBから一時的にインポートして作業し、再度削除します。
+
+---
+
+## トラブルシューティング / Troubleshooting
+
+| 症状 | 対処 |
+|------|------|
+| 署名時に `No secret key` | `gpg --list-secret-keys` でサブキーに `ssb` があるか確認。無ければ `mise run gpg:import` |
+| GitHub で `Unverified` 表示 | GitHub側の公開鍵が期限切れのまま。公開鍵を再登録する |
+| pinentry が出ない | `~/.gnupg/gpg-agent.conf` を確認し `gpg-connect-agent reloadagent /bye` |
+| trust が `unknown` になる | `gpg --import-ownertrust .backup/gpg/ownertrust.txt` |
+
+---
+
+## 参考 / References
+
+- [Debian Wiki: Subkeys](https://wiki.debian.org/Subkeys)
+- [GitHub Docs: Commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)

--- a/docs/how-to/manage-gpg-keys.md
+++ b/docs/how-to/manage-gpg-keys.md
@@ -101,10 +101,13 @@ mise run gpg:extend
 
 ```bash
 # 1. まず主キーを含む完全バックアップを安全な場所へ(USB等・暗号化推奨)
+umask 077   # 秘密鍵ファイルを 600 で作る
 gpg --export-secret-keys --armor "$(git config user.signingkey)" > /path/to/usb/master-full.asc
 
 # 2. 検証: バックアップが本当にインポート可能か、一時キーリングで確認
-GNUPGHOME=$(mktemp -d) gpg --import /path/to/usb/master-full.asc
+tmp=$(mktemp -d)
+GNUPGHOME=$tmp gpg --import /path/to/usb/master-full.asc
+GNUPGHOME=$tmp gpgconf --kill gpg-agent && rm -rf "$tmp"   # 検証後、秘密鍵をディスクに残さない
 
 # 3. 主キーの秘密鍵だけをこの端末から削除(grip指定)
 grip=$(gpg --list-secret-keys --with-keygrip "$(git config user.signingkey)" | awk '/Keygrip/{print $3; exit}')

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -60,8 +60,9 @@ mise タスクではないが、あわせてよく使うNix関連コマンド:
 |------|-------------|
 | `mise run gpg:status` | 署名鍵の有効期限を表示し、期限が近いと警告 |
 | `mise run gpg:export` | 転送バンドル(公開鍵 + 秘密サブキー + ownertrust)を `.backup/gpg/` に生成 |
-| `mise run gpg:import` | 新端末でバンドルをimportし、trust設定まで完了 |
+| `mise run gpg:import` | 新端末でバンドルをimportし、trust設定まで完了(バンドルが無ければBitwardenから自動取得) |
 | `mise run gpg:extend` | 期限延長(主キー +5y、サブキー +2y)+ バンドル再生成 |
+| `mise run gpg:bw:push` | バンドルをBitwardenアイテム(既定: `gpg-bundle`)の添付としてアップロード |
 
 mise タスクではないが、あわせてよく使うコマンド:
 

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -50,6 +50,19 @@ mise タスクではないが、あわせてよく使うNix関連コマンド:
 |------|-------------|---------------------|
 | `mise run backup` | Arch Linux パッケージリストをバックアップ (`.backup/` は gitignore 対象・ローカル用) | `mkdir -p .backup/pacman && sudo pacman -Qne > .backup/pacman/pkglist.txt` |
 
+---
+
+## GPG Tasks
+
+複数端末での署名鍵運用。手順の詳細は [manage-gpg-keys.md](../how-to/manage-gpg-keys.md) を参照。
+
+| Task | Description |
+|------|-------------|
+| `mise run gpg:status` | 署名鍵の有効期限を表示し、期限が近いと警告 |
+| `mise run gpg:export` | 転送バンドル(公開鍵 + 秘密サブキー + ownertrust)を `.backup/gpg/` に生成 |
+| `mise run gpg:import` | 新端末でバンドルをimportし、trust設定まで完了 |
+| `mise run gpg:extend` | 期限延長(主キー +5y、サブキー +2y)+ バンドル再生成 |
+
 mise タスクではないが、あわせてよく使うコマンド:
 
 | Command | Description |

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -84,6 +84,12 @@ in
     git-secret # Git secret management
     # gh is in git.nix
 
+    # Secret management / パスワードマネージャCLI
+    # bw: 公式CLI。添付ファイル対応 (GPG転送バンドルの push/fetch に使用 — mise gpg:* タスク)
+    # rbw: Rust製agent方式クライアント。日常のシークレット取得向け
+    bitwarden-cli # Official Bitwarden CLI (attachments support)
+    rbw # Unofficial Rust Bitwarden client (agent-based)
+
     # Network tools
     nmap # Network scanner
     netcat # Network utility


### PR DESCRIPTION
## 概要
GPG鍵の複数端末運用(新端末セットアップ・期限延長)を mise タスク + ランブックに集約する。さらに Bitwarden CLI 連携で、バンドルの端末間転送をゼロタッチ化する。

Closes #435
Closes #439

## 変更内容

### GPG鍵運用のmiseタスク化 (#435)
- `.mise.toml` に GPG Tasks セクションを追加
  - `gpg:status` — 主キー・サブキー全体の最短期限を colons 形式から取得し、残り3日以内で警告
  - `gpg:export` — 転送バンドル(公開鍵 + **秘密サブキーのみ** + ownertrust)を `.backup/gpg/` に生成
  - `gpg:import` — 新端末でバンドルを import し、ownertrust 復元まで完了
  - `gpg:extend` — 期限延長(主キー +5y / サブキー +2y)とバンドル再生成をセットで実行
- `docs/how-to/manage-gpg-keys.md` — サブキー運用の考え方、新端末セットアップ、期限延長、主キーのオフライン保管、トラブルシューティング

### Bitwarden CLI連携 (#439)
- nix: `bitwarden-cli`(添付ファイル対応の公式CLI)と `rbw` を dev-tools に追加
- `gpg:bw:push` — バンドル3ファイルを Bitwarden アイテム(既定: `gpg-bundle`)の添付として登録。同名の既存添付は置き換え
- `gpg:import` — `.backup/gpg/` が無ければ Bitwarden から自動取得するフォールバック
- vault ロック中はタスクが自己解錠(マスターパスワード対話入力)。シェル固有の `BW_SESSION` export を不要にし、fish でもそのまま動く
- ランブックに Bitwarden 経由の転送手順と「パスフレーズは同じ vault アイテムに置かない」運用ルールを追記

## テスト
- `mise run gpg:status` / `gpg:export` — 実鍵で動作確認(バンドル3ファイル生成、`.backup/` は gitignore 対象)
- E2E(捨て鍵): 端末A export → 空の GNUPGHOME に import で `sec#` + サブキー2本 + trust `ultimate` を確認
- `mise run gpg:bw:push` — 実 vault への添付アップロード成功を確認
- `mise run gpg:import` — バンドル既存パスで冪等動作を確認(exit 0)
- `nix build --dry-run` — 追加パッケージ名の解決を確認

## 補足
- 期限延長(2026-07-13 実施: 主キー→2031-07-11、サブキー→2028-07-11)後は GitHub 側の公開鍵再登録が必要。手順はランブックに記載
- Bitwarden の添付ファイル機能には Premium が必要。バンドル用セキュアノート(既定名 `gpg-bundle`)の初回作成は手動

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8FJkoUukfwxfH3zKqLACm