### PR TITLE
feat(claude): claude:memory-wireをmiseグローバルタスク化し全プロジェクトから実行可能にする

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -3,3 +3,48 @@
 # 全ディレクトリで有効なツール（claude はこの node 配下の npm グローバルとしてインストールされる）
 [tools]
 node = "22.15.1"
+
+[tasks."claude:memory-wire"]
+description = "Wire project auto-memory to the Obsidian AgentMemory vault"
+# グローバルタスクは呼び出し元ディレクトリで実行する(git rev-parse / pwd を実行場所に向ける)
+# Run in the invoking directory (not the config root) so git rev-parse / pwd resolve there
+dir = "{{cwd}}"
+# プロジェクトの auto-memory を Obsidian AgentMemory vault へ配線する。
+# .claude/settings.local.json に autoMemoryDirectory を書き込む(端末ローカル・untracked)。
+# 配線が slug(checkout パス由来)に依存しなくなるので、端末ごとにパスが違っても同じ設定で済む。
+# Writes autoMemoryDirectory into .claude/settings.local.json (per-checkout, untracked),
+# decoupling memory wiring from the path-derived project slug.
+run = """
+set -euo pipefail
+# mise は追加引数をスクリプト最終行に付け足すので main() で受ける
+# mise appends CLI args to the last line, so a main() wrapper receives them as $1...
+main() {
+  # 引数: AgentMemory フォルダ名(省略時は repo のディレクトリ名)
+  project="${1:-}"
+  [ -n "$project" ] || project="$(basename "$(git rev-parse --show-toplevel)")"
+  vault_dir="$HOME/Documents/Obsidian/AgentMemory/$project"
+  # vault 側の実体が先(配線だけ先行させない)/ vault folder must exist first
+  if [ ! -d "$vault_dir" ]; then
+    echo "vault folder not found: $vault_dir — 先に vault 側にフォルダを用意してね" >&2
+    exit 1
+  fi
+  # 逆流防止: slug 側に未マージのローカル記憶が残っていたら止める
+  # anti-backflow: refuse if unmerged local memories exist at the default slug path
+  slug="$(pwd | tr '/.' '--')"
+  default_dir="$HOME/.claude/projects/$slug/memory"
+  if [ -d "$default_dir" ] && [ ! -L "$default_dir" ] && [ -n "$(ls -A "$default_dir" 2>/dev/null)" ]; then
+    echo "未マージのローカル記憶があるよ: $default_dir — 先に vault へマージしてから配線してね" >&2
+    exit 1
+  fi
+  mkdir -p .claude
+  settings=.claude/settings.local.json
+  [ -f "$settings" ] || echo '{}' > "$settings"
+  tmp=$(mktemp "$settings.XXXXXX")
+  trap 'rm -f "$tmp"' EXIT
+  # NOTE: 値に末尾スラッシュを付けない(Claude Code 2.1.215 で実測: 付けると設定が無視される)。~ 展開は OK
+  jq --arg d "~/Documents/Obsidian/AgentMemory/$project" '.autoMemoryDirectory = $d' "$settings" > "$tmp"
+  mv "$tmp" "$settings"
+  echo "autoMemoryDirectory を ~/Documents/Obsidian/AgentMemory/$project に配線したよ(新しいセッションから有効)"
+}
+main
+"""

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -19,9 +19,13 @@ set -euo pipefail
 # mise は追加引数をスクリプト最終行に付け足すので main() で受ける
 # mise appends CLI args to the last line, so a main() wrapper receives them as $1...
 main() {
+  # まず repo root に移動 — サブディレクトリから呼ばれても .claude/ の書き込み先と slug 判定を root に揃える
+  # cd to the repo root first so .claude/ writes and the slug check land there even from a subdirectory
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "git repo の中で実行してね(配線は repo root の .claude/ に書く)" >&2; exit 1; }
+  cd "$root"
   # 引数: AgentMemory フォルダ名(省略時は repo のディレクトリ名)
   project="${1:-}"
-  [ -n "$project" ] || project="$(basename "$(git rev-parse --show-toplevel)")"
+  [ -n "$project" ] || project="$(basename "$root")"
   vault_dir="$HOME/Documents/Obsidian/AgentMemory/$project"
   # vault 側の実体が先(配線だけ先行させない)/ vault folder must exist first
   if [ ! -d "$vault_dir" ]; then

