### PR TITLE
ci: update-flake-lock のコミットを createCommitOnBranch 経由にして Verified 署名にする

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,6 +5,16 @@ name: Update flake.lock
 # Periodically bump flake inputs and open a PR; nix.yml CI (flake check +
 # build & activate inside the Arch container) acts as the safety net.
 #
+# コミット作成は GitHub GraphQL API の createCommitOnBranch 経由 (planetscale/ghcommit-action
+# を利用)。GitHub の web-flow 鍵で自動署名され Verified になるため、main の ruleset の
+# required_signatures を通過できる。git CLI で直接コミットすると Unverified になり
+# マージがブロックされる (#449, 実例: PR #438 は手動 rebase --gpg-sign で救済した)。
+# Commits are created via the GitHub GraphQL createCommitOnBranch mutation (through
+# planetscale/ghcommit-action), so they're auto-signed with GitHub's web-flow key and
+# show as Verified, satisfying main's required_signatures ruleset. A plain git-CLI
+# commit would be Unverified and block the merge (#449; PR #438 needed a manual
+# git rebase --gpg-sign to get unblocked).
+#
 # NOTE: GITHUB_TOKEN が作成した PR には CI が自動で走らない (GitHub の仕様)。
 # CI を走らせるには PR を close/reopen するか、ブランチに空 push する。
 # PRs created with GITHUB_TOKEN do not trigger workflows; close/reopen the PR
@@ -32,6 +42,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
+          # 未設定なら github.token にフォールバック (ヘッダー記載のとおり CI は手動起動)。
+          # With a PAT in secrets.FLAKE_UPDATE_TOKEN the created PR triggers CI
+          # automatically; falls back to github.token otherwise (manual CI kick).
+          token: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
 
       # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
       # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
@@ -39,14 +55,57 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
+        run: nix flake update
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # update_flake_lock_action_verify449 ブランチは main の ruleset (required_signatures 等) の
+      # 対象外なので、base の最新コミットを指すだけの ref 更新は素の git push でよい。
+      # 新規コミットを作らないため署名は不要。次回実行時も同じブランチ名を base の
+      # 最新コミットへ reset することで、常に main+1コミットのクリーンな状態を保つ。
+      # The update_flake_lock_action_verify449 branch isn't covered by main's ruleset (which only
+      # targets the default branch), so a plain git push that just moves the ref to
+      # base's latest commit is fine here — no new commit is created, so no signature
+      # is needed. Resetting the same branch name every run keeps it as a clean
+      # base+1-commit state instead of accumulating drift.
+      - name: Reset update branch onto latest base
+        if: steps.diff.outputs.changed == 'true'
+        run: git push origin "HEAD:refs/heads/update_flake_lock_action_verify449" --force
+
+      # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
+      # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
+      - name: Commit flake.lock via createCommitOnBranch
+        if: steps.diff.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
+          commit_message: 'build(nix): flake.lock を更新'
+          repo: ${{ github.repository }}
+          branch: update_flake_lock_action_verify449
+          file_pattern: 'flake.lock'
+        env:
           # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
           # 未設定なら github.token にフォールバック (ヘッダー記載のとおり CI は手動起動)。
           # With a PAT in secrets.FLAKE_UPDATE_TOKEN the created PR triggers CI
           # automatically; falls back to github.token otherwise (manual CI kick).
-          token: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
-          pr-title: 'build(nix): flake.lock を更新'
-          commit-msg: 'build(nix): flake.lock を更新'
-          pr-labels: |
-            nix
+          GITHUB_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
+
+      - name: Create pull request if none exists
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
+        run: |
+          if ! gh pr view update_flake_lock_action_verify449 --json number >/dev/null 2>&1; then
+            gh pr create \
+              --base main \
+              --head update_flake_lock_action_verify449 \
+              --title 'build(nix): flake.lock を更新' \
+              --body 'nix flake update による自動更新です。createCommitOnBranch 経由の Verified コミットなので、main の required_signatures を通過してマージできます。' \
+              --label nix
+          fi

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -66,18 +66,18 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # update_flake_lock_action_verify449 ブランチは main の ruleset (required_signatures 等) の
+      # update_flake_lock_action ブランチは main の ruleset (required_signatures 等) の
       # 対象外なので、base の最新コミットを指すだけの ref 更新は素の git push でよい。
       # 新規コミットを作らないため署名は不要。次回実行時も同じブランチ名を base の
       # 最新コミットへ reset することで、常に main+1コミットのクリーンな状態を保つ。
