### PR TITLE
feat(nvim): dpp installer運用の整備 — :DppInstall/:DppUpdateコマンドと初回自動インストール

### DIFF
--- a/.config/nvim/dashboard.toml
+++ b/.config/nvim/dashboard.toml
@@ -201,7 +201,7 @@ default.buttons = {
     button("e", "  New file", ":ene <BAR> startinsert <CR>"),
     button("f", "  Find file ", ":Ddu file_rec <CR>"),
     button("r", "  Recently used files", ":Ddu -name=mru <CR>"),
-    button("u", "  Update", ":call dein#update()<CR>"),
+    button("u", "  Update", ":DppUpdate<CR>"),
     button("c", "  Configuration", ":e ~/.config/nvim/init.lua <CR>"),
     button("q", "  quit", ":qa<CR>"),
   },

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -106,7 +106,13 @@ else
       )
       return
     end
-    vim.fn['dpp#async_ext_action']('installer', action, params or {})
+    -- 注: Luaの空テーブル{}はvim.fn境界で空リスト[]に変換され、dpp側の
+    -- isRecord検証に弾かれる(実機で確認済み)。空paramsはvim.empty_dict()で
+    -- 辞書として渡す。
+    -- NOTE: an empty Lua table {} crosses the vim.fn boundary as an empty
+    -- LIST [], which dpp's isRecord assertion rejects (observed live).
+    -- Pass vim.empty_dict() so empty params serialize as a dict.
+    vim.fn['dpp#async_ext_action']('installer', action, params or vim.empty_dict())
   end
 
   -- 自動インストールをトリガーしたかどうかを覚えておき、その場合だけ
@@ -134,11 +140,11 @@ else
       'dpp: no plugins found under repos/. Auto-installing (this may take a while)...',
       vim.log.levels.INFO
     )
