### PR TITLE
docs(mise): claude インストール方式コメントを native installer 実態に合わせて修正

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,6 +1,6 @@
 # mise global config / mise グローバル設定
-# Tools available in every directory (claude is installed as an npm global under this node)
-# 全ディレクトリで有効なツール（claude はこの node 配下の npm グローバルとしてインストールされる）
+# Tools available in every directory. claude is managed by its native installer (~/.local/bin/claude), not an npm global under this node — node is kept here for other tools.
+# 全ディレクトリで有効なツール。claude は native installer(~/.local/bin/claude)管理であり、この node 配下の npm グローバルではない — node は他ツールのために残している
 [tools]
 node = "22.15.1"
 


### PR DESCRIPTION
## 概要
- \`.config/mise/config.toml\` 冒頭のコメント(EN/JA)が古かったため修正

## 背景
claude CLI は npm グローバルインストールから native installer 管理(\`~/.local/bin/claude\` → \`~/.local/share/claude/versions/<version>\`)へ移行済みで、config.toml のコメントだけが stale なまま残っていた。実測(2026-07-24)でも \`mise x node@22.15.1 -- npm ls -g --depth=0\` に claude は含まれない(@modelcontextprotocol/server-github / corepack / npm のみ)ことを確認済み。

\`[tools] node = "22.15.1"\` 自体は claude 以外のツールのために引き続き必要なので維持。

## 変更内容
- \`.config/mise/config.toml\` 冒頭のコメント(EN/JA)を、claude が native installer 管理である実態に書き換え
- node を残す理由が読み取れる文面に更新

## 確認事項
- \`grep -rn -iE "claude.*(npm|node)|npm.*claude" docs/ .config/ README.md\` で他に同種の stale な記述がないことを確認済み

Closes #485