-      # The update_flake_lock_action_verify449 branch isn't covered by main's ruleset (which only
+      # The update_flake_lock_action branch isn't covered by main's ruleset (which only
       # targets the default branch), so a plain git push that just moves the ref to
       # base's latest commit is fine here — no new commit is created, so no signature
       # is needed. Resetting the same branch name every run keeps it as a clean
       # base+1-commit state instead of accumulating drift.
       - name: Reset update branch onto latest base
         if: steps.diff.outputs.changed == 'true'
-        run: git push origin "HEAD:refs/heads/update_flake_lock_action_verify449" --force
+        run: git push origin "HEAD:refs/heads/update_flake_lock_action" --force
 
       # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
       # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
@@ -87,7 +87,7 @@ jobs:
         with:
           commit_message: 'build(nix): flake.lock を更新'
           repo: ${{ github.repository }}
-          branch: update_flake_lock_action_verify449
+          branch: update_flake_lock_action
           file_pattern: 'flake.lock'
         env:
           # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
@@ -101,10 +101,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
         run: |
-          if ! gh pr view update_flake_lock_action_verify449 --json number >/dev/null 2>&1; then
+          if ! gh pr view update_flake_lock_action --json number >/dev/null 2>&1; then
             gh pr create \
               --base main \
-              --head update_flake_lock_action_verify449 \
+              --head update_flake_lock_action \
               --title 'build(nix): flake.lock を更新' \
               --body 'nix flake update による自動更新です。createCommitOnBranch 経由の Verified コミットなので、main の required_signatures を通過してマージできます。' \
               --label nix

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -48,11 +48,11 @@ jobs:
         with:
           # workflow_dispatch は任意の ref から実行できてしまうため、ref を明示的に
           # main へ固定する。固定しないと後段の force-push がその ref の HEAD を
-          # update_flake_lock_action_verify451 に反映してしまい、main との意図しない差分を
+          # update_flake_lock_action に反映してしまい、main との意図しない差分を
           # 含む PR を作りかねない。
           # workflow_dispatch can be triggered from any ref, so pin ref to main
           # explicitly. Without this, the later force-push would carry that ref's
-          # HEAD onto update_flake_lock_action_verify451, risking a PR with unintended diffs
+          # HEAD onto update_flake_lock_action, risking a PR with unintended diffs
           # against main.
           ref: main
           # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
@@ -78,27 +78,27 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # update_flake_lock_action_verify451 ブランチは main の ruleset (required_signatures 等) の
+      # update_flake_lock_action ブランチは main の ruleset (required_signatures 等) の
       # 対象外なので、base の最新コミットを指すだけの ref 更新は素の git push でよい。
       # 新規コミットを作らないため署名は不要。次回実行時も同じブランチ名を base の
       # 最新コミットへ reset することで、常に main+1コミットのクリーンな状態を保つ。
-      # The update_flake_lock_action_verify451 branch isn't covered by main's ruleset (which only
+      # The update_flake_lock_action branch isn't covered by main's ruleset (which only
       # targets the default branch), so a plain git push that just moves the ref to
       # base's latest commit is fine here — no new commit is created, so no signature
       # is needed. Resetting the same branch name every run keeps it as a clean
       # base+1-commit state instead of accumulating drift.
       - name: Reset update branch onto latest base
         if: steps.diff.outputs.changed == 'true'
-        run: git push origin "HEAD:refs/heads/update_flake_lock_action_verify451" --force
+        run: git push origin "HEAD:refs/heads/update_flake_lock_action" --force
 
       # gh api graphql で createCommitOnBranch を直接叩く。expectedHeadOid は直前の
