### PR TITLE
fix(nvim): treesitterパーサ未インストール問題を解消しmiseで再現可能にする

### DIFF
--- a/.config/nvim/lua/treesitter_parsers.lua
+++ b/.config/nvim/lua/treesitter_parsers.lua
@@ -1,0 +1,30 @@
+-- nvim-treesitter でインストールするパーサの一覧 (唯一の情報源)
+-- treesitter_settings.toml (dein 経由の起動時 require) と
+-- scripts/install_treesitter_parsers.lua (mise タスクの dofile) の両方から参照される。
+-- Single source of truth for the parser list — required by treesitter_settings.toml
+-- at startup and dofile'd by the mise task script, so the list is never duplicated.
+return {
+  "lua",
+  "rust",
+  "python",
+  "fish",
+  "bash",
+  "typescript",
+  "svelte",
+  "json",
+  "go",
+  "dockerfile",
+  "html",
+  "markdown",
+  "markdown_inline",
+  "toml",
+  "make",
+  "yaml",
+  "jsonnet",
+  "hurl",
+  "vim",
+  "vimdoc",
+  "query",
+  "regex",
+  "css",
+}

--- a/.config/nvim/scripts/install_treesitter_parsers.lua
+++ b/.config/nvim/scripts/install_treesitter_parsers.lua
@@ -1,0 +1,46 @@
+-- mise run nvim:ts-install から headless nvim (-u ~/.config/nvim/init.lua -l このファイル) で実行される。
+-- ~/.config/nvim は home-manager 経由でNix storeへ個別シンボリックリンクされるため、worktree の
+-- lua/treesitter_parsers.lua を即座に(マージ前でも)反映するには require ではなく cwd 相対の dofile を使う。
+-- Invoked headless via `mise run nvim:ts-install`. ~/.config/nvim symlinks per-file into the Nix
+-- store, so `require()` would not see worktree edits until nix:switch — dofile a repo-relative path instead.
+local repo_root = arg[1]
+if not repo_root then
+  io.stderr:write("usage: nvim --headless -u ~/.config/nvim/init.lua -l install_treesitter_parsers.lua -- <repo_root>\n")
+  os.exit(1)
+end
+
+local parsers = dofile(repo_root .. '/.config/nvim/lua/treesitter_parsers.lua')
+
+local ts = require('nvim-treesitter')
+ts.setup {}
+
+local install_ok, install_err = pcall(function()
+  ts.install(parsers, { summary = false }):wait(300000)
+end)
+
+-- インストール済みパーサは install() がスキップするだけで報告してくれないため、
+-- .so の有無を自前でチェックして成功/失敗を出力する (silent skip 禁止)
+-- install() silently skips already-installed parsers without reporting them,
+-- so check for each .so directly and print an explicit success/failure summary.
+local parser_dir = vim.fn.stdpath('data') .. '/site/parser'
+local succeeded, failed = {}, {}
+for _, name in ipairs(parsers) do
+  if vim.fn.filereadable(parser_dir .. '/' .. name .. '.so') == 1 then
+    table.insert(succeeded, name)
+  else
+    table.insert(failed, name)
+  end
+end
+
+print('=== treesitter parser install result ===')
+print(string.format('succeeded (%d): %s', #succeeded, table.concat(succeeded, ', ')))
+if #failed > 0 then
+  print(string.format('FAILED (%d): %s', #failed, table.concat(failed, ', ')))
+end
+if not install_ok then
+  print('install() raised an error: ' .. tostring(install_err))
+end
+
+if #failed > 0 or not install_ok then
+  os.exit(1)
+end

--- a/.config/nvim/scripts/install_treesitter_parsers.lua
+++ b/.config/nvim/scripts/install_treesitter_parsers.lua
@@ -5,7 +5,9 @@
 -- store, so `require()` would not see worktree edits until nix:switch — dofile a repo-relative path instead.
 local repo_root = arg[1]
 if not repo_root then
-  io.stderr:write("usage: nvim --headless -u ~/.config/nvim/init.lua -l install_treesitter_parsers.lua -- <repo_root>\n")
+  -- nvim -l はスクリプト後の引数をそのまま arg[] に渡すため -- は不要 (付けると arg[1] が '--' になり壊れる)
+  -- nvim -l passes post-script args straight into arg[] — no `--` separator (adding one makes arg[1] literally '--')
+  io.stderr:write("usage: nvim --headless -u ~/.config/nvim/init.lua -l install_treesitter_parsers.lua <repo_root>\n")
   os.exit(1)
 end
 

--- a/.config/nvim/treesitter_settings.toml
+++ b/.config/nvim/treesitter_settings.toml
@@ -9,32 +9,9 @@ local ts = require('nvim-treesitter')
 ts.setup {}
 
 -- Install parsers
--- Using pcall to avoid errors if parsers are already installed
-local parsers = {
-  "lua",
-  "rust",
-  "python",
-  "fish",
-  "bash",
-  "typescript",
-  "svelte",
-  "json",
-  "go",
-  "dockerfile",
-  "html",
-  "markdown",
-  "markdown_inline",
-  "toml",
-  "make",
-  "yaml",
-  "jsonnet",
-  "hurl",
-  "vim",
-  "vimdoc",
-  "query",
-  "regex",
-  "css",
-}
+-- パーサ一覧は lua/treesitter_parsers.lua に集約 (mise タスクと二重管理しないため)
+-- Parser list lives in lua/treesitter_parsers.lua (shared with the mise install task)
+local parsers = require('treesitter_parsers')
 
 -- Install parsers asynchronously (non-blocking)
 ts.install(parsers, { summary = false })

--- a/.mise.toml
+++ b/.mise.toml
@@ -92,6 +92,23 @@ description = "Stop and remove docker container"
 run = "docker stop arch && docker rm arch"
 
 # =============================================================================
+# Neovim Tasks
+# =============================================================================
+
+[tasks."nvim:ts-install"]
+description = "nvim-treesitterのパーサをtreesitter_parsers.luaのリストに従ってインストール(冪等・既存機は自動スキップ)"
+# tree-sitter CLI は home-manager の nvim ラッパー経由でしか PATH に無いため、
+# 必ず headless nvim 経由でインストールする。~/.config/nvim は個別ファイルシンボリックリンクのため
+# require() ではなく dofile(cwd 相対) でパーサリストを読み、worktree の変更を即時反映する。
+# tree-sitter CLI only exists on nvim's own PATH (via the home-manager wrapper), so this must run
+# through headless nvim. dofile (repo-relative) instead of require() so worktree edits apply immediately.
+run = """
+set -euo pipefail
+repo_root="$(pwd)"
+nvim --headless -u ~/.config/nvim/init.lua -l "$repo_root/.config/nvim/scripts/install_treesitter_parsers.lua" "$repo_root"
+"""
+
+# =============================================================================
 # Utility Tasks
 # =============================================================================
 


### PR DESCRIPTION
## 概要

- Issue #465 で報告された「nvim-treesitterのパーサがyaml以外全て未インストール」の状態を解消
- 実機 (`~/.local/share/nvim/site/parser/`) に23パーサ全てをインストール済み
- 将来のマシンセットアップ・再発時に同じインストールを再現できる `mise run nvim:ts-install` タスクを追加

## 変更内容

- `.config/nvim/lua/treesitter_parsers.lua` (新規): パーサ一覧の単一情報源。tomlの起動時フックとmiseタスクで二重管理しないための切り出し
- `.config/nvim/treesitter_settings.toml`: インライン定義していたパーサ一覧を `require('treesitter_parsers')` に置換。フック構造・`ts.setup`の挙動は変更なし
- `.config/nvim/scripts/install_treesitter_parsers.lua` (新規): headless nvim から呼ばれるインストール用スクリプト。`~/.config/nvim` はhome-manager経由でファイル単位のシンボリックリンクのため、`require()`ではなく`dofile(リポジトリルート相対パス)`でパーサ一覧を読み込み、worktreeでの変更も即時反映されるようにした
- `.mise.toml`: `nvim:ts-install` タスクを追加。`nvim-treesitter`の`install()`が導入済みパーサを自動スキップするため冪等

## インストール結果 (このマシンで実行済み)

23パーサ全て成功: lua, rust, python, fish, bash, typescript, svelte, json, go, dockerfile, html, markdown, markdown_inline, toml, make, yaml, jsonnet, hurl, vim, vimdoc, query, regex, css

## 検証

1. headless nvimで `vim.treesitter.get_string_parser('key: value', 'yaml')` が成功し、パースツリーのroot取得を確認
2. codecompanionのprompt_library frontmatterパース (`commit.md`) が treesitter yaml経由で `name`/`interaction` を正しく取得できることを確認 (`--clean` + site/.dein cache をrtpに追加した最小構成で再現)

## スコープ外

- 起動フックがdein state経由で実行されない根本原因 (#464) は本PRでは扱わない
- `treesitter_settings.toml` の `ts.setup` / フック構造は変更していない (参照先の切り出しのみ)

Closes #465