### PR TITLE
feat(claude): effortLevel を明示設定化し mise タスクでワンコマンド切替

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -1,5 +1,6 @@
 {
   "model": "opus",
+  "effortLevel": "xhigh",
   "statusLine": {
     "type": "command",
     "command": "bash $HOME/.claude/statusline-command.sh"

--- a/.mise.toml
+++ b/.mise.toml
@@ -50,14 +50,19 @@ description = "Set Claude Code effortLevel and rebuild (low|medium|high|xhigh)"
 # Write effortLevel into the nix source, then activate — the change stays tracked.
 usage = 'arg "<level>" help="low|medium|high|xhigh"'
 run = """
+set -euo pipefail
 level="$usage_level"
 case "$level" in
   low|medium|high|xhigh) ;;
   *) echo "usage: mise run claude:effort <low|medium|high|xhigh>" >&2; exit 1 ;;
 esac
-tmp=$(mktemp)
-jq --arg l "$level" '.effortLevel = $l' .config/claude/settings.json > "$tmp"
-mv "$tmp" .config/claude/settings.json
+settings=.config/claude/settings.json
+# 同一ディレクトリに temp を作り rename をアトミックに / jq 失敗時は trap で temp を掃除し本体を守る
+# temp in the same dir keeps the rename atomic; trap cleans up so a jq failure never clobbers settings
+tmp=$(mktemp "$settings.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+jq --arg l "$level" '.effortLevel = $l' "$settings" > "$tmp"
+mv "$tmp" "$settings"
 mise run nix:switch
 echo "effortLevel を $level に設定して反映したよ"
 """

--- a/.mise.toml
+++ b/.mise.toml
@@ -40,8 +40,27 @@ description = "Garbage collect old Nix generations"
 run = "nix-collect-garbage -d"
 
 # =============================================================================
-# Docker Tasks
+# Claude Code Tasks
 # =============================================================================
+
+[tasks."claude:effort"]
+description = "Set Claude Code effortLevel and rebuild (low|medium|high|xhigh)"
+# effortLevel を .config/claude/settings.json に書き込んで nix:switch で反映する。
+# tracked な変更なので diff が残り、そのまま commit/PR に乗せられる。
+# Write effortLevel into the nix source, then activate — the change stays tracked.
+usage = 'arg "<level>" help="low|medium|high|xhigh"'
+run = """
+level="$usage_level"
+case "$level" in
+  low|medium|high|xhigh) ;;
+  *) echo "usage: mise run claude:effort <low|medium|high|xhigh>" >&2; exit 1 ;;
+esac
+tmp=$(mktemp)
+jq --arg l "$level" '.effortLevel = $l' .config/claude/settings.json > "$tmp"
+mv "$tmp" .config/claude/settings.json
+mise run nix:switch
+echo "effortLevel を $level に設定して反映したよ"
+"""
 
 [tasks."docker:build"]
 description = "Build docker image"


### PR DESCRIPTION
## [optional body]

### 背景
Claude Code の reasoning effort は nix 管理下の `~/.claude/settings.json`（読み取り専用 symlink）
経由でしか固定できず、変更のたびに nix ソース編集 + rebuild が必要で手間だった。

### 変更内容
- `.config/claude/settings.json` に `effortLevel: "xhigh"` を明示。デフォルト値をソースで一覧化。
- `.mise.toml` に `claude:effort <low|medium|high|xhigh>` タスクを追加。
  jq で settings.json を書き換え → `nix:switch` まで自動実行する。
  tracked な変更として diff が残るため、そのまま commit / PR に乗せられる
  （＝「PR を出すまで勝手に変わらない」状態を維持できる）。

### 使い方
`mise run claude:effort high` の1コマンドで切替 → 再ビルドまで完了。

### 検証
- `mise tasks` に `claude:effort` 登録・不正値/引数なしのガードを確認
- `mise run claude:effort xhigh` で nix:switch まで完走、live の `~/.claude/settings.json` に反映確認
- 注記: effortLevel の反映は次回 Claude Code 起動時から有効

## [optional footer(s)]

🤖 Generated with [Claude Code](https://claude.com/claude-code)