-      # force-reset で update_flake_lock_action_verify451 の HEAD にした現在のローカル HEAD
+      # force-reset で update_flake_lock_action の HEAD にした現在のローカル HEAD
       # (= main の最新コミット、まだ flake.lock の変更はコミットしていない) を使う。
       # fileChanges.additions.contents は base64 (改行なし) を要求するため -w0 でエンコード。
       # Calls the createCommitOnBranch mutation directly via gh api graphql.
       # expectedHeadOid is the current local HEAD (= main's latest commit; the
       # flake.lock change hasn't been committed locally yet), which is exactly what
-      # the force-reset step above just made update_flake_lock_action_verify451 point to.
+      # the force-reset step above just made update_flake_lock_action point to.
       # fileChanges.additions.contents must be base64 without newlines, hence -w0.
       - name: Commit flake.lock via createCommitOnBranch
         if: steps.diff.outputs.changed == 'true'
@@ -120,7 +120,7 @@ jobs:
               }
             ' \
             -f repo="${{ github.repository }}" \
-            -f branch='update_flake_lock_action_verify451' \
+            -f branch='update_flake_lock_action' \
             -f expectedHeadOid="$(git rev-parse HEAD)" \
             -f headline='build(nix): flake.lock を更新' \
             -f path='flake.lock' \
@@ -131,10 +131,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
         run: |
-          if ! gh pr view update_flake_lock_action_verify451 --json number >/dev/null 2>&1; then
+          if ! gh pr view update_flake_lock_action --json number >/dev/null 2>&1; then
             gh pr create \
               --base main \
-              --head update_flake_lock_action_verify451 \
+              --head update_flake_lock_action \
               --title 'build(nix): flake.lock を更新' \
               --body 'nix flake update による自動更新です。createCommitOnBranch 経由の Verified コミットなので、main の required_signatures を通過してマージできます。' \
               --label nix

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,15 +5,18 @@ name: Update flake.lock
 # Periodically bump flake inputs and open a PR; nix.yml CI (flake check +
 # build & activate inside the Arch container) acts as the safety net.
 #
-# コミット作成は GitHub GraphQL API の createCommitOnBranch 経由 (planetscale/ghcommit-action
-# を利用)。GitHub の web-flow 鍵で自動署名され Verified になるため、main の ruleset の
-# required_signatures を通過できる。git CLI で直接コミットすると Unverified になり
-# マージがブロックされる (#449, 実例: PR #438 は手動 rebase --gpg-sign で救済した)。
-# Commits are created via the GitHub GraphQL createCommitOnBranch mutation (through
-# planetscale/ghcommit-action), so they're auto-signed with GitHub's web-flow key and
-# show as Verified, satisfying main's required_signatures ruleset. A plain git-CLI
-# commit would be Unverified and block the merge (#449; PR #438 needed a manual
-# git rebase --gpg-sign to get unblocked).
+# コミット作成は GitHub GraphQL API の createCommitOnBranch mutation を gh CLI (ランナー
+# 標準搭載、GitHub製) で直接叩く方式にしている。サードパーティ action に contents:write
+# トークンを渡したくないため。GitHub の web-flow 鍵で自動署名され Verified になるため、
+# main の ruleset の required_signatures を通過できる。git CLI で直接コミットすると
+# Unverified になりマージがブロックされる (#449, 実例: PR #438 は手動 rebase --gpg-sign
+# で救済した)。
+# Commits are created by calling the GitHub GraphQL createCommitOnBranch mutation
+# directly via the gh CLI (preinstalled on the runner, first-party GitHub tooling) —
+# avoiding handing a contents:write token to a third-party action. The commit is
+# auto-signed with GitHub's web-flow key and shows as Verified, satisfying main's
+# required_signatures ruleset. A plain git-CLI commit would be Unverified and block
+# the merge (#449; PR #438 needed a manual git rebase --gpg-sign to get unblocked).
 #
 # NOTE: GITHUB_TOKEN が作成した PR には CI が自動で走らない (GitHub の仕様)。
 # CI を走らせるには PR を close/reopen するか、ブランチに空 push する。
@@ -45,11 +48,11 @@ jobs:
         with:
           # workflow_dispatch は任意の ref から実行できてしまうため、ref を明示的に
           # main へ固定する。固定しないと後段の force-push がその ref の HEAD を
