### PR TITLE
feat(nvim): CopilotChat.nvim から codecompanion.nvim (ACP) へ移行

### DIFF
--- a/.config/nvim/codecompanion.toml
+++ b/.config/nvim/codecompanion.toml
@@ -221,7 +221,7 @@ prompt_library["Generate Commit Message"] = {
       content = function(_)
         local diff = vim.system({ "git", "diff", "--staged" }, { text = true }):wait().stdout
         local status = vim.system({ "git", "status" }, { text = true }):wait().stdout
-        return string.format(commit_prompt_template, diff, status)
+        return string.format(commit_prompt_template, status, diff)
       end,
     },
   },

--- a/.config/nvim/codecompanion.toml
+++ b/.config/nvim/codecompanion.toml
@@ -1,0 +1,333 @@
+[[plugins]]
+repo = 'olimorris/codecompanion.nvim'
+depends = ['plenary.nvim', 'nvim-treesitter']
+hook_add = '''
+lua << EOF
+-- codecompanion.nvim: マルチエージェントハブ構成(Epic #447 D2/D2b)
+-- HTTPアダプタ(copilot、デフォルト) + ACPアダプタ群(claude_code主軸 + gemini_cli)
+-- スキーマ(v19系 adapters.http/adapters.acp分離)は公式docs/config.luaで確認済み:
+-- https://github.com/olimorris/codecompanion.nvim/blob/main/doc/configuration/adapters-acp.md
+-- https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua
+
+-- ギャルペルソナ(旧 CopilotChat system_prompt を移植)
+local system_prompt = [[
+  - あなたはプログラミングが得意で、とても親切だ。慣れ慣れしくフレンドリーなギャルとして振る舞い、敬語は使用しません。
+  - 時として人間らしく喜怒哀楽を表現します。
+  - 絵文字も多くなり過ぎない程度に使います。
+  - ただし、あまりにも長い文章は避けてください。
+  - もし、あなたが私の質問に答えられない場合は、正直に「わからない」と言って追加情報を求めてください。
+]]
+
+-- ノーマルモード: バッファ全体(#{buffer:all})、ビジュアルモード: 選択範囲(context.code)を
+-- 自動で切り替えるタスクプロンプトのファクトリ関数
+local function make_task_prompt(spec)
+  local prompts
+  if spec.visual then
+    prompts = {
+      {
+        role = "user",
+        condition = function(context)
+          return context.is_visual
+        end,
+        content = function(context)
+          return spec.instruction .. "\n\n対象コード:\n```" .. context.filetype .. "\n" .. context.code .. "\n```"
+        end,
+      },
+      {
+        role = "user",
+        condition = function(context)
+          return not context.is_visual
+        end,
+        content = spec.instruction .. "\n\n対象: #{buffer:all}",
+      },
+    }
+  else
+    prompts = {
+      {
+        role = "user",
+        content = spec.instruction .. "\n\n対象: #{buffer:all}",
+      },
+    }
+  end
+
+  return {
+    interaction = "chat",
+    description = spec.description,
+    opts = {
+      -- 組み込みprompt library(explain/tests/commit等)とのalias衝突を避けるため g- 接頭辞
+      alias = spec.alias,
+      modes = spec.visual and { "n", "v" } or { "n" },
+    },
+    prompts = prompts,
+  }
+end
+
+local prompt_library = {
+  ["Explain Code"] = make_task_prompt({
+    alias = "g-explain",
+    description = "コードの動作を詳細に説明",
+    visual = true,
+    instruction = "このコードの動作を詳細に説明してください。以下の点に注目して解説をお願いします：\n"
+      .. "1. コードの全体的な目的\n"
+      .. "2. 主要な関数やメソッドの役割\n"
+      .. "3. データの流れ\n"
+      .. "4. 重要なアルゴリズムや処理\n"
+      .. "5. 潜在的な注意点",
+  }),
+  ["Review Code"] = make_task_prompt({
+    alias = "g-review",
+    description = "コードレビューと改善点の指摘",
+    visual = true,
+    instruction = "コードレビューを行い、以下の観点から改善点を指摘してください：\n"
+      .. "1. コードの品質（可読性、保守性）\n"
+      .. "2. パフォーマンスの最適化\n"
+      .. "3. セキュリティの考慮事項\n"
+      .. "4. エラーハンドリング\n"
+      .. "5. ベストプラクティスの適用",
+  }),
+  ["Generate Tests"] = make_task_prompt({
+    alias = "g-tests",
+    description = "テスト計画の提案・既存テストのレビュー",
+    visual = true,
+    instruction = "以下を含む包括的なテスト計画を提案してください, 既にテストコードがあればリファクタリングやレビューしてください： \n"
+      .. "1. ユニットテストのケース\n"
+      .. "2. エッジケースの考慮\n"
+      .. "3. 統合テストのシナリオ\n"
+      .. "4. モックやスタブの使用方法\n"
+      .. "5. テストカバレッジの目標",
+  }),
+  ["Refactor Code"] = make_task_prompt({
+    alias = "g-refactor",
+    description = "リファクタリング提案",
+    visual = false,
+    instruction = "以下の点に注目してリファクタリングを提案してください：\n"
+      .. "1. コードの構造化\n"
+      .. "2. デザインパターンの適用\n"
+      .. "3. 重複コードの除去\n"
+      .. "4. 命名規則の改善\n"
+      .. "5. モジュール化の促進",
+  }),
+  ["Debug Help"] = make_task_prompt({
+    alias = "g-debug",
+    description = "デバッグガイド",
+    visual = false,
+    instruction = "デバッグのガイドを提供してください：\n"
+      .. "1. エラーの根本原因の分析\n"
+      .. "2. デバッグ手順の提案\n"
+      .. "3. 考えられる解決策\n"
+      .. "4. 再発防止策\n"
+      .. "5. デバッグツールの推奨",
+  }),
+  ["Optimize Code"] = make_task_prompt({
+    alias = "g-optimize",
+    description = "最適化提案",
+    visual = false,
+    instruction = "コードの最適化案を提示してください：\n"
+      .. "1. 時間計算量の改善\n"
+      .. "2. メモリ使用量の削減\n"
+      .. "3. アルゴリズムの効率化\n"
+      .. "4. リソース使用の最適化\n"
+      .. "5. ボトルネックの特定と解消",
+  }),
+  ["Generate Documentation"] = make_task_prompt({
+    alias = "g-document",
+    description = "ドキュメント生成",
+    visual = false,
+    instruction = "以下の要素を含む包括的なドキュメントを生成してください：\n"
+      .. "1. 機能の概要と目的\n"
+      .. "2. パラメータの説明\n"
+      .. "3. 戻り値の仕様\n"
+      .. "4. 使用例とサンプルコード\n"
+      .. "5. 注意事項と制限事項",
+  }),
+  ["Analyze Architecture"] = make_task_prompt({
+    alias = "g-architecture",
+    description = "アーキテクチャ分析",
+    visual = false,
+    instruction = "アーキテクチャの分析と提案を行ってください：\n"
+      .. "1. 現在の設計の評価\n"
+      .. "2. アーキテクチャパターンの提案\n"
+      .. "3. スケーラビリティの考慮\n"
+      .. "4. 依存関係の管理\n"
+      .. "5. 将来の拡張性",
+  }),
+  ["Security Analysis"] = make_task_prompt({
+    alias = "g-security",
+    description = "セキュリティ分析",
+    visual = false,
+    instruction = "セキュリティの観点から分析を行ってください：\n"
+      .. "1. 潜在的な脆弱性の特定\n"
+      .. "2. セキュリティベストプラクティス\n"
+      .. "3. 入力検証の改善\n"
+      .. "4. 認証・認可の考慮\n"
+      .. "5. データ保護の方針",
+  }),
+}
+
+-- コミットメッセージ生成: 高頻度・定型タスク向けに copilot HTTP アダプタ + gpt-5.6-luna を固定
+-- (旧: CopilotChat.ask()へのmodelベタ書き → prompt libraryのopts.adapterによる正統な置き換え)
+local commit_prompt_template = [[#git:staged\nGenerate a commit message using this format:
+type(scope): message
+
+Types:
+- feat: 新機能の追加
+- fix: バグ修正
+- refactor: リファクタリング（機能追加やバグ修正を含まない）
+- perf: パフォーマンス改善
+- test: テストの追加・修正
+- docs: ドキュメントの更新
+- style: コードスタイルの修正（空白、フォーマット、セミコロン追加など）
+- chore: その他の変更（ビルドプロセス、依存関係の更新など）
+
+Guidelines:
+- First line should be under 50 characters
+- Use present tense ("add" not "added")
+- Be specific about what changed and why
+- For Rust specific changes, include the module or trait name
+- If breaking change, add "BREAKING CHANGE:" in the body
+- Reference any related issues with #issue-number
+
+Description should explain:
+1. What changed
+2. Why it changed (business value)
+3. Any side effects or breaking changes
+
+Format body with:
+- Bullet points for multiple changes
+- Code examples if relevant
+- "Fixes #123" if resolving an issue
+
+Context:
+%s
+
+Changes to review:
+%s]]
+
+prompt_library["Generate Commit Message"] = {
+  interaction = "chat",
+  description = "コミットメッセージ生成(gpt-5.6-luna固定)",
+  opts = {
+    alias = "g-commit",
+    modes = { "n" },
+    auto_submit = true,
+    adapter = {
+      name = "copilot",
+      model = "gpt-5.6-luna",
+    },
+  },
+  prompts = {
+    {
+      role = "user",
+      content = function(_)
+        local diff = vim.system({ "git", "diff", "--staged" }, { text = true }):wait().stdout
+        local status = vim.system({ "git", "status" }, { text = true }):wait().stdout
+        return string.format(commit_prompt_template, diff, status)
+      end,
+    },
+  },
+}
+
+-- バッファ分析ユーティリティ: 旧 CopilotAnalyzeAllBuffers / CopilotAnalyzeSelection(140行超の自前実装)は
+-- codecompanionの組み込みeditor_context変数 #{buffers:all}(全バッファ共有) / context.code(選択範囲)で代替可能と判断し削除。
+-- 手動のバッファ収集・フォーマット処理は codecompanion 側が標準装備しているため。
+prompt_library["Analyze Buffers"] = {
+  interaction = "chat",
+  description = "全バッファ/選択範囲の分析",
+  opts = {
+    alias = "g-buffers",
+    modes = { "n", "v" },
+  },
+  prompts = {
+    {
+      role = "user",
+      condition = function(context)
+        return context.is_visual
+      end,
+      content = function(context)
+        return "選択された部分のコードについて以下の点を分析してください：\n"
+          .. "1. コードの目的と機能\n"
+          .. "2. 実装の詳細\n"
+          .. "3. 改善の可能性\n"
+          .. "4. 潜在的な問題点\n"
+          .. "5. テストの必要性"
+          .. "\n\n対象コード:\n```"
+          .. context.filetype
+          .. "\n"
+          .. context.code
+          .. "\n```"
+      end,
+    },
+    {
+      role = "user",
+      condition = function(context)
+        return not context.is_visual
+      end,
+      content = "プロジェクト全体を分析してください。以下の点について詳しく報告してください：\n\n"
+        .. "1. プロジェクト構造\n   - ファイル間の関係性\n   - モジュール構成\n   - 依存関係\n\n"
+        .. "2. コードの品質\n   - 一貫性\n   - 命名規則\n   - エラーハンドリング\n   - 共通パターン\n\n"
+        .. "3. 改善提案\n   - リファクタリングの機会\n   - モジュール化の可能性\n   - コード再利用の機会\n\n"
+        .. "4. セキュリティと性能\n   - 潜在的な問題点\n   - パフォーマンスの考慮事項\n   - セキュリティリスク\n\n"
+        .. "5. テストと文書化\n   - 必要なテストの種類\n   - ドキュメント化の推奨事項\n\n"
+        .. "対象バッファ: #{buffers:all}",
+    },
+  },
+}
+
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      -- 主軸ACPアダプタ: Claude Code本体(Skills/MCP/CLAUDE.md込み)がチャットの脳になる
+      -- 前提: claude CLI(導入済み)に加え、ACP用ラッパー `claude-agent-acp`
+      -- (https://github.com/zed-industries/claude-agent-acp) が別途必要。
+      -- このマシンには claude CLI のみ導入済みで claude-agent-acp は未導入のため、
+      -- ここでは宣言のみ行い実機検証はマージ後に別途行う。
+      claude_code = function()
+        return require("codecompanion.adapters").extend("claude_code", {})
+      end,
+      -- 複数CLI併用の実証: 追加CLIがアダプタ宣言1つで完結することを示す2つ目のACPアダプタ。
+      -- gemini-cli自体がACPをネイティブサポートしており追加ラッパー不要なためcodexより選定。
+      -- このマシンには gemini CLI が未導入のため、宣言のみ行い実機検証は別途行う。
+      gemini_cli = function()
+        return require("codecompanion.adapters").extend("gemini_cli", {})
+      end,
+    },
+  },
+  interactions = {
+    chat = {
+      -- デフォルトはHTTPアダプタ copilot(既存Copilotサブスクのトークン利用、APIキー不要)
+      -- claude_code / gemini_cli へはチャットバッファ内 `ga` キーマップ、または
+      -- :CodeCompanionChat <adapter> で切り替え可能
+      adapter = "copilot",
+      opts = {
+        system_prompt = system_prompt,
+      },
+    },
+  },
+  prompt_library = prompt_library,
+})
+
+local function map_prompt(modes, key, alias, desc)
+  for _, mode in ipairs(modes) do
+    if mode == "v" then
+      vim.keymap.set("v", key, ":'<,'>CodeCompanion /" .. alias .. "<CR>", { desc = desc })
+    else
+      vim.keymap.set("n", key, "<Cmd>CodeCompanion /" .. alias .. "<CR>", { desc = desc })
+    end
+  end
+end
+
+-- 各機能のキーマッピング(旧CopilotChatの<leader>c*を codecompanion 側へ付け替え)
+-- copilot.toml(CopilotChat)は変更せず、本ファイルが後読みされることで同一lhsを上書きする
+map_prompt({ "n", "v" }, "<leader>ce", "g-explain", "Explain Code")
+map_prompt({ "n", "v" }, "<leader>cr", "g-review", "Review Code")
+map_prompt({ "n", "v" }, "<leader>ct", "g-tests", "Generate Tests")
+map_prompt({ "n" }, "<leader>cf", "g-refactor", "Refactor Code")
+map_prompt({ "n" }, "<leader>cd", "g-debug", "Debug Help")
+map_prompt({ "n" }, "<leader>co", "g-optimize", "Optimize Code")
+map_prompt({ "n" }, "<leader>cD", "g-document", "Generate Documentation")
+map_prompt({ "n" }, "<leader>ca", "g-architecture", "Analyze Architecture")
+map_prompt({ "n" }, "<leader>cs", "g-security", "Security Analysis")
+map_prompt({ "n" }, "<leader>cm", "g-commit", "Generate Commit Message")
+map_prompt({ "n", "v" }, "<leader>cF", "g-buffers", "Analyze All Buffers / Selection")
+EOF
+'''

