### PR TITLE
refactor(nvim): LSP設定をvim.lsp.config/enableベースにネイティブ化しmasonを削除

### DIFF
--- a/.config/nvim/dashboard.toml
+++ b/.config/nvim/dashboard.toml
@@ -177,7 +177,6 @@ local filer = {
 local lsp_nav1 = {
   "         LSP         ",
   "",
-  ":Mason manage LSP server",
   "ge  show diagnostic openf loat",
   "g[  goto diagnostic to prev",
   "g]  goto diagnostic to next",

--- a/.config/nvim/lsp_settings.toml
+++ b/.config/nvim/lsp_settings.toml
@@ -42,9 +42,14 @@ lua_source = '''
       vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, opts)
 
       -- クライアントがフォーマット機能をサポートしている場合、保存時に自動フォーマットを適用する
+      -- none-ls.nvim(prettier)と同じaugroup("LspFormatting")を共有し、登録前にバッファ単位でクリアして常に1つだけ保つ。
+      -- vim.lsp.buf.format()はバッファにアタッチした対応クライアントを全て順に処理するため、
+      -- 複数クライアント(例: ts_ls + null-ls)が同一バッファにアタッチしても1つのautocmdで二重フォーマットにならない
       if client ~= nil and client:supports_method('textDocument/formatting') then
+        local augroup = vim.api.nvim_create_augroup('LspFormatting', { clear = false })
+        vim.api.nvim_clear_autocmds({ group = augroup, buffer = ev.buf })
         vim.api.nvim_create_autocmd('BufWritePre', {
-          group = vim.api.nvim_create_augroup('Format', { clear = false }),
+          group = augroup,
           buffer = ev.buf,
           callback = function() vim.lsp.buf.format({ bufnr = ev.buf }) end,
         })

--- a/.config/nvim/lsp_settings.toml
+++ b/.config/nvim/lsp_settings.toml
@@ -1,10 +1,10 @@
 [[plugins]]
 repo = 'neovim/nvim-lspconfig'
 on_event = 'BufEnter'
+# ddc-source-lsp の capabilities 登録に require('ddc_source_lsp') を使うため、
+# 遅延読み込みされるddc-source-lspを先にrtpへ乗せておく(dein依存解決で強制ソース)
+depends = ['ddc-source-lsp']
 lua_source = '''
-  -- nvim-lspconfigのrequire
-  local nvim_lspconfig = require('lspconfig')
-
   -- グローバルな診断用のキーマッピング
   vim.keymap.set('n', 'ge', vim.diagnostic.open_float)
   vim.keymap.set('n', 'g[', vim.diagnostic.goto_prev)
@@ -14,11 +14,17 @@ lua_source = '''
   -- デバッグログを有効にする場合はコメントを解除
   -- vim.lsp.set_log_level("debug")
 
+  -- ddc-source-lsp (Shougoスタック) が推奨するcapabilitiesを全サーバーに登録
+  -- https://github.com/Shougo/ddc-source-lsp
+  vim.lsp.config('*', {
+    capabilities = require('ddc_source_lsp').make_client_capabilities(),
+  })
 
   -- LSPがアタッチされた時の処理
   vim.api.nvim_create_autocmd('LspAttach', {
     group = vim.api.nvim_create_augroup('UserLspConfig', {}),
     callback = function(ev)
+      local client = vim.lsp.get_client_by_id(ev.data.client_id)
 
       -- バッファローカルなキーマッピングの設定
       local opts = { buffer = ev.buf }
@@ -34,34 +40,21 @@ lua_source = '''
       vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, opts)
       vim.keymap.set({ 'n', 'v' }, '<space>ca', vim.lsp.buf.code_action, opts)
       vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, opts)
-      vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, opts)
+
+      -- クライアントがフォーマット機能をサポートしている場合、保存時に自動フォーマットを適用する
+      if client ~= nil and client:supports_method('textDocument/formatting') then
+        vim.api.nvim_create_autocmd('BufWritePre', {
+          group = vim.api.nvim_create_augroup('Format', { clear = false }),
+          buffer = ev.buf,
+          callback = function() vim.lsp.buf.format({ bufnr = ev.buf }) end,
+        })
+      end
     end,
   })
-  
-  -- 自動フォーマット用のon_attach関数
-  local on_attach = function(client, bufnr)
-    -- クライアントがフォーマット機能をサポートしているか確認
-    if client.server_capabilities.documentFormattingProvider then
-      -- ファイル保存時に自動フォーマットを適用するautocmdを作成
-      vim.api.nvim_create_autocmd("BufWritePre", {
-        group = vim.api.nvim_create_augroup("Format", { clear = true }),
-        buffer = bufnr,
-        callback = function() vim.lsp.buf.format() end
-      })
-    end
-  end
 