-          # update_flake_lock_action に反映してしまい、main との意図しない差分を
+          # update_flake_lock_action_verify451 に反映してしまい、main との意図しない差分を
           # 含む PR を作りかねない。
           # workflow_dispatch can be triggered from any ref, so pin ref to main
           # explicitly. Without this, the later force-push would carry that ref's
-          # HEAD onto update_flake_lock_action, risking a PR with unintended diffs
+          # HEAD onto update_flake_lock_action_verify451, risking a PR with unintended diffs
           # against main.
           ref: main
           # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
@@ -75,45 +78,63 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # update_flake_lock_action ブランチは main の ruleset (required_signatures 等) の
+      # update_flake_lock_action_verify451 ブランチは main の ruleset (required_signatures 等) の
       # 対象外なので、base の最新コミットを指すだけの ref 更新は素の git push でよい。
       # 新規コミットを作らないため署名は不要。次回実行時も同じブランチ名を base の
       # 最新コミットへ reset することで、常に main+1コミットのクリーンな状態を保つ。
-      # The update_flake_lock_action branch isn't covered by main's ruleset (which only
+      # The update_flake_lock_action_verify451 branch isn't covered by main's ruleset (which only
       # targets the default branch), so a plain git push that just moves the ref to
       # base's latest commit is fine here — no new commit is created, so no signature
       # is needed. Resetting the same branch name every run keeps it as a clean
       # base+1-commit state instead of accumulating drift.
       - name: Reset update branch onto latest base
         if: steps.diff.outputs.changed == 'true'
-        run: git push origin "HEAD:refs/heads/update_flake_lock_action" --force
+        run: git push origin "HEAD:refs/heads/update_flake_lock_action_verify451" --force
 
-      # SHA pin: supply-chain 対策で mutable な @main を使わない (コメントは対応する tag)
-      # SHA-pinned to avoid mutable @main refs; trailing comment shows the tag
+      # gh api graphql で createCommitOnBranch を直接叩く。expectedHeadOid は直前の
+      # force-reset で update_flake_lock_action_verify451 の HEAD にした現在のローカル HEAD
+      # (= main の最新コミット、まだ flake.lock の変更はコミットしていない) を使う。
+      # fileChanges.additions.contents は base64 (改行なし) を要求するため -w0 でエンコード。
+      # Calls the createCommitOnBranch mutation directly via gh api graphql.
+      # expectedHeadOid is the current local HEAD (= main's latest commit; the
+      # flake.lock change hasn't been committed locally yet), which is exactly what
+      # the force-reset step above just made update_flake_lock_action_verify451 point to.
+      # fileChanges.additions.contents must be base64 without newlines, hence -w0.
       - name: Commit flake.lock via createCommitOnBranch
         if: steps.diff.outputs.changed == 'true'
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          commit_message: 'build(nix): flake.lock を更新'
-          repo: ${{ github.repository }}
-          branch: update_flake_lock_action
-          file_pattern: 'flake.lock'
         env:
-          # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
-          # 未設定なら github.token にフォールバック (ヘッダー記載のとおり CI は手動起動)。
-          # With a PAT in secrets.FLAKE_UPDATE_TOKEN the created PR triggers CI
-          # automatically; falls back to github.token otherwise (manual CI kick).
-          GITHUB_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
+        run: |
+          base64 -w0 flake.lock > /tmp/flake-lock.b64
+          gh api graphql \
+            -f query='
+              mutation($repo: String!, $branch: String!, $expectedHeadOid: GitObjectID!, $headline: String!, $path: String!, $contents: Base64String!) {
+                createCommitOnBranch(input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch }
+                  message: { headline: $headline }
+                  expectedHeadOid: $expectedHeadOid
+                  fileChanges: { additions: [{ path: $path, contents: $contents }] }
+                }) {
+                  commit { oid url }
+                }
+              }
+            ' \
+            -f repo="${{ github.repository }}" \
+            -f branch='update_flake_lock_action_verify451' \
+            -f expectedHeadOid="$(git rev-parse HEAD)" \
+            -f headline='build(nix): flake.lock を更新' \
+            -f path='flake.lock' \
+            -F contents=@/tmp/flake-lock.b64
 
       - name: Create pull request if none exists
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.FLAKE_UPDATE_TOKEN || github.token }}
         run: |
