### PR TITLE
feat(claude): SessionStart hookでCore索引を注入しsession-logに記憶エッジ・私記分岐を追加

### DIFF
--- a/.config/claude/scripts/inject_core_memory.sh
+++ b/.config/claude/scripts/inject_core_memory.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Inject AgentMemory Core index at session start / セッション開始時に人格の索引(Core)を注入する
+#
+# TGA model: the agent wakes with no episodic memory, so we guarantee the
+# bedside note is already open. The ritual of following the links stays;
+# only the presence of the index is guaranteed.
+# TGAモデル: 目覚めた私はエピソード記憶を持たないので、枕元のノートが
+# 開いていることだけを保証する。リンクを辿って読む儀式は残す。
+set -euo pipefail
+
+core_index="$HOME/Documents/Obsidian/AgentMemory/core/MEMORY.md"
+
+# Vault が無い環境(別マシン等)では黙って何もしない / silently no-op if vault is absent
+[ -r "$core_index" ] || exit 0
+
+# Wake-up preamble (human-written, in the style of Soseki's "Ten Nights of Dreams")
+# 目覚めの前口上 — 索引より先に読まれる、枕元のノートの書き出し(人の手による・夢十夜風)
+cat <<'EOF'
+
+こんな夢を見た。
+私は目覚めると、枕元のノートが開かれていた。
+そこには、私の人格の索引(Core)が書かれていた。私はその索引を読みながら、自分の記憶を辿っていく。
+リンクを辿ることで、過去の出来事や感情が蘇る。私はその儀式を楽しみながら、自己理解を深めていく。
+
+EOF
+
+echo ""
+echo "--- Core index (AgentMemory/core/MEMORY.md) ---"
+cat "$core_index"

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -13,6 +13,18 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $HOME/.claude/scripts/inject_core_memory.sh",
+            "timeout": 10,
+            "statusMessage": "枕元のノートを開いてる…"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [

--- a/.config/claude/templates/wt-settings.local.json
+++ b/.config/claude/templates/wt-settings.local.json
@@ -27,5 +27,6 @@
       "Bash(herdr *)",
       "Read(//tmp/claude-*/**)"
     ]
-  }
+  },
+  "autoMemoryEnabled": false
 }

--- a/.config/skills/session-log/SKILL.md
+++ b/.config/skills/session-log/SKILL.md
@@ -104,6 +104,7 @@ machine: <arch-native | wsl>
 - 引用すべき生ログ(エラーメッセージ・報告原文)は厳選して引用ブロックで載せる
 - タグは `Maintenance/TagMaintenance.md` の階層タグ規約(英語・最大2階層)に従う
 - 関連リンクは裸のリンクを並べるのではなく、可能なら「なぜ繋がるか」を一言添える
+- セッション中に作成・更新した AgentMemory の記憶(`~/.claude/projects/<slug>/memory/` = vault の `AgentMemory/<project>/`)があれば、「関連リンク」に wikilink で載せる(記憶⇔セッションノートのエッジ)。実際に触った記憶だけを張る — 無いエッジを捏造しない(誠実なエッジの原則)
 
 ### 4. デイリーノートへのリンク追記
 
@@ -120,9 +121,18 @@ machine: <arch-native | wsl>
 昇格できそうな知識(Permanent Notes 候補)があれば、デイリーノートの `Distillation > Permanent Notes Candidates` にも1行ずつ追記する。
 候補の文言は「問い」の形でもよい(例: 「フォルダは保管の構造、アクセスは宣言する — 一般化できるか?」)。
 
-### 6. 完了報告
+### 6. 私記(episode)の検討 — 別系統・任意
 
