### PR TITLE
fix(nvim): dduの自動プレビューを復活させ廃止済み設定を掃除

### DIFF
--- a/.config/nvim/ddu_settings.toml
+++ b/.config/nvim/ddu_settings.toml
@@ -114,7 +114,44 @@ function! s:open_in_prev_window_ff() abort
   endif
 endfunction
 
-nmap <silent> ,m <Cmd>call <SID>save_prev_winid()<CR><Cmd>call ddu#start({ 'name' : 'file' })<CR>
+" ,m は filer のトグル: 表示中なら正規の quit アクションで閉じる
+" (quit を通ることで preview window もプラグイン側で畳まれる)
+function! s:toggle_filer() abort
+  if exists('*denops#plugin#is_loaded') && denops#plugin#is_loaded('ddu')
+        \ && ddu#ui#visible('file')
+    call ddu#ui#do_action('quit', {}, 'file')
+  else
+    call s:save_prev_winid()
+    call ddu#start(#{name: 'file'})
+  endif
+endfunction
+
+nmap <silent> ,m <Cmd>call <SID>toggle_filer()<CR>
+
+" :q や <C-w>c で ddu window が直接閉じられると quit アクションを通らず
+" preview window が取り残されるため、WinClosed で検知して掃除する
+augroup ddu_preview_cleanup
+  autocmd!
+  autocmd WinClosed * call s:schedule_preview_cleanup(str2nr(expand('<abuf>')))
+augroup END
+
+function! s:schedule_preview_cleanup(bufnr) abort
+  if a:bufnr > 0 && getbufvar(a:bufnr, '&filetype') =~# '^ddu-\%(ff\|filer\)$'
+    let name = getbufvar(a:bufnr, 'ddu_ui_name', '')
+    if !empty(name)
+      " NOTE: ddu#ui#do_action は autocmd 内で呼べないため timer で脱出する
+      call timer_start(0, { -> s:do_preview_cleanup(name) })
+    endif
+  endif
+endfunction
+
+function! s:do_preview_cleanup(name) abort
+  try
+    call ddu#ui#do_action('closePreviewWindow', {}, a:name)
+  catch
+    " 正規の quit 経由で閉じた場合など、ddu 側で処理済みなら何もしない
+  endtry
+endfunction
 
 " fuzzy find full text search
 " 元のウィンドウIDを保存してから検索を開始

--- a/.config/nvim/ddu_settings.toml
+++ b/.config/nvim/ddu_settings.toml
@@ -39,6 +39,9 @@ function! s:open_in_prev_window() abort
   if !empty(item) && has_key(item, 'action') && has_key(item.action, 'path')
     if !item->get('isTree', v:false)
       " ファイルの場合
+      " bwipeout はプラグインの quit 経路を通らないため、
+      " 取り残される preview window を先に閉じる
+      call ddu#ui#sync_action('closePreviewWindow')
       let filepath = item.action.path
       " 現在のdduバッファを記録（後で削除するため）
       let ddu_bufnr = bufnr('%')
@@ -96,6 +99,9 @@ function! s:open_in_prev_window_ff() abort
   let item = ddu#ui#get_item()
   if !empty(item) && has_key(item, 'action') && has_key(item.action, 'path')
     let filepath = item.action.path
+    " bwipeout はプラグインの quit 経路を通らないため、
+    " 取り残される preview window を先に閉じる
+    call ddu#ui#sync_action('closePreviewWindow')
     " 現在のdduバッファを記録（後で削除するため）
     let ddu_bufnr = bufnr('%')
     " 元のウィンドウに移動

--- a/.config/nvim/ddu_settings.toml
+++ b/.config/nvim/ddu_settings.toml
@@ -180,6 +180,11 @@ let s:win_size = s:calculate_window_size()
 " ddu Global Setting
 call ddu#custom#patch_global({
 \   'ui': 'ff',
+\   'uiOptions': {
+\     '_': {
+\       'filterPrompt': '> ',
+\     },
+\   },
 \   'actionOptions': {
 \     'open': {
 \       'quit': v:false,
@@ -200,27 +205,30 @@ call ddu#custom#patch_global({
 \   },
 \   'uiParams': {
 \     'ff': {
-\       'prompt': '> ',
 \       'split': 'floating',
-\       'preview': v:true,
 \       'previewFloating': v:true,
 \       'floatingBorder': 'rounded',
-\       'filterSplitDirection': 'floating',
+\       'previewFloatingBorder': 'rounded',
 \       'previewSplit': 'vertical',
+\       'winHeight': s:win_size.winHeight,
+\       'winWidth': s:win_size.winWidth,
+\       'winRow': s:win_size.winRow,
+\       'winCol': s:win_size.winCol,
+\       'previewHeight': s:win_size.previewHeight,
+\       'previewWidth': s:win_size.previewWidth,
+\       'startAutoAction': v:true,
 \       'autoAction': { 'name': 'preview' },
 \     },
 \     'filer': {
 \       'split': 'floating',
 \       'sortTreesFirst': v:true,
 \       'sort': 'filename',
-\       'preview': v:true,
 \       'floatingBorder': 'rounded',
 \       'winHeight': s:win_size.winHeight,
 \       'winWidth': s:win_size.winWidth,
 \       'winRow': s:win_size.winRow,
 \       'winCol': s:win_size.winCol,
 \       'previewSplit': 'vertical',
-\       'filterSplitDirection': 'floating',
 \       'previewFloating': v:true,
 \       'previewHeight': s:win_size.previewHeight,
 \       'previewWidth': s:win_size.previewWidth,
@@ -231,6 +239,7 @@ call ddu#custom#patch_global({
 \          ['&foldcolumn', 0],
 \          ['&wrap', 0],
 \       ],
+\       'startAutoAction': v:true,
 \       'autoAction': { 'name': 'preview' },
 \     }
 \  },