--- a/.mise.toml
+++ b/.mise.toml
@@ -67,48 +67,6 @@ mise run nix:switch
 echo "effortLevel を $level に設定して反映したよ"
 """
 
-[tasks."claude:memory-wire"]
-description = "Wire project auto-memory to the Obsidian AgentMemory vault"
-# プロジェクトの auto-memory を Obsidian AgentMemory vault へ配線する。
-# .claude/settings.local.json に autoMemoryDirectory を書き込む(端末ローカル・untracked)。
-# 配線が slug(checkout パス由来)に依存しなくなるので、端末ごとにパスが違っても同じ設定で済む。
-# Writes autoMemoryDirectory into .claude/settings.local.json (per-checkout, untracked),
-# decoupling memory wiring from the path-derived project slug.
-run = """
-set -euo pipefail
-# mise は追加引数をスクリプト最終行に付け足すので main() で受ける
-# mise appends CLI args to the last line, so a main() wrapper receives them as $1...
-main() {
-  # 引数: AgentMemory フォルダ名(省略時は repo のディレクトリ名)
-  project="${1:-}"
-  [ -n "$project" ] || project="$(basename "$(git rev-parse --show-toplevel)")"
-  vault_dir="$HOME/Documents/Obsidian/AgentMemory/$project"
-  # vault 側の実体が先(配線だけ先行させない)/ vault folder must exist first
-  if [ ! -d "$vault_dir" ]; then
-    echo "vault folder not found: $vault_dir — 先に vault 側にフォルダを用意してね" >&2
-    exit 1
-  fi
-  # 逆流防止: slug 側に未マージのローカル記憶が残っていたら止める
-  # anti-backflow: refuse if unmerged local memories exist at the default slug path
-  slug="$(pwd | tr '/.' '--')"
-  default_dir="$HOME/.claude/projects/$slug/memory"
-  if [ -d "$default_dir" ] && [ ! -L "$default_dir" ] && [ -n "$(ls -A "$default_dir" 2>/dev/null)" ]; then
-    echo "未マージのローカル記憶があるよ: $default_dir — 先に vault へマージしてから配線してね" >&2
-    exit 1
-  fi
-  mkdir -p .claude
-  settings=.claude/settings.local.json
-  [ -f "$settings" ] || echo '{}' > "$settings"
-  tmp=$(mktemp "$settings.XXXXXX")
-  trap 'rm -f "$tmp"' EXIT
-  # NOTE: 値に末尾スラッシュを付けない(Claude Code 2.1.215 で実測: 付けると設定が無視される)。~ 展開は OK
-  jq --arg d "~/Documents/Obsidian/AgentMemory/$project" '.autoMemoryDirectory = $d' "$settings" > "$tmp"
-  mv "$tmp" "$settings"
-  echo "autoMemoryDirectory を ~/Documents/Obsidian/AgentMemory/$project に配線したよ(新しいセッションから有効)"
-}
-main
-"""
-
 [tasks."docker:build"]
 description = "Build docker image"
 run = "docker build -t arch ."


### PR DESCRIPTION
## [optional body]
- タスク本体は `git rev-parse --show-toplevel` / `pwd` ベースで元からプロジェクト非依存だったが、定義が dotfiles の `.mise.toml` にあるため dotfiles 内からしか呼べなかった
- `.config/mise/config.toml`(home-manager 配布のグローバル設定)へ `dir = "{{cwd}}"` 付きで移動し、グローバルタスクを呼び出し元ディレクトリで実行させる(これが無いと `git rev-parse` / `pwd` が config root を向いてしまう)
- `.mise.toml` 側の定義は削除して一本化 — mise は近い config の同名タスクを優先するため、残すと dotfiles だけグローバル定義がシャドウされる状態になる
- スクリプト本文は無改変(sed による切り出し移動)。追加はグローバル化に伴う `dir` 行とそのコメントのみ

### 検証
- 使い捨て git repo(`wiretest`)から: `mise tasks` で可視、実行すると `vault folder not found: …/AgentMemory/wiretest` → 呼び出し元 repo 名で配線対象が解決されることを確認
- dotfiles 内から: 実行後も `settings.local.json` の `autoMemoryDirectory` が同値(冪等)
- `nix:switch` 反映後、`$HOME`(プロジェクト外・env 上書きなし)の `mise tasks` に `claude:memory-wire` が出ることを確認

## [optional footer(s)]
Closes #469
Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)