### PR TITLE
fix(nvim): ddc-source-copilotの非遅延depends昇格でddcソース群がロードされない問題を修正

### DIFF
--- a/.config/nvim/copilot.toml
+++ b/.config/nvim/copilot.toml
@@ -2,11 +2,6 @@
 repo = 'github/copilot.vim'
 on_event = 'InsertEnter'
 
-
-[[plugins]]
-repo = 'Shougo/ddc-source-copilot'
-depends = ['copilot.vim', 'ddc.vim']
-
 [[plugins]]
 repo = 'MeanderingProgrammer/render-markdown.nvim'
 depends = ['copilot.vim', 'plenary.nvim', 'CopilotChat.nvim', 'codecompanion.nvim']

--- a/.config/nvim/ddc_settings.toml
+++ b/.config/nvim/ddc_settings.toml
@@ -79,12 +79,14 @@ on_source = 'ddc.vim'
 # NOTE: copilot.toml(非遅延グループ)から移動 (#494)。dpp-ext-toml の lazy は
 # ファイル単位(config.ts の options.lazy)で決まるため、非遅延ファイルに置くと
 # depends の ddc.vim が起動時に昇格し(rtp/hook_source が startup.vim に焼き込まれ
-# sourced: true になる)、on_source 連鎖が永遠に発火しなくなる。
+# sourced: true になる)、このファイル内の on_source = 'ddc.vim' 依存ソース全体で
+# 連鎖が永遠に発火しなくなる。
 # Moved from copilot.toml (non-lazy group) — dpp-ext-toml's lazy flag is
 # decided per file (config.ts's options.lazy), so keeping this in a non-lazy
 # file promotes its lazy ddc.vim dependency at startup (baked into
 # startup.vim's rtp/hook_source, marked sourced: true) and permanently
-# breaks the on_source chain for every ddc source below.
+# breaks the on_source chain for every on_source = 'ddc.vim' source in this
+# file, not just this block.
 [[plugins]]
 repo = 'Shougo/ddc-source-copilot'
 on_source = 'ddc.vim'

--- a/.config/nvim/ddc_settings.toml
+++ b/.config/nvim/ddc_settings.toml
@@ -76,6 +76,20 @@ on_source = 'ddc.vim'
 repo = 'Shougo/ddc-source-cmdline-history'
 on_source = 'ddc.vim'
 
+# NOTE: copilot.toml(非遅延グループ)から移動 (#494)。dpp-ext-toml の lazy は
+# ファイル単位(config.ts の options.lazy)で決まるため、非遅延ファイルに置くと
+# depends の ddc.vim が起動時に昇格し(rtp/hook_source が startup.vim に焼き込まれ
+# sourced: true になる)、on_source 連鎖が永遠に発火しなくなる。
+# Moved from copilot.toml (non-lazy group) — dpp-ext-toml's lazy flag is
+# decided per file (config.ts's options.lazy), so keeping this in a non-lazy
+# file promotes its lazy ddc.vim dependency at startup (baked into
+# startup.vim's rtp/hook_source, marked sourced: true) and permanently
+# breaks the on_source chain for every ddc source below.
+[[plugins]]
+repo = 'Shougo/ddc-source-copilot'
+on_source = 'ddc.vim'
+depends = ['copilot.vim']
+
 [[plugins]]
 repo = 'matsui54/denops-popup-preview.vim'
 on_source = 'ddc.vim'


### PR DESCRIPTION
## 概要
`ddc-source-copilot` の宣言を `copilot.toml`(非遅延グループ)から `ddc_settings.toml`(遅延グループ)へ移動し、dpp の起動時に `ddc.vim` が誤って昇格して ddc ソース群(around/file/lsp/vsnip/cmdline/cmdline-history)の `on_source` 連鎖が発火しなくなる問題を修正する。

Closes #494

## 変更内容
- `copilot.toml`: `ddc-source-copilot` の `[[plugins]]` ブロックを削除
- `ddc_settings.toml`: 同ブロックを他の `on_source = 'ddc.vim'` の並びに追加。`depends` から `ddc.vim` を除去(`ddc-around` 等の兄弟ソースと同じ形)し、移動理由の日英併記コメントを追加

