### PR TITLE
claude:effort タスクを ultracode モードに対応させる

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -44,7 +44,7 @@ run = "nix-collect-garbage -d"
 # =============================================================================
 
 [tasks."claude:effort"]
-description = "Set Claude Code effortLevel and rebuild (low|medium|high|xhigh|ultracode)"
+description = "Set Claude Code effort settings (effortLevel/ultracode) and rebuild (low|medium|high|xhigh|ultracode)"
 # effortLevel を .config/claude/settings.json に書き込んで nix:switch で反映する。
 # tracked な変更なので diff が残り、そのまま commit/PR に乗せられる。
 # Write effortLevel into the nix source, then activate — the change stays tracked.

--- a/.mise.toml
+++ b/.mise.toml
@@ -44,27 +44,41 @@ run = "nix-collect-garbage -d"
 # =============================================================================
 
 [tasks."claude:effort"]
-description = "Set Claude Code effortLevel and rebuild (low|medium|high|xhigh)"
+description = "Set Claude Code effortLevel and rebuild (low|medium|high|xhigh|ultracode)"
 # effortLevel を .config/claude/settings.json に書き込んで nix:switch で反映する。
 # tracked な変更なので diff が残り、そのまま commit/PR に乗せられる。
 # Write effortLevel into the nix source, then activate — the change stays tracked.
-usage = 'arg "<level>" help="low|medium|high|xhigh"'
+# ultracode は effortLevel の値ではなく独立した boolean キー。xhigh 相当の effort に加えて
+# 常設の dynamic-workflow(マルチエージェント)オーケストレーションを有効にする。
+# ultracode is not an effortLevel value — it's a separate boolean key. It layers standing
+# dynamic-workflow (multi-agent) orchestration on top of xhigh-equivalent effort.
+usage = 'arg "<level>" help="low|medium|high|xhigh|ultracode"'
 run = """
 set -euo pipefail
 level="$usage_level"
 case "$level" in
-  low|medium|high|xhigh) ;;
-  *) echo "usage: mise run claude:effort <low|medium|high|xhigh>" >&2; exit 1 ;;
+  low|medium|high|xhigh|ultracode) ;;
+  *) echo "usage: mise run claude:effort <low|medium|high|xhigh|ultracode>" >&2; exit 1 ;;
 esac
 settings=.config/claude/settings.json
 # 同一ディレクトリに temp を作り rename をアトミックに / jq 失敗時は trap で temp を掃除し本体を守る
 # temp in the same dir keeps the rename atomic; trap cleans up so a jq failure never clobbers settings
 tmp=$(mktemp "$settings.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
-jq --arg l "$level" '.effortLevel = $l' "$settings" > "$tmp"
+if [ "$level" = "ultracode" ]; then
+  # ultracode: xhigh 相当の effort に固定しつつ常設オーケストレーションを有効化
+  jq '.effortLevel = "xhigh" | .ultracode = true' "$settings" > "$tmp"
+else
+  # 通常レベル: ultracode キー自体を削除して設定ファイルを最小に保つ
+  jq --arg l "$level" '.effortLevel = $l | del(.ultracode)' "$settings" > "$tmp"
+fi
 mv "$tmp" "$settings"
 mise run nix:switch
-echo "effortLevel を $level に設定して反映したよ"
+if [ "$level" = "ultracode" ]; then
+  echo "ultracode を有効化したよ(effortLevel=xhigh + 常設マルチエージェントオーケストレーション)"
+else
+  echo "effortLevel を $level に設定して反映したよ"
+fi
 """
 
 [tasks."docker:build"]

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -31,6 +31,22 @@ mise タスクではないが、あわせてよく使うNix関連コマンド:
 
 ---
 