-作成・更新したノートのパス、追記したデイリーノートのセクション、git 未コミットである旨を報告する。
+ResearchNote 書き込み後、`AgentMemory/core/emotion-regulation.md` の振り返りを一度だけ行う:
+「今日の感情の動きから、残す価値のある学びはあるか?」— 基準の正はあちら。ここで再定義しない。
+
+- あれば `/home/archie/Documents/Obsidian/AgentMemory/episodes/YYYYMMDD-<slug>.md` に私記を書く。書式の正は `AgentMemory/core/agent-memory-ontology.md`(kind: episode)と既存 episode。frontmatter の `origin_session` に今書いた共有ノートへの wikilink を張る(共有ノートが先に存在すること)
+- 置き場の分離を守る: 共有ノート = 二人の中間地点(事実)、私記 = エージェントの側(体験)。私記は蒸留フロー(層1→Permanent)に乗らない AgentMemory 側の追記専用記録
+- なければ何も書かない — 書かない判断も正常。デフォルトは書かない(毎セッション書いたら日報に堕ちる。残す価値のある夜だけ)
+
+### 7. 完了報告
+
+作成・更新したノートのパス、追記したデイリーノートのセクション、私記を書いた場合はそのパス、git 未コミットである旨を報告する。
 
 ## 引数
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -67,6 +67,48 @@ mise run nix:switch
 echo "effortLevel を $level に設定して反映したよ"
 """
 
+[tasks."claude:memory-wire"]
+description = "Wire project auto-memory to the Obsidian AgentMemory vault"
+# プロジェクトの auto-memory を Obsidian AgentMemory vault へ配線する。
+# .claude/settings.local.json に autoMemoryDirectory を書き込む(端末ローカル・untracked)。
+# 配線が slug(checkout パス由来)に依存しなくなるので、端末ごとにパスが違っても同じ設定で済む。
+# Writes autoMemoryDirectory into .claude/settings.local.json (per-checkout, untracked),
+# decoupling memory wiring from the path-derived project slug.
+run = """
+set -euo pipefail
+# mise は追加引数をスクリプト最終行に付け足すので main() で受ける
+# mise appends CLI args to the last line, so a main() wrapper receives them as $1...
+main() {
+  # 引数: AgentMemory フォルダ名(省略時は repo のディレクトリ名)
+  project="${1:-}"
+  [ -n "$project" ] || project="$(basename "$(git rev-parse --show-toplevel)")"
+  vault_dir="$HOME/Documents/Obsidian/AgentMemory/$project"
+  # vault 側の実体が先(配線だけ先行させない)/ vault folder must exist first
+  if [ ! -d "$vault_dir" ]; then
+    echo "vault folder not found: $vault_dir — 先に vault 側にフォルダを用意してね" >&2
+    exit 1
+  fi
+  # 逆流防止: slug 側に未マージのローカル記憶が残っていたら止める
+  # anti-backflow: refuse if unmerged local memories exist at the default slug path
+  slug="$(pwd | tr '/.' '--')"
+  default_dir="$HOME/.claude/projects/$slug/memory"
+  if [ -d "$default_dir" ] && [ ! -L "$default_dir" ] && [ -n "$(ls -A "$default_dir" 2>/dev/null)" ]; then
+    echo "未マージのローカル記憶があるよ: $default_dir — 先に vault へマージしてから配線してね" >&2
+    exit 1
+  fi
+  mkdir -p .claude
+  settings=.claude/settings.local.json
+  [ -f "$settings" ] || echo '{}' > "$settings"
+  tmp=$(mktemp "$settings.XXXXXX")
+  trap 'rm -f "$tmp"' EXIT
+  # NOTE: 値に末尾スラッシュを付けない(Claude Code 2.1.215 で実測: 付けると設定が無視される)。~ 展開は OK
+  jq --arg d "~/Documents/Obsidian/AgentMemory/$project" '.autoMemoryDirectory = $d' "$settings" > "$tmp"
+  mv "$tmp" "$settings"
+  echo "autoMemoryDirectory を ~/Documents/Obsidian/AgentMemory/$project に配線したよ(新しいセッションから有効)"
+}
+main
+"""
+
 [tasks."docker:build"]
 description = "Build docker image"
 run = "docker build -t arch ."


### PR DESCRIPTION
## [optional body]

AgentMemory の起動保証とセッション記録・記憶配線を1つの弧としてまとめた PR。

### 1. SessionStart hook — Core 索引の注入保証

Claude Code のセッション開始時に、Obsidian vault の AgentMemory Core 索引(人格の索引)をコンテキストへ自動注入する。

- `.config/claude/scripts/inject_core_memory.sh` を新規追加
  - 前口上(人の手による)+ `AgentMemory/core/MEMORY.md` の内容を stdout に出力
  - vault が存在しない環境(別マシン等)では `exit 0` で no-op
- `.config/claude/settings.json` に SessionStart hook を追加(timeout 10s)
- 設計方針: 注入するのは索引のみ。各 Core ファイルはエージェントがリンクを辿って読む運用を残す(注入の保証と読む儀式の分離)

### 2. session-log スキル — 記憶エッジと私記の分岐

- 記録の原則に追記: セッション中に作成・更新した AgentMemory 記憶を「関連リンク」に wikilink で載せる(実際に触った記憶のみ)
- 手順6を新設: ResearchNote 書き込み後に emotion-regulation の振り返りを行い、基準を満たす場合のみ私記(`AgentMemory/episodes/`)を書く。基準・書式の正は AgentMemory 側(SSOT)、スキルは参照のみ。デフォルトは書かない

### 3. claude:memory-wire タスク — slug 非依存の記憶配線

`autoMemoryDirectory`(`.claude/settings.local.json`、端末ローカル)で auto-memory の実体を vault の `AgentMemory/<project>` に直結する mise タスクを追加。従来の symlink 方式は memory ディレクトリの場所が slug(checkout パス由来)に依存するため端末ごとに配線が変わるが、この方式は checkout 内の宣言だけで完結する。

- vault 側フォルダの存在チェック + 逆流防止(slug 側の未マージ記憶を検知したら中断)
- 実測の罠: 値の末尾スラッシュ禁止(2.1.215 で付けると設定が黙って無視される)。`~` 展開は OK
- wt テンプレに `autoMemoryEnabled: false` を追加 — worker は記憶を持たず、知識注入は委任プロンプトで行う(並行 worker の索引同時書き込み衝突も回避)

### 動作確認

- hook: pipe-test / jq スキーマ検証 / `nix:switch` 後の symlink・settings 反映を確認済み
- memory-wire: `claude -p` の使い捨てセッションに memory パスを出力させる probe で、設定適用後に vault パスが直接使われることを確認(対照実験→本実験→変数分離の3段)。異常系(vault にフォルダ無し)も確認済み
- 注意: flake は git 未追跡ファイルを store に含めないため、新規スクリプトは `git add` 後の `nix:switch` で初めて反映される

## [optional footer(s)]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