ロジック変更はなし(宣言の位置移動のみ)。

## 根本原因(Issue #494 参照)
dpp-ext-toml の lazy フラグは**ファイル単位**(config.ts の `options.lazy`)で決まる。非遅延ファイル(copilot.toml)内の宣言が `depends = ['ddc.vim']` を持っていたため、`dpp#make_state()` がその depends を起動時に昇格させ、lazy のはずの `ddc.vim` の rtp と `hook_source`(`call ddc#enable()` 含む)が `startup.vim` に焼き込まれ、state 上 `sourced: true` になっていた。結果、`on_source = 'ddc.vim'` の ddc ソース群は「`ddc.vim` が `dpp#source()` を通る瞬間」にしか発火しないため、`sourced: true` のままだと永遠に発火しなかった。

## 検証
実 HOME (`~/.cache/dpp`) を汚さないよう、隔離した `$SCRATCH` に `.config/nvim` シンボリックリンク(このブランチの worktree を指す)と `.cache/dpp/repos` シンボリックリンク(クローン済みプラグイン再利用、ネットワーク不要)のみを用意し、headless nvim で検証した。

### 検証1: state生成(1回目起動、DenopsReady後にdpp#make_state())
成功。`Dpp:makeStatePost` 発火を確認。

### 検証2: 生成物の検査
`state.vim`(JSON):
```
ddc.vim             -> lazy: true, sourced: false, on_event: InsertEnter
ddc-source-copilot   -> lazy: true, sourced: false, on_source: ddc.vim, depends: ['copilot.vim']
ddc-around           -> lazy: true, sourced: false, on_source: ddc.vim
copilot.vim          -> lazy: false, sourced: true, merged: true  (意図通り、copilot.vim自体は非遅延のまま)
```
`ddc.vim` が修正前の `sourced: true`(起動時昇格による歪み)から `sourced: false` に戻った。

`startup.vim` の `let &runtimepath = ...` 焼き込み行に `repos/github.com/Shougo/ddc.vim` のパスは**含まれない**ことを確認(grep で不一致)。

### 検証3: 動作検証(2回目起動、通常起動 → 10秒後に `doautocmd InsertEnter` → 22秒後に状態をJSON書き出し)
```json
{
  "rtp_has_ddc_around": true,
  "rtp_has_ddc_source_copilot": true,
  "ddc_around_sourced": true,
  "ddc_source_copilot_sourced": true
}
```
`InsertEnter` 後に `ddc-around` / `ddc-source-copilot` が runtimepath に入り、`dpp#get('ddc-around').sourced` が `true` になることを確認。

`:messages` には `[ddc] Not found source: cmdline-history` が1件残ったが、これは本Issueとは無関係な既存バグ(`ddc_settings.toml` の `hook_source` が `cmdline-history`(ハイフン)を指定しているのに対し、実際の登録ソース名は denops 側で `cmdline_history`(アンダースコア)— `denops/@ddc-sources/cmdline_history/main.ts` で確認)。around/file/lsp/vsnip/cmdline 等、本Issueが対象とするソース群については `Not found source` は解消しており、主症状(#494)は解消済みと判断。この既存バグは別Issue化を検討中。

## マージ後の作業(重要)
この修正は**設定ファイルの変更のみ**で、実 state (`~/.cache/dpp/nvim/state.vim` / `startup.vim`)には反映されない。マージ後、実環境で state 再生成が必要:
- #466 の mise タスク(`nvim:state` 相当)が導入済みならそれを利用
- 未導入の場合は手動で `~/.cache/dpp/nvim/state.vim` を削除するか、TOML/config.ts への書き込みで `dpp#check_files()` の自動再生成(`BufWritePost` フック、`init.lua` 参照)をトリガーする、または headless で `dpp#make_state()` を明示実行する

## 制約範囲
`copilot.toml` / `ddc_settings.toml` の2ファイルのみ変更。`config.ts` / `init.lua` は触っていない。