+## Claude Code Tasks
+
+| Task | Description | Equivalent Command |
+|------|-------------|---------------------|
+| `mise run claude:effort <level>` | Claude Code の effortLevel を設定してNix経由で反映 (`low\|medium\|high\|xhigh\|ultracode`) | `.config/claude/settings.json` を jq で書き換え + `nix:switch` |
+
+`ultracode` は effortLevel の値ではなく、独立した boolean 設定キー。xhigh 相当の effort に加えて、常設の dynamic-workflow(マルチエージェント)オーケストレーションをセッション全体で有効にする。`mise run claude:effort ultracode` を実行すると `effortLevel = "xhigh"` と `ultracode = true` が書き込まれる。通常レベル(low/medium/high/xhigh)に戻すと `ultracode` キー自体を削除し、設定ファイルを最小に保つ。
+
+mise タスクではないが、あわせて使うグローバルタスク(`.config/mise/config.toml` 定義、リポジトリを問わずどのディレクトリからでも実行可):
+
+| Task | Description |
+|------|-------------|
+| `mise run claude:memory-wire [project]` | プロジェクトの auto-memory を Obsidian AgentMemory vault へ配線 (`.claude/settings.local.json` に `autoMemoryDirectory` を書き込む、端末ローカル・untracked) |
+
+---
+
 ## Docker Tasks
 
 | Task | Description | Equivalent Command |

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -35,7 +35,7 @@ mise タスクではないが、あわせてよく使うNix関連コマンド:
 
 | Task | Description | Equivalent Command |
 |------|-------------|---------------------|
-| `mise run claude:effort <level>` | Claude Code の effortLevel を設定してNix経由で反映 (`low\|medium\|high\|xhigh\|ultracode`) | `.config/claude/settings.json` を jq で書き換え + `nix:switch` |
+| `mise run claude:effort <level>` | Claude Code の effort 設定(effortLevel/ultracode)を更新してNix経由で反映 (`low` / `medium` / `high` / `xhigh` / `ultracode`) | `.config/claude/settings.json` を jq で書き換え + `nix:switch` |
 
 `ultracode` は effortLevel の値ではなく、独立した boolean 設定キー。xhigh 相当の effort に加えて、常設の dynamic-workflow(マルチエージェント)オーケストレーションをセッション全体で有効にする。`mise run claude:effort ultracode` を実行すると `effortLevel = "xhigh"` と `ultracode = true` が書き込まれる。通常レベル(low/medium/high/xhigh)に戻すと `ultracode` キー自体を削除し、設定ファイルを最小に保つ。
 


### PR DESCRIPTION
## 概要
- `.mise.toml` の `claude:effort` タスクを `low|medium|high|xhigh` に加えて `ultracode` に対応させた
- `docs/reference/mise-tasks.md` に「Claude Code Tasks」セクションを新設した

Closes #487

## 背景
Claude Code 2.1.218 のバイナリと CHANGELOG から実測確認した事実として、settings.json の `effortLevel` スキーマは `["low","medium","high","xhigh"]` のままで、`ultracode` は effortLevel の値としては無効。別途 boolean の `ultracode` 設定キーが存在し、公式スキーマ説明文(英語)は次の通り:

> Whether ultracode (xhigh effort plus standing dynamic-workflow orchestration) is active for the session. Set per session via the `ultracode` settings key (--settings or apply_flag_settings).

つまり `ultracode` = 「xhigh 相当の effort」+「常設の dynamic-workflow(マルチエージェント)オーケストレーション」で、settings.json に `"ultracode": true` と書けば常設化できる。

## 変更内容
1. `claude:effort` の usage・case 分岐・エラーメッセージ・description を `low|medium|high|xhigh|ultracode` に拡張
2. `ultracode` 指定時: `.effortLevel = "xhigh"` かつ `.ultracode = true` を書き込み
3. 通常レベル指定時: `.effortLevel = <level>` に加えて `del(.ultracode)` でキー自体を削除し、設定ファイルを最小に保つ
4. 完了メッセージ(echo)も ultracode の場合が分かる文面に変更
5. `docs/reference/mise-tasks.md` に Claude Code Tasks セクションを追加。`claude:effort`(ultracode 含む挙動)と、グローバルタスク `claude:memory-wire`(`.config/mise/config.toml` 定義)を表形式で記載

既存の jq atomic write パターン(同一ディレクトリに temp を作って rename、trap で掃除)は変更せず踏襲している。

## Test plan
- [x] `.mise.toml` の diff レビュー(意図通りの変更のみ)
- [x] `docs/reference/mise-tasks.md` の diff レビュー(既存セクションを変更せず新セクションのみ追加)
- [x] jq 変換ロジックをテンポラリファイルにコピーした `.config/claude/settings.json` に対して直接実行し、`low/medium/high/xhigh/ultracode` の5パターンすべてで期待通りの JSON になることを確認済み(実ファイルは無変更)
- [ ] `mise run claude:effort` / `mise run nix:switch` のエンドツーエンド実行は本 PR のスコープ外(ライブなホーム環境を書き換えるため未実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)