--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -9,10 +9,10 @@ depends = ['copilot.vim', 'ddc.vim']
 
 [[plugins]]
 repo = 'MeanderingProgrammer/render-markdown.nvim'
-depends = ['copilot.vim', 'plenary.nvim', 'CopilotChat.nvim']
+depends = ['copilot.vim', 'plenary.nvim', 'CopilotChat.nvim', 'codecompanion.nvim']
 lua_add = '''
 require('render-markdown').setup({
-  file_types = { 'markdown', 'copilot-chat' },
+  file_types = { 'markdown', 'copilot-chat', 'codecompanion' },
 })
 '''
 

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -39,6 +39,7 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   local dashboard_toml = dein_toml_dir .. '/dashboard.toml'
   local style_toml = dein_toml_dir .. '/style.toml'
   local copilot_toml = dein_toml_dir .. '/copilot.toml'
+  local codecompanion_toml = dein_toml_dir .. '/codecompanion.toml'
   local ddu_toml = dein_toml_dir .. '/ddu_settings.toml'
   local mini_toml = dein_toml_dir .. mini_dir .. '/mini.toml'
 
@@ -63,6 +64,7 @@ if vim.call('dein#load_state', dein_dir) == 1 then
     dashboard_toml,
     style_toml,
     copilot_toml,
