### PR TITLE
fix(skills): session-log の context 判定をマシン由来から repo owner 由来に分離

### DIFF
--- a/.config/skills/session-log/SKILL.md
+++ b/.config/skills/session-log/SKILL.md
@@ -39,7 +39,9 @@ ResearchNotes は Zenn 下書きの供給源でもある。週次レビューで
 ## 前提情報
 
 - Vault: `/home/archie/Documents/Obsidian/Zettelkasten/`(ファイル直接読み書き。Obsidian MCP は使わない。WSL ではこのパスは Windows 側 vault への symlink — nix/modules/wsl.nix が管理)
-- **出自の判定**: vault は全マシン共有(Obsidian Sync)なので、どこで書いたかを frontmatter に刻む。`uname -r` に `microsoft` を含む → 仕事機なので `context: work` / `machine: wsl`。それ以外(native Arch)→ `context: personal` / `machine: arch-native`
+- **出自の判定**: vault は全マシン共有(Obsidian Sync)なので、出自を frontmatter に刻む。`machine` と `context` は別の軸として判定する:
+  - **machine**(どこで書いたか): `uname -r` に `microsoft` を含む → `machine: wsl`。それ以外(native Arch)→ `machine: arch-native`
+  - **context**(何の文脈か): マシンではなく、セッションの主対象リポジトリの owner で判定する(`git remote get-url origin`)。勤務先系 org のリポジトリ → `context: work`、それ以外(個人リポジトリ・第三者 OSS の clone)→ `context: personal`。具体的な org リストの正は `Zettelkasten/MOC-ObsidianWorkflow.md` の「出自判定宣言」(アクセスパターン宣言と同様、食い違う場合はそちらを優先)。リポジトリに紐付かないセッションは内容で判断する(迷ったら personal)
 - **パス・運用ルールの単一の真実**: `Zettelkasten/MOC-ObsidianWorkflow.md` の「アクセスパターン宣言」。本スキルの記載と食い違う場合はそちらを優先し、差分を報告する
 - 保存先: `ResearchNotes/ClaudeCodeSession-YYYYMMDD-<TopicSlug>.md`(TopicSlug は PascalCase の英語)
 - デイリーノート: `DailyNotes/YYYY-MM-DD.md`(フラット構造・年月フォルダなし)


### PR DESCRIPTION
## [optional body]

session-log スキルの「出自の判定」で、`machine`(どこで書いたか)と `context`(何の文脈か)が `uname -r` の同一軸に潰れており、仕事機(WSL)で個人プロジェクトのセッションを記録した際に `context: work` と誤判定された(2026-07-21 に実際に発生、当該ノートは手動修正済み)。

- **machine**: `uname -r` 由来(現行どおり)
- **context**: セッションの主対象リポジトリの owner で判定(`git remote get-url origin`)。勤務先系 org → `work`、それ以外(個人リポジトリ・第三者 OSS clone)→ `personal`。リポジトリに紐付かないセッションは内容で判断(迷ったら personal)
- 具体的な org リストは公開リポジトリに置かず、vault の `MOC-ObsidianWorkflow.md`「出自判定宣言」を単一の真実とする(アクセスパターン宣言と同じ「手順は skill、固有名詞入りの運用宣言は vault」の分離。vault 側は追記済み)

変更は `.config/skills/session-log/SKILL.md` の1箇所のみ(home.nix 変更なし、既存マウントで配布される)。

## [optional footer(s)]

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)