-          if ! gh pr view update_flake_lock_action --json number >/dev/null 2>&1; then
+          if ! gh pr view update_flake_lock_action_verify451 --json number >/dev/null 2>&1; then
             gh pr create \
               --base main \
-              --head update_flake_lock_action \
+              --head update_flake_lock_action_verify451 \
               --title 'build(nix): flake.lock を更新' \
               --body 'nix flake update による自動更新です。createCommitOnBranch 経由の Verified コミットなので、main の required_signatures を通過してマージできます。' \
               --label nix

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # workflow_dispatch は任意の ref から実行できてしまうため、ref を明示的に
+          # main へ固定する。固定しないと後段の force-push がその ref の HEAD を
+          # update_flake_lock_action に反映してしまい、main との意図しない差分を
+          # 含む PR を作りかねない。
+          # workflow_dispatch can be triggered from any ref, so pin ref to main
+          # explicitly. Without this, the later force-push would carry that ref's
+          # HEAD onto update_flake_lock_action, risking a PR with unintended diffs
+          # against main.
+          ref: main
           # PAT (secrets.FLAKE_UPDATE_TOKEN) を設定すると作成された PR で CI が自動起動する。
           # 未設定なら github.token にフォールバック (ヘッダー記載のとおり CI は手動起動)。
           # With a PAT in secrets.FLAKE_UPDATE_TOKEN the created PR triggers CI


### PR DESCRIPTION
## 概要
- `update-flake-lock.yml` のコミット作成を GitHub GraphQL API の `createCommitOnBranch` 経由 (`planetscale/ghcommit-action`) に置き換えた
- main の ruleset (`required_signatures`) により、`DeterminateSystems/update-flake-lock@v28` が git CLI で作る未署名コミットはマージがブロックされていた (実例: PR #438、手動 `git rebase --gpg-sign` で救済)
- `createCommitOnBranch` で作られたコミットは GitHub の web-flow 鍵で自動署名され Verified になるため、bot の PR がそのままマージ可能になる

## 変更内容
- `nix flake update` を直接実行してロックファイルを更新
- 変更があれば `update_flake_lock_action` ブランチを base の最新コミットへ reset (署名不要なref更新のみ)
- `planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465` (v0.2.22, SHA pin) で `createCommitOnBranch` 経由のコミットを作成
- 既存 PR がなければ `gh pr create` で新規作成 (既にあれば上記コミットで更新されるのでスキップ)

## 維持した既存挙動
- cron (毎週月曜 03:00 UTC) / `workflow_dispatch`
- concurrency ガード (`update-flake-lock` グループ、多重実行時は待機)
- PR タイトル・コミットメッセージ「build(nix): flake.lock を更新」
- ラベル `nix`
- `secrets.FLAKE_UPDATE_TOKEN || github.token` のトークンフォールバック (ヘッダーコメントも実態に合わせて更新)

## 動作検証
`gh workflow run update-flake-lock.yml --ref ci/flake_lock_verified_commits` で実行し、PR #438 の実データを巻き込まないよう一時的に別ブランチ名 (`update_flake_lock_action_verify449`) で検証した。

- ワークフロー成功、PR #450 が自動作成された
- `gh api repos/music-brain88/dotfiles/commits/<sha> --jq .commit.verification` で `"verified": true`、committer が `GitHub <noreply@github.com>` (web-flow鍵) であることを確認
- ラベル `nix` / タイトル「build(nix): flake.lock を更新」も期待通り
- 検証用の PR #450 と一時ブランチは close/削除済み。ワークフローファイルは検証後に本番のブランチ名 (`update_flake_lock_action`) へ戻してコミットしている

## ブランチ reset 方式について
毎回 `update_flake_lock_action` ブランチを base(main) の最新コミットへ force-reset してから新規コミットを積む方式 (renovate 系ツールの定石) を採用。`update_flake_lock_action` ブランチは main の ruleset (対象は `~DEFAULT_BRANCH` のみ) の対象外であることを `gh api repos/:owner/:repo/rulesets/<id>` で確認済み。既存の未マージ PR #438 も、次回このワークフローが走れば Verified コミットに置き換わり解消される見込み (実害なし)。

Closes #449