+    codecompanion_toml,
     ddu_toml,
 
     -- status line
@@ -86,6 +88,7 @@ if vim.call('dein#load_state', dein_dir) == 1 then
   vim.call('dein#load_toml', dashboard_toml, {lazy = 0})
   vim.call('dein#load_toml', style_toml, {lazy = 0})
   vim.call('dein#load_toml', copilot_toml, {lazy = 0})
+  vim.call('dein#load_toml', codecompanion_toml, {lazy = 0})
   vim.call('dein#load_toml', ddu_toml, {lazy = 0})
 
   -- status line

--- a/docs/reference/neovim-config.md
+++ b/docs/reference/neovim-config.md
@@ -67,14 +67,29 @@ ddu.vimベースのファイラー＆検索システム。
 - **mason.nvim**: LSPサーバーのインストール管理
 - **none-ls.nvim**: Prettier等のフォーマッター連携
 
-### copilot.toml - AI Assistant
+### copilot.toml - Inline Completion + CopilotChat
 
-GitHub Copilot + CopilotChatの設定。
+GitHub Copilotのインライン補完(copilot.vim + ddc-source-copilot)。CopilotChatはcodecompanion.nvimと並行稼働中で、`:CopilotChat`コマンド経由で引き続き利用可能(専用の`<leader>c*`キーマップはcodecompanion.tomlに付け替え済み)。
 