-  -- 設定する言語サーバーのリスト
-  local servers = {'rust_analyzer', 'pyright', 'ts_ls'}
-
-  -- 各言語サーバーの設定
-  for _, lsp in ipairs(servers) do
-    nvim_lspconfig[lsp].setup {
-      on_attach = on_attach,  -- 自動フォーマット用の関数を設定
-
-      -- capabilities = capabilities,  -- 必要に応じて追加の機能を設定
-    }
-  end
+  -- 有効化する言語サーバー
+  -- (いずれもnix/modules/neovim.nixのextraPackagesから供給)
+  vim.lsp.enable({ 'rust_analyzer', 'pyright', 'ts_ls' })
 '''
 
 [[plugins]]
@@ -87,35 +80,4 @@ lua_source = '''
       end
     end
   })
-'''
-
-[[plugins]]
-repo = 'williamboman/mason.nvim'
-on_event = 'BufEnter'
-lua_source = '''
-  local mason = require('mason')
-  mason.setup({
-    PATH = "prepend",
-    log_level = vim.log.levels.INFO,
-    pip = {
-      upgrade_pip = false,
-    },
-    ui = {
-      width = 0.6,
-      height = 0.7,
-      icons = {
-        package_installed = "✓",
-        package_pending = "➜",
-        package_uninstalled = "✗"
-      }
-    }
-})
-'''
-
-[[plugins]]
-repo = 'williamboman/mason-lspconfig.nvim'
-on_event = 'BufEnter'
-depends = ['nvim-lspconfig', 'mason.nvim']
-lua_source= '''
-  local mason_lspconfig = require('mason-lspconfig')
 '''

--- a/.config/nvim/mini/mini.toml
+++ b/.config/nvim/mini/mini.toml
@@ -35,7 +35,6 @@ vim.api.nvim_create_autocmd("FileType", {
     "norg",
     "Trouble",
     "lazy",
-    "mason",
     "ddu",
     "ddu-filer-file",
   },

--- a/docs/reference/neovim-config.md
+++ b/docs/reference/neovim-config.md
@@ -55,6 +55,8 @@ ddu.vimベースのファイラー＆検索システム。
 
 ### lsp_settings.toml - Language Server
 
+`vim.lsp.config()` / `vim.lsp.enable()` (Neovim 0.11+ ネイティブAPI) ベース。nvim-lspconfigはサーバー定義データ(`lsp/*.lua`)の提供元としてdeinプラグインのまま維持し、`require('lspconfig')...setup{}`のフレームワーク層は使わない。LSPサーバー本体はすべて`nix/modules/neovim.nix`のextraPackagesから供給される(mason.nvim/mason-lspconfig.nvimは廃止)。
+
 対応言語サーバー:
 
 | Server | Language |
@@ -64,7 +66,6 @@ ddu.vimベースのファイラー＆検索システム。
 | `ts_ls` | TypeScript/JavaScript |
 
 追加ツール:
-- **mason.nvim**: LSPサーバーのインストール管理
 - **none-ls.nvim**: Prettier等のフォーマッター連携
 
 ### copilot.toml - Inline Completion + CopilotChat

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -31,6 +31,8 @@
       # NOTE: python3 (デフォルト版) を使うことでバイナリキャッシュに乗せる（3.11 指名はソースビルドに落ちる）
       # Use default python3 to hit cache.nixos.org; pinning 3.11 forces source builds
       python3Packages.python-lsp-server
+      # NOTE: lsp_settings.tomlはpyrightを有効化(旧mason.nvim経由で供給されていた)。pylspはpython-lsp-server由来で別供給、現状未使用だが将来の切替に残置
+      pyright # Python LSP (lsp_settings.tomlで有効化)
       rust-analyzer
       gopls
       terraform-ls

--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -31,8 +31,9 @@
       # NOTE: python3 (デフォルト版) を使うことでバイナリキャッシュに乗せる（3.11 指名はソースビルドに落ちる）
       # Use default python3 to hit cache.nixos.org; pinning 3.11 forces source builds
       python3Packages.python-lsp-server
-      # NOTE: lsp_settings.tomlはpyrightを有効化(旧mason.nvim経由で供給されていた)。pylspはpython-lsp-server由来で別供給、現状未使用だが将来の切替に残置
-      pyright # Python LSP (lsp_settings.tomlで有効化)
+      # NOTE: pyright は旧mason.nvim経由で供給されていたが、mason削除に伴いここで供給する(python-lsp-serverは別途Nix供給済みだがlsp_settings.tomlでは現状未使用)
+      # pyright was previously supplied via mason.nvim; now supplied here after removing mason (python-lsp-server is also Nix-supplied but currently unused by lsp_settings.toml)
+      pyright
       rust-analyzer
       gopls
       terraform-ls


### PR DESCRIPTION
## 概要

`.config/nvim/lsp_settings.toml` の LSP 設定を、`require('lspconfig')....setup{}` の旧フレームワーク方式から Neovim 0.11+ のネイティブ API (`vim.lsp.config()` / `vim.lsp.enable()`) へ書き換え、mason.nvim / mason-lspconfig.nvim を削除しました。

Closes #446 (Epic: #447)

## 現状構成の棚卸し

変更前の `lsp_settings.toml` は dein の TOML で4ブロック構成でした:

1. **nvim-lspconfig**: `require('lspconfig')[lsp].setup{}` 方式で `rust_analyzer` / `pyright` / `ts_ls` の3サーバーのみ設定。グローバル診断キーマップ + `LspAttach` autocmd でバッファローカルキーマップ + `on_attach` 関数による `documentFormattingProvider` 判定 → `BufWritePre` 自動フォーマット
2. **none-ls.nvim**: prettier のみを formatting source として使用
3. **mason.nvim**: setup のみ(実質、LSPサーバーのインストール管理役)
4. **mason-lspconfig.nvim**: require するだけで実質未使用

`nix/modules/neovim.nix` の `extraPackages` は lua-language-server, nil, typescript-language-server, vscode-langservers-extracted, yaml-language-server, bash-language-server, python3Packages.python-lsp-server (pylsp), rust-analyzer, gopls, terraform-ls, dockerfile-language-server, marksman を供給済みで、これらは nvim-lspconfig の `lsp/*.lua` に定義データが揃っています。

**発見した不一致**: 設定側は `pyright` を使っていましたが、Nix が供給する Python LSP は `pylsp`。`pyright` は mason 経由で個別インストールされていたため、mason を削除すると消える状態でした(下記「設計判断」参照)。

## 設計判断

着手前に司令塔へ以下2点を相談しましたが、司令塔側セッションが別件の権限プロンプトで長時間応答不能だったため、相談時に提示した自分の推奨案で実装を先行して進めました。後日司令塔から両案とも承認の回答が届き、「Issue #446 は refactor ラベル(挙動を変えない)なので既存挙動保持を優先する」という方針が明確化されています。

### Python LSP: pyright を維持(pkgs.pyright を追加)

- **選択肢A**: pylsp へ切替(Nix供給済み、追加コストゼロ)
- **選択肢B(採用)**: pyright を維持し、`pkgs.pyright` を `neovim.nix` の `extraPackages` に追加
- **理由**: 既存挙動を壊さない方を優先。`pkgs.pyright` は nixpkgs トップレベルで提供されており(`nodePackages.pyright` は廃止済み)、`nix build nixpkgs#pyright` で実際にビルドして `pyright` / `pyright-langserver` 両バイナリが揃うことを確認済み。1行追加のコストで済むため破壊的変更を避けられます
- pylsp (python-lsp-server) 自体は Nix 側に残置していますが、現状 lsp_settings.toml からは未参照のままです(このパッケージは元々この不一致の原因でもあったので、コメントで経緯を明記しました)

### none-ls.nvim: 維持

- **選択肢A(採用)**: 維持。prettier 用の軽量ラッパーとして残す
- **選択肢B**: 削除して `BufWritePre` autocmd で prettier を直接実行するネイティブ実装に置換
- **B案を退けた理由**:
  - none-ls は prettier を疑似 LSP クライアントとして登録し、`vim.lsp.buf.format()` の土俵に乗せてくれる。フォーマット結果の適用も含め LSP 標準の `textDocument/formatting` レスポンス処理(バッファへの差分適用)に一本化されており、今回追加した `LspAttach` autocmd の自動フォーマット判定ロジックとも自然に共存する
  - B案(prettier を直接シェルアウト実行)は、フォーマット結果をどうバッファへ反映するかを自前で作り込む必要がある。同期的に `vim.fn.system()` で呼んで `:edit!` するとカーソル位置やアンドゥ履歴が壊れやすく、非同期(`vim.system`)にすると今度は保存直後に別の書き込みが走る競合状態や、フォーマット未完了のままバッファが閉じられるケースのハンドリングが必要になる。prettier 1個のためにこの複雑さを引き受けるのは割に合わない
  - Issue #446 は refactor(挙動を変えない)が前提のため、`vim.lsp.buf.format()` に統一されている既存の安定した経路をそのまま使えるA案が妥当と判断した

### 有効化するサーバー範囲: 現状維持(拡張は将来課題)

Issue の指示どおり、迷った場合は現状維持を優先し `rust_analyzer` / `pyright` / `ts_ls` の3サーバーのみを `vim.lsp.enable()` で有効化しています。Nix は他に `lua_ls` / `nil_ls` / `html` / `cssls` / `jsonls` / `eslint` / `yamlls` / `bashls` / `gopls` / `terraformls` / `dockerls` / `marksman` 用のサーバーも供給済みで、対応する `lsp/*.lua` 定義も nvim-lspconfig に揃っているため、`vim.lsp.enable({...})` の配列に追加するだけで拡張可能です。挙動が変わる(未設定ファイルタイプでも自動的にLSPが起動する)ため、今回はスコープ外としました。

## 実装の詳細

- `vim.lsp.config('*', { capabilities = require('ddc_source_lsp').make_client_capabilities() })` を追加。ddc-source-lsp (Shougoスタック) の README が補完機能をフルに使うために推奨している設定です
  - **ハマりポイント**: `ddc-source-lsp` は `on_source = 'ddc.vim'` で `InsertEnter` まで遅延読み込みされる一方、nvim-lspconfig ブロックは `on_event = 'BufEnter'` で起動直後に読み込まれるため、素朴に `require('ddc_source_lsp')` を呼ぶと初回起動時にモジュールが見つからずエラーになる可能性がありました。nvim-lspconfig の plugin 定義に `depends = ['ddc-source-lsp']` を追加し、dein の依存解決で強制的に先読みさせることで解決しています(dein.vim のソースを確認し、lazy 同士の depends 指定は正しく先読みされる実装になっていることを確認済み)
- `LspAttach` autocmd 内でクライアントの `textDocument/formatting` 対応を判定し、保存時自動フォーマットを設定。旧実装は同じロジックを別の `on_attach` 関数として各サーバーの `.setup{}` に渡していましたが、`vim.lsp.enable()` には `.setup{}` に相当するサーバー単位のコールバック引数がないため、`LspAttach` autocmd 1箇所に統合しました(挙動は変化なし)
- 旧ファイルに存在した `<space>rn` キーマップの重複登録(同じ行が2回書かれていた)も、この書き換えのついでに1つに整理しています
- mason.nvim / mason-lspconfig.nvim ブロックを削除
- `dashboard.toml` の `:Mason manage LSP server` ショートカット表示、`mini.toml` の `mini.indentscope` 無効化対象ファイルタイプ一覧から `mason` を削除
- `docs/reference/neovim-config.md` の `lsp_settings.toml` セクションを更新

## 動作確認

**このリポジトリの nvim 設定は home-manager の symlink 経由でデプロイされるため、worktree 内の編集はライブ環境に反映されません。** `mise run nix:switch` はライブ環境を書き換えるため worktree からは実行していません。今回行った検証は以下の構文・API チェックまでです:

- `python3 -c "import tomllib; ..."` で TOML として正しくパースでき、mason ブロックが除去されていることを確認
- `luac -p` で `lsp_settings.toml` 内の2つの `lua_source` ブロックの構文チェック(エラーなし)
- `nvim --clean --headless` に nvim-lspconfig / ddc-source-lsp / none-ls.nvim / plenary.nvim の実体だけを `runtimepath` に追加し、`luafile` で実際に `lua_source` を実行してエラーが出ないことを確認(`require()` の解決、`vim.lsp.config` / `vim.lsp.enable` / `vim.api.nvim_create_autocmd` などAPI呼び出しの妥当性を実行時検証)
- `nix build nixpkgs#pyright --no-link` でパッケージが実際にビルドでき、`bin/pyright` と `bin/pyright-langserver` が両方存在することを確認
- `nix-instantiate --parse nix/modules/neovim.nix` で Nix 構文を確認

### 実機確認手順(マージ後にホスト側で実施)

1. `mise run nix:switch` を実行してホーム環境に反映
2. dein の state は mtime ベースでキャッシュされ古い hook を使い続ける罠があるため、`~/.cache/dein/state_nvim-unwrapped.vim` 等の state ファイルを削除するか `:call dein#clear_state()` 相当の操作でキャッシュをクリアしてから nvim を起動([reference_nvim_config_deploy_gotcha] 参照)
3. Python / Rust / TypeScript のファイルを開き、以下を確認:
   - `:checkhealth vim.lsp` で `pyright` / `rust_analyzer` / `ts_ls` が Enabled Configurations に出ていること
   - `ge` / `g[` / `g]` / `gr` / `gd` / `gh` / `gs` / `<space>rn` / `<space>ca` / `<space>D` / `<space>wa` / `<space>wr` / `<space>wl` のキーマップが動作すること
   - 保存時に自動フォーマットが効くこと(Rust/Python は LSP側、JS/TS は none-ls経由のprettier)
   - ddc補完(インサートモードでの入力補完)が今までどおり機能すること
4. `:Mason` 等のmason系コマンドが存在しなくなっていることを確認

## 変更ファイル

- `.config/nvim/lsp_settings.toml`
- `.config/nvim/dashboard.toml`
- `.config/nvim/mini/mini.toml`
- `docs/reference/neovim-config.md`
- `nix/modules/neovim.nix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
