### PR TITLE
feat(nvim): コミットメッセージ生成モデルを gpt-5.6-luna に変更

### DIFF
--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -224,9 +224,9 @@ vim.keymap.set('n', '<leader>cm', function()
     -- プロンプトをフォーマット
     local formatted_prompt = string.format(extended_prompts.Commit.prompt, git_context, git_status)
     
-    -- コミットメッセージ生成時のみsonnet4を使用
+    -- コミットメッセージ生成時のみ高速・低コストなモデルを使用
     require('CopilotChat').ask(formatted_prompt, {
-        model = 'claude-sonnet-4.5'  -- このaskだけsonnet4を使用
+        model = 'gpt-5.6-luna'  -- このaskだけ定型タスク向けモデルを使用
     })
 end, { desc = "Generate Commit Message" })
 


### PR DESCRIPTION
## 概要

`<leader>cm`(コミットメッセージ生成)で使用するモデルを `claude-sonnet-4.5` から `gpt-5.6-luna` に変更する。

Neovim刷新Epic(#447)の Phase 0(即効・最小リスク)。

Closes #442

## 変更内容

- `.config/nvim/copilot.toml`: `CopilotChat.ask()` の model を `gpt-5.6-luna` に変更
- 付随コメントをモデル固有の記述から役割ベースの記述に変更(「モデル名の変遷履歴をコメントの地層として積まない」— Epic #447 設計書の洞察2の実践)

## 背景

- gpt-5.6-luna は 2026-07-09 に GitHub Copilot へ追加された GPT-5.6 ファミリー(Sol/Terra/Luna)の最速・最安 tier($1/$6 per 1M tokens)
- 「高頻度・定型タスク向け」の位置づけで、コミットメッセージ生成に適する

## 動作確認

- [ ] `:CopilotChatModels` で `gpt-5.6-luna` が一覧に出ることを確認(新モデルのため他クライアントで "model not found" 系の報告あり。出ない場合は `gpt-5.6-sol` / `gpt-5.6-terra` へフォールバック)
- [ ] `<leader>cm` でコミットメッセージが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMHCpv8k3d9RoFzFwbGN5g