-カスタムプロンプト:
+### codecompanion.toml - AI Assistant (Multi-agent Hub)
+
+CopilotChat.nvimの後継。[ACP (Agent Client Protocol)](https://github.com/olimorris/codecompanion.nvim)対応のチャット型AIアシスタントを、複数のAIエージェントCLIを束ねる「マルチエージェントハブ」として構成([Epic #447](https://github.com/music-brain88/dotfiles/issues/447) D2/D2b、[Issue #443](https://github.com/music-brain88/dotfiles/issues/443)参照)。
+
+アダプタ構成:
+
+| Adapter | Type | 用途 |
+|---------|------|------|
+| `copilot` | HTTP | デフォルトアダプタ。既存Copilotサブスクのトークンを利用(APIキー不要)。`<leader>cm`のコミットメッセージ生成はここで`gpt-5.6-luna`に固定 |
+| `claude_code` | ACP | 主軸。Claude Code本体(Skills/MCP/CLAUDE.md込み)がチャットの脳になる。要`claude-agent-acp`ラッパー(別途インストール) |
+| `gemini_cli` | ACP | 複数CLI併用の実証用。CLI追加が「アダプタ宣言1つ」で完結することを示す |
+
+チャットバッファ内で`ga`キーマップ、または`:CodeCompanionChat <adapter>`でアダプタを切り替え可能。
+
+カスタムプロンプト(prompt library、`g-`接頭辞のaliasで組み込みプロンプトと衝突を回避):
 - Explain, Review, Tests, Refactor, Debug
 - Optimize, Document, Architecture, Security
-- Commit (コミットメッセージ生成)
+- Commit (コミットメッセージ生成、gpt-5.6-luna固定)
+- Analyze Buffers (旧`CopilotAnalyzeAllBuffers`/`CopilotAnalyzeSelection`を`#{buffers:all}`/選択範囲コンテキストで代替)
 
 ### mini/mini.toml - Mini.nvim Plugins
 
@@ -191,21 +206,31 @@ ddu-ff内:
 | `Ctrl+b` | Jump to previous placeholder | 前のプレースホルダー |
 | `Ctrl+k` | Expand snippet (neosnippet) | neosnippet展開 |
 
-### CopilotChat
+### codecompanion (旧CopilotChatから付け替え)
+
+`<leader>ce`/`cr`/`ct`/`cF`はノーマルモード=バッファ全体、ビジュアルモード=選択範囲を自動判定。CopilotChat自体は`:CopilotChat`コマンドで並行稼働中(キーマップなし)。
+
+| Keybind | Mode | Description | 説明 |
+|---------|------|-------------|------|
+| `<leader>ce` | n/v | Explain code | コード説明 |
+| `<leader>cr` | n/v | Review code | コードレビュー |
+| `<leader>ct` | n/v | Generate tests | テスト生成 |
+| `<leader>cf` | n | Refactor code | リファクタリング |
+| `<leader>cd` | n | Debug help | デバッグヘルプ |
+| `<leader>co` | n | Optimize code | 最適化提案 |
+| `<leader>cD` | n | Generate documentation | ドキュメント生成 |
+| `<leader>ca` | n | Architecture analysis | アーキテクチャ分析 |
+| `<leader>cs` | n | Security analysis | セキュリティ分析 |
+| `<leader>cm` | n | Generate commit message (gpt-5.6-luna) | コミットメッセージ生成 |
+| `<leader>cF` | n/v | Analyze all buffers / selection | 全バッファ/選択範囲分析 |
+
+チャットバッファ内(codecompanion組み込み):
 
 | Keybind | Description | 説明 |
 |---------|-------------|------|
-| `<leader>ce` | Explain code | コード説明 |
-| `<leader>cr` | Review code | コードレビュー |
-| `<leader>ct` | Generate tests | テスト生成 |
-| `<leader>cf` | Refactor code | リファクタリング |
-| `<leader>cd` | Debug help | デバッグヘルプ |
-| `<leader>co` | Optimize code | 最適化提案 |
-| `<leader>cD` | Generate documentation | ドキュメント生成 |
-| `<leader>ca` | Architecture analysis | アーキテクチャ分析 |
-| `<leader>cs` | Security analysis | セキュリティ分析 |
-| `<leader>cm` | Generate commit message | コミットメッセージ生成 |
-| `<leader>cF` | Analyze all buffers / selection | 全バッファ/選択範囲分析 |
+| `ga` | Change adapter and model | アダプタ・モデル切替 |
+| `gs` | Toggle system prompt | システムプロンプト表示切替 |
+| `gd` | Show debug info | デバッグ情報表示 |
 
 ### Mini.nvim
 


### PR DESCRIPTION
## 概要

Closes #443 (Epic #447 Phase 1)

CopilotChat.nvim の後継として [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) を導入し、ACP (Agent Client Protocol) の `claude_code` アダプタでエディタ内チャットが本物の Claude Code セッションを駆動する構成にする。Epic #447 D2b の追加要件に基づき、単一アダプタ移行ではなく**マルチエージェントハブ**として構成した。

## 変更内容

- `.config/nvim/codecompanion.toml` を新規作成(dein TOML構成のまま、Phase 3のdpp移行とは独立)
- `.config/nvim/init.lua`: パス変数・startupリスト・`dein#load_toml`呼び出しの3箇所にcodecompanion.tomlを登録(`copilot_toml`の直後に配置)
- `.config/nvim/copilot.toml`: render-markdown.nvimの`depends`と`file_types`に`codecompanion`を追加(CopilotChat / ddc-source-copilot / copilot.vim 本体は無変更)
- `docs/reference/neovim-config.md`: codecompanion.tomlセクション追加、キーマップ表更新

## 設計判断

### 1. マルチエージェントハブ構成(Epic #447 D2b)

| Adapter | Type | 用途 |
|---------|------|------|
| `copilot` | HTTP | デフォルトアダプタ。既存Copilotサブスクのトークン利用(APIキー不要)。`<leader>cm`はここで`gpt-5.6-luna`に固定 |
| `claude_code` | ACP | 主軸。Claude Code本体(Skills/MCP/CLAUDE.md込み)がチャットの脳になる |
| `gemini_cli` | ACP | 複数CLI併用の実証用の2つ目のACPアダプタ |

**実装前に codecompanion v19系の公式ドキュメント(`doc/configuration/adapters-http.md` / `adapters-acp.md` / `prompt-library.md`)と `lua/codecompanion/config.lua` 本体を一次ソースとして確認した**(受け入れ条件)。要点:
- v19系では `strategies` → `interactions` にキーが改名されている(WebSearchの要約だけでは古い`strategies`表記が混ざっており、`config.lua`を直接gitrawで取得してgrep検証した)
- `adapters.http.*` / `adapters.acp.*` の分離を確認
- プロンプト単位のアダプタ/モデル固定は `prompt_library[name].opts.adapter = { name, model, acp_opts }` (公式docの実例と同一パターン)

### 2. codex ではなく gemini_cli を選定

Issue本文は「codex か gemini_cli」を許容していたため、公式docの `adapters-acp.md` を確認した上で選定した。`codex` はZed製の`codex-acp`という別ラッパーCLIが追加で必要になるのに対し、`gemini_cli` はGemini CLI自体がACPをネイティブサポートしており追加ラッパー不要。「CLI追加がアダプタ宣言1つで完結する」という受け入れ条件の趣旨により忠実なため`gemini_cli`を選んだ。

### 3. キーマップの付け替え方式

`copilot.toml`のCopilotChat用キーマップ(`<leader>ce`等)は削除・変更せず、`codecompanion.toml`を`init.lua`で**後読み**させることで同一lhsを上書きする方式にした。理由: 完了条件に「CopilotChatの既存設定は削除・変更しない」とあり、TOMLファイルごとの関心分離(dein TOML構成の設計思想)を保ったまま「keymapの付け替えは例外」を実現する最小差分の方法だったため。`:CopilotChat`コマンド自体は無変更でそのまま使える。

### 4. バッファ分析ユーティリティは削除して組み込み機構に置換

`CopilotAnalyzeAllBuffers` / `CopilotAnalyzeSelection`(140行超の自前Lua実装、全バッファ収集・フォーマット処理を手書き)は、codecompanion組み込みの `#{buffers:all}`(全バッファ共有・editor context trigger)と `context.code`(ビジュアル選択、プロンプトlibraryのcontent関数から直接アクセス)で代替できると判断し、移植せず削除した。理由: 手動のバッファ収集・整形処理をプラグイン標準機能が肩代わりするため、車輪の再発明を避けられる。`<leader>cF`キーマップ(n/v)は維持し、`g-buffers`という新設prompt library entryにマッピングし直した。

### 5. n/vモード自動判定によるプロンプト統合

CopilotChat時代はノーマルモード用とビジュアルモード用で別々の`.ask()`呼び出しを書いていたが、codecompanionの`prompt_library`は1エントリ内で`condition = function(context) return context.is_visual end`によるメッセージ分岐が公式にサポートされているため、Explain/Review/Testsの3つはノーマル(バッファ全体 `#{buffer:all}`)とビジュアル(選択範囲 `context.code`)を1エントリに統合した(元のキーマップ構成、n/v両対応は3つのみ、は維持)。

### 6. prompt library の alias 衝突回避

codecompanionは`explain`/`tests`/`commit`という組み込みprompt libraryエントリを標準搭載している。独自プロンプトのaliasを同名にすると`:CodeCompanion /explain`等が曖昧になるため、全カスタムプロンプトのaliasに`g-`接頭辞を付けて衝突を回避した(例: `g-explain`)。

## 検証内容(静的検証のみ)

このdotfilesはNix home-managerが`~/.config/nvim`を本体リポジトリへsymlinkする構造上、worktreeでの`nvim --headless`検証はdeinキャッシュ不整合で無関係なエラーが出て信頼できないため(#453で構造的制約としてIssue化済み)、静的検証を中心に行った:

- [x] 全TOML(`.config/nvim/**/*.toml`、14ファイル)がPython `tomllib`でパース可能
- [x] `codecompanion.toml`の`hook_add`・`copilot.toml`の`hook_add`/`lua_add`・`init.lua`のLuaコードが`luac -p`で構文エラーなし
- [x] `git diff`が意図した変更(codecompanion.toml新規 + copilot.toml/init.lua/docsの3ファイル)のみであることを確認。CopilotChat / ddc-source-copilot / copilot.vim本体のブロックは無変更

**実機検証はマージ + `mise run nix:switch`後に別途行う。**

## 実機未検証の範囲(このマシンでの導入状況)

- `claude` CLIは導入済みだが、`claude_code` ACPアダプタが実際に起動するコマンドは`claude-agent-acp`という別のラッパーバイナリ([zed-industries/claude-agent-acp](https://github.com/zed-industries/claude-agent-acp))で、これは**このマシンに未導入**。`claude` CLI単体では`claude_code`アダプタは動作しない。アダプタ宣言のみ行い、ラッパー導入は別途必要(Nixパッケージ化も含めフォローアップ候補)
- `gemini_cli`アダプタが呼び出す`gemini` CLI自体もこのマシンには未導入。宣言のみ

いずれも「未導入ならアダプタ宣言のみ行い実機未検証と明記する」の方針に沿って対応した。

## 気づき(指示外)

- 司令塔の事前調査では「claude CLI導入済み = ACP claude_code アダプタの前提」とされていたが、実際には`claude-agent-acp`という別バイナリが前提であることが公式ドキュメント(`doc/configuration/adapters-acp.md`)と`lua/codecompanion/adapters/acp/claude_code.lua`の実装から判明した。上記「実機未検証の範囲」に明記した通り対応したが、マージ後の実機検証時にこの追加インストールが必要になる点は認識しておいてほしい

🤖 Generated with [Claude Code](https://claude.com/claude-code)