@@ -296,11 +305,6 @@ call ddu#custom#patch_local('text', {
 \       'args': ['--column', '--no-heading', '--color', 'never', '--sort-files', '--hidden'],
 \     },
 \   },
-\   'uiParams': {
-\     'ff': {
-\       'startFilter': v:true,
-\     }
-\   },
 \ })
 
 " fuzzy find buffer
@@ -311,21 +315,11 @@ call ddu#custom#patch_local('buffer', {
 \       'args': ['--column', '--no-heading', '--color', 'never'],
 \     },
 \   },
-\   'uiParams': {
-\     'ff': {
-\       'startFilter': v:true,
-\     }
-\   },
 \ })
 
 " fuzzy find recently used files (MRU) setting
 call ddu#custom#patch_local('mru', {
 \   'sources': [{'name': 'file_old', 'params': {}}],
-\   'uiParams': {
-\     'ff': {
-\       'startFilter': v:true,
-\     }
-\   },
 \ })
 
 " fuzzy find grep cursor word setting
@@ -334,11 +328,6 @@ call ddu#custom#patch_local('word', {
 \     'rg' : {
 \       'args': ['--column', '--no-heading', '--color', 'never'],
 \     },
-\   },
-\   'uiParams': {
-\     'ff': {
-\       'startFilter': v:true,
-\     }
 \   },
 \ })
 
@@ -356,19 +345,6 @@ function! s:ddu_my_settings() abort
         \ <Cmd>call ddu#ui#do_action('openFilterWindow')<CR>
   nnoremap <buffer><silent> q
         \ <Cmd>call ddu#ui#do_action('quit')<CR>
-endfunction
-
-" from ddu document
-autocmd FileType ddu-ff-filter call s:ddu_filter_my_settings()
-function! s:ddu_filter_my_settings() abort
-  " winfixbufを無効化
-  setlocal nowinfixbuf
-  inoremap <buffer><silent> <CR>
-  \ <Esc><Cmd>close<CR>
-  nnoremap <buffer><silent> <CR>
-  \ <Cmd>close<CR>
-  nnoremap <buffer><silent> q
-  \ <Cmd>close<CR>
 endfunction
 '''
 


### PR DESCRIPTION
## [optional body]
telescope 廃止(#452)後の ddu テコ入れ第一弾。カーソル移動でプレビューが
追従する telescope 相当の体験を ddu 全リスト(`,m` `,g` `,b` `,r` `,w`)で
復活させる。

`autoAction: { name: 'preview' }` は設定済みだったが、ddu-ui-ff /
ddu-ui-filer の破壊的変更(2023-07-05)で `startAutoAction: v:true` が
必須になっており発火していなかった。バージョン固定運用のため破壊的変更に
気づけていなかったのが原因。

### 変更内容
- ff / filer の uiParams に `startAutoAction: v:true` を追加(本命の修正)
- 廃止・非実在になっていた「化石設定」を削除:
  - `startFilter`(2024-05-21 廃止。text / buffer / mru / word の4箇所)
  - `filterSplitDirection`(2024-05-21 のフィルターウィンドウ廃止で削除。ff / filer)
  - `preview`(ドキュメントに存在しないパラメータ。ff / filer)
  - `ddu-ff-filter` の autocmd 一式(フィルターウィンドウ廃止により発火しない dead code)
- `prompt` を ff uiParam から ddu core の `uiOptions.filterPrompt` へ移行
- ff にも filer と同じ `s:win_size`(画面80% + 右半分プレビュー)の
  サイズ指定を追加してレイアウトを統一

### 動作確認
- [x] TOML 構文チェック(tomllib)
- [x] `nvim --headless` 起動でエラーなし(lspconfig の deprecation 警告は既存・無関係)
- [ ] 実機で `,m` / `,g` / `,b` / `,r` / `,w` のカーソル追従プレビュー確認 ← マージ前に要チェック

### 備考
- ff のレイアウト設計(filer 統一 vs 小リスト+大プレビュー、previewSplit の向き)は
  dpp.vim 移行時に改めて検討する

## [optional footer(s)]
Closes #458
Closes #460
Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)