-    dpp_run_installer('install', {})
+    dpp_run_installer('install')
   end
 
   vim.api.nvim_create_user_command('DppInstall', function()
-    dpp_run_installer('install', {})
+    dpp_run_installer('install')
   end, { desc = 'Install missing dpp plugins (dpp-ext-installer#install)' })
 
   vim.api.nvim_create_user_command('DppUpdate', function(opts)
@@ -152,7 +158,7 @@ else
     -- されており、更新は意図的なrev bump PR経由が原則。dpp-protocol-gitは
     -- update後もrev固定プラグインを当該revへ再チェックアウトするため無条件
     -- 実行してもrevは動かないが、本コマンドを基盤層更新の手段として使わないこと。
-    local params = {}
+    local params = vim.empty_dict()
     if #opts.fargs > 0 then
       params.names = opts.fargs
     end

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -82,9 +82,14 @@ else
   -- Detects "no cloned plugins under dpp_base/repos yet" — covers both the
   -- initial bootstrap and repos/ having been wiped out of band (e.g. manual
   -- cache cleanup), not just first launch.
+  -- 判定は実クローンの有無(.git の存在)で行う。repos/<host>/<owner>/<repo>
+  -- の3階層構造のため、途中のプレースホルダディレクトリだけが残っていても
+  -- 「未インストール」と正しく判定できる。
+  -- The check looks for actual clones (.git present). repos/ nests as
+  -- <host>/<owner>/<repo>, so leftover placeholder directories alone still
+  -- correctly count as "not installed".
   local function dpp_repos_missing()
-    return vim.fn.isdirectory(dpp_base .. '/repos') == 0
-      or #vim.fn.glob(dpp_base .. '/repos/*', 0, 1) == 0
+    return #vim.fn.glob(dpp_base .. '/repos/*/*/*/.git', 0, 1) == 0
   end
 
   -- dpp#async_ext_action() はdenops経由で動くため、denops未起動時に呼ぶと
@@ -113,6 +118,14 @@ else
   local dpp_auto_install_pending = false
 
   local function dpp_auto_install_if_missing()
+    -- minimalプロファイル(Docker等)はプラグイン宣言が空で repos/ が空なのが
+    -- 正常状態。自動インストールすると毎起動で空振りの通知が出るためスキップ。
+    -- Under the minimal profile (e.g. Docker) an empty plugin set — and thus
+    -- an empty repos/ — is the normal state. Skip auto-install to avoid a
+    -- no-op install + notification on every startup.
+    if vim.env.DOTFILES_PROFILE == 'minimal' then
+      return
+    end
     if not dpp_repos_missing() then
       return
     end

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -76,9 +76,80 @@ else
   local dpp_base = vim.env.HOME .. '/.cache/dpp'
   local dpp_config_path = vim.fn.stdpath('config') .. '/dpp/config.ts'
 
+  -- dpp_base/repos配下にクローン済みプラグインが1つもない状態を検知する。
+  -- 初回起動(bootstrap直後)だけでなく、repos/を手動やキャッシュ掃除などで
+  -- out-of-bandに消してしまったケースも同じ条件で拾える。
+  -- Detects "no cloned plugins under dpp_base/repos yet" — covers both the
+  -- initial bootstrap and repos/ having been wiped out of band (e.g. manual
+  -- cache cleanup), not just first launch.
+  local function dpp_repos_missing()
+    return vim.fn.isdirectory(dpp_base .. '/repos') == 0
+      or #vim.fn.glob(dpp_base .. '/repos/*', 0, 1) == 0
+  end
+
+  -- dpp#async_ext_action() はdenops経由で動くため、denops未起動時に呼ぶと
+  -- 失敗する。:DppInstall/:DppUpdate/自動インストールの全呼び出し口はここを通す。
+  -- dpp#async_ext_action() talks to denops; calling it before denops is up
+  -- fails. Every entry point below (:DppInstall/:DppUpdate/auto-install)
+  -- routes through this guard.
+  local function dpp_run_installer(action, params)
+    if vim.fn['denops#server#status']() ~= 'running' then
+      vim.notify(
+        'dpp: denops server is not running yet. '
+          .. 'Wait for it to finish starting (see DenopsReady) and retry.',
+        vim.log.levels.WARN
+      )
+      return
+    end
+    vim.fn['dpp#async_ext_action']('installer', action, params or {})
+  end
+
+  -- 自動インストールをトリガーしたかどうかを覚えておき、その場合だけ
+  -- installer完了時に「再起動してね」通知を出す(手動:DppUpdateの度に
+  -- 出るのは煩わしいため)。
+  -- Remembers whether *this* run triggered the auto-install, so the
+  -- "restart Neovim" notice only fires for that path — not on every manual
+  -- :DppUpdate.
+  local dpp_auto_install_pending = false
+
+  local function dpp_auto_install_if_missing()
+    if not dpp_repos_missing() then
+      return
+    end
+    dpp_auto_install_pending = true
+    vim.notify(
+      'dpp: no plugins found under repos/. Auto-installing (this may take a while)...',
+      vim.log.levels.INFO
+    )
+    dpp_run_installer('install', {})
+  end
+
+  vim.api.nvim_create_user_command('DppInstall', function()
+    dpp_run_installer('install', {})
+  end, { desc = 'Install missing dpp plugins (dpp-ext-installer#install)' })
+
+  vim.api.nvim_create_user_command('DppUpdate', function(opts)
+    -- NOTE (Decision Log D2): base-layer plugins (denops/ddc/ddu core, UI
+    -- layer) are rev-pinned in TOML; bump them via an intentional rev-bump
+    -- PR, not this command. dpp-protocol-git re-checks-out `rev`-pinned
+    -- plugins after update, so an unqualified :DppUpdate does not move
+    -- them in practice — but this command must not become the mechanism
+    -- used to bump base-layer revs.
+    -- 注(Decision Log D2): 基盤層(denops/ddc/ddu本体・UI層)はTOMLでrev固定
+    -- されており、更新は意図的なrev bump PR経由が原則。dpp-protocol-gitは
+    -- update後もrev固定プラグインを当該revへ再チェックアウトするため無条件
+    -- 実行してもrevは動かないが、本コマンドを基盤層更新の手段として使わないこと。
+    local params = {}
+    if #opts.fargs > 0 then
+      params.names = opts.fargs
+    end
+    dpp_run_installer('update', params)
+  end, { nargs = '*', desc = 'Update dpp plugins (all, or the given plugin names)' })
+
   if vim.fn['dpp#min#load_state'](dpp_base) ~= 0 then
     -- state未生成(初回起動 or state破棄後): denops起動後にmake_state()で
-    -- state(startup.vim/state.vim)を生成する。
+    -- state(startup.vim/state.vim)を生成する。make_state成功後もrepos/が
+    -- 空なことがある(#479実害)ため、Dpp:makeStatePost側で欠損チェックする。
     vim.api.nvim_create_autocmd('User', {
       pattern = 'DenopsReady',
       once = true,
@@ -86,12 +157,36 @@ else
         vim.fn['dpp#make_state'](dpp_base, dpp_config_path)
       end,
     })
+  else
+    -- state生成済み(通常起動): make_state()は走らずDpp:makeStatePostも
+    -- 発火しないため、repos/欠損はここでdenops起動後に一度だけチェックする。
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'DenopsReady',
+      once = true,
+      callback = dpp_auto_install_if_missing,
+    })
   end
 
   vim.api.nvim_create_autocmd('User', {
     pattern = 'Dpp:makeStatePost',
     callback = function()
       vim.notify('dpp#make_state() done. Restart Neovim to load plugins.')
+      dpp_auto_install_if_missing()
+    end,
+  })
+
+  -- installer install/updateの完了通知(Dpp:ext:installer:updateDone)。
+  -- 自動インストールをトリガーした時だけ再起動を促す。
+  vim.api.nvim_create_autocmd('User', {
+    pattern = 'Dpp:ext:installer:updateDone',
+    callback = function()
+      if dpp_auto_install_pending then
+        dpp_auto_install_pending = false
+        vim.notify(
+          'dpp: initial plugin install finished. Restart Neovim to load them.',
+          vim.log.levels.INFO
+        )
+      end
     end,
   })
 

--- a/docs/reference/neovim-config.md
+++ b/docs/reference/neovim-config.md
@@ -116,7 +116,7 @@ CopilotChat.nvimの後継。[ACP (Agent Client Protocol)](https://github.com/oli
 |---------|-------------|
 | `:DppInstall` | 未インストールのプラグインを一括インストール(`dpp-ext-installer#install`のラッパー) |
 | `:DppUpdate` | 全プラグインを更新(`dpp-ext-installer#update`のラッパー) |
-| `:DppUpdate {plugin...}` | 指定したプラグインのみ更新(スペース区切りで複数指定可) |
+| `:DppUpdate [plugin ...]` | 指定したプラグインのみ更新(スペース区切りで複数指定可・省略時は全プラグイン) |
 
 両コマンドとも、denopsサーバー起動前(`DenopsReady`前)に実行すると警告を出して中断する(`denops#server#status() != 'running'`をガード)。
 

--- a/docs/reference/neovim-config.md
+++ b/docs/reference/neovim-config.md
@@ -9,6 +9,7 @@
 ## 📚 Table of Contents
 
 - [TOML File Structure](#toml-file-structure)
+- [Plugin Management (dpp)](#plugin-management-dpp)
 - [Keybindings](#keybindings)
 - [Related Files](#related-files)
 
@@ -102,6 +103,35 @@ CopilotChat.nvimの後継。[ACP (Agent Client Protocol)](https://github.com/oli
 | `mini.comment` | コメントトグル (`gc`) |
 | `mini.splitjoin` | 引数の分割・結合 |
 | `mini.surround` | テキストを囲む操作 |
+
+---
+
+## 🔌 Plugin Management (dpp)
+
+> dein→dpp移行([#478](https://github.com/music-brain88/dotfiles/pull/478))のフォローアップ([#479](https://github.com/music-brain88/dotfiles/issues/479))。dpp.vimは「本体ミニマル＋拡張分離」の設計思想のため、dein時代と異なりプラグインの取得(インストール・更新)は`dpp-ext-installer`経由の明示的なアクション呼び出しが必要。
+
+### コマンド
+
+| Command | Description |
+|---------|-------------|
+| `:DppInstall` | 未インストールのプラグインを一括インストール(`dpp-ext-installer#install`のラッパー) |
+| `:DppUpdate` | 全プラグインを更新(`dpp-ext-installer#update`のラッパー) |
+| `:DppUpdate {plugin...}` | 指定したプラグインのみ更新(スペース区切りで複数指定可) |
+
+両コマンドとも、denopsサーバー起動前(`DenopsReady`前)に実行すると警告を出して中断する(`denops#server#status() != 'running'`をガード)。
+
+### 初回起動時の自動インストール
+
+`init.lua`は`~/.cache/dpp/repos/`配下にクローン済みプラグインが1つもない状態を検知すると、`:DppInstall`相当の処理を通知付きで自動発動する。検知タイミングは以下の2箇所:
+
+- `Dpp:makeStatePost`(state生成直後。主に初回起動でここに引っかかる)
+- `DenopsReady`(state生成済みの通常起動時。`repos/`がキャッシュ掃除等で out-of-band に消失していた場合の保険)
+
+自動インストールが完了すると`Dpp:ext:installer:updateDone`イベントで検知し、「Neovimを再起動してプラグインを読み込んでください」と通知する(自動インストールをトリガーした場合のみ表示。手動`:DppUpdate`のたびには出さない)。
+
+### 更新方針(Decision Log D2: 基盤層はrev固定)
+
+denops/ddc/ddu本体・UI層などの基盤層プラグインはTOMLで`rev`を固定しており、dpp-protocol-gitがそのrev指定を尊重するため`:DppUpdate`を無条件に実行してもバージョンは動かない。ただし基盤層プラグインの更新自体は`:DppUpdate`に頼らず、**意図的なrev bump PR**を経由するのが原則([Epic #447](https://github.com/music-brain88/dotfiles/issues/447) Decision Log D2)。`:DppUpdate`は非基盤層プラグイン(rev未指定)の追従更新に使う。
 
 ---
 


### PR DESCRIPTION
## 概要
PR #478(dein→dpp移行本体)のフォローアップ。Issue #479 の実装。dpp.vimは「本体ミニマル+拡張分離」の設計思想のため、dein時代のような自動インストールが無く、プラグイン取得は明示的な ext action 呼び出しが必要になった。実機で2026-07-20に「初回起動時、`make_state` 成功後も `~/.cache/dpp/repos/` が空でプラグインゼロのまま起動する」実害が発生し、`:call dpp#async_ext_action('installer', 'install')` の手動実行で解消していたため、これを恒久対応する。

Closes #479

## 変更内容

### `.config/nvim/init.lua`
既存の dpp bootstrap(環境変数ガードの else ブロック内)に以下を追加:

1. **`:DppInstall`**: `dpp-ext-installer#install` のラッパー
2. **`:DppUpdate [plugin...]`**: `dpp-ext-installer#update` のラッパー。引数なしで全体、引数ありで指定プラグインのみ更新
3. **denops未起動ガード**: 両コマンドとも `denops#server#status() != 'running'` を共通の `dpp_run_installer()` 関数でチェックし、denops未起動時は警告 notify を出して `dpp#async_ext_action` を呼ばずに中断する
4. **初回起動時の自動インストール**: `~/.cache/dpp/repos/` 配下にクローン済みプラグインが1つもない状態(`dpp_repos_missing()`)を検知したら install を自動発動する。検知タイミングは2箇所:
   - `Dpp:makeStatePost`(state生成直後。主に初回起動)
   - `DenopsReady`(state生成済みの通常起動時。`repos/` が out-of-band に消失していた場合の保険)
   - `Dpp:ext:installer:updateDone` で完了を検知し、自動インストールをトリガーした場合のみ「再起動してください」通知を出す(手動 `:DppUpdate` の度には出さない)

### `docs/reference/neovim-config.md`
「Plugin Management (dpp)」セクションを新規追加。上記コマンド・自動インストールの挙動、および基盤層(denops/ddc/ddu本体・UI層)は TOML の `rev` 固定を維持し、更新は `:DppUpdate` ではなく意図的な rev bump PR 経由が原則である旨(Decision Log D2)を明記した。dein 前提の他セクションの全面書き換えは今回のスコープ外(移行完了後の別PRで対応)。

## 設計判断メモ
- `installer#update` アクションの実装(`dpp-ext-installer`)を読むと、`plugin.rev` が設定されたプラグインは更新コマンド実行の前後で強制的に当該revへチェックアウトし直す(`revisionLockPlugin`)。つまり rev 固定の尊重は dpp 本体側が保証しており、コマンド実装側で追加のフィルタリングは不要と判断。ドキュメント・コード両方に運用原則(意図的な rev bump PR 経由)をコメントとして明記するに留めた
- 自動インストールの検知は Issue の「`Dpp:makeStatePost` 後、または起動時に」を素直に汲み、両方のタイミングでチェックする実装にした(state生成済みの通常起動でも `repos/` 欠損をカバーできるようにするため)

## 検証(隔離環境、headless nvim)
ライブの `~/.config/nvim`・`~/.cache/dpp` には書き込んでいない。`HOME`/`XDG_CONFIG_HOME`/`XDG_CACHE_HOME` 等を worktree 内・一時ディレクトリへ差し替えた隔離環境で検証(PR #478 の検証方式を踏襲)。

```
HOME=<tmp> XDG_CONFIG_HOME=<worktree>/.config XDG_CACHE_HOME=<tmp>/.cache-test \
  nvim --headless -c "luafile verify_dpp_installer.lua"
```

```
command_DppInstall_exists=true
command_DppUpdate_exists=true
denops_status=stopped
after_DppInstall_notify=dpp: denops server is not running yet. Wait for it to finish starting (see DenopsReady) and retry.
after_DppUpdate_bare_notify=dpp: denops server is not running yet. Wait for it to finish starting (see DenopsReady) and retry.
after_DppUpdate_named_notify=dpp: denops server is not running yet. Wait for it to finish starting (see DenopsReady) and retry.
after_makeStatePost_notify=dpp#make_state() done. Restart Neovim to load plugins. || dpp: no plugins found under repos/. Auto-installing (this may take a while)... || dpp: denops server is not running yet. Wait for it to finish starting (see DenopsReady) and retry.
```

確認できたこと:
- `:DppInstall` / `:DppUpdate` コマンドが定義されている
- denops未起動状態(`stopped`)で両コマンドを実行すると、`dpp#async_ext_action` を呼ばずに警告のみで中断する(ガードが機能)
- `Dpp:makeStatePost` を疑似発火させると、`repos/` 欠損を検知して自動インストール通知が出た上で installer 呼び出しを試み、denopsガードに引っかかって中断する一連の流れが動作する(＝「欠損検知→installerアクション発火(予約)」の判定ロジックが機能していることを確認)

実機フルclone検証(60リポジトリのclone)は Issue の指示通り実施していない。判定ロジックの単体確認を優先した。

## 補足
PR-4(#474、dein掃除)との統合はせず、別PRのまま。`docs/reference/neovim-config.md` の dein 前提記述の全面書き換えは今回のスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)