### PR TITLE
feat(nvim): dpp state鮮度管理を明示的な再生成運用として整備する

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -92,18 +92,27 @@ else
     return #vim.fn.glob(dpp_base .. '/repos/*/*/*/.git', 0, 1) == 0
   end
 
-  -- dpp#async_ext_action() はdenops経由で動くため、denops未起動時に呼ぶと
-  -- 失敗する。:DppInstall/:DppUpdate/自動インストールの全呼び出し口はここを通す。
-  -- dpp#async_ext_action() talks to denops; calling it before denops is up
-  -- fails. Every entry point below (:DppInstall/:DppUpdate/auto-install)
+  -- dpp#async_ext_action()/dpp#make_state()はいずれもdenops経由で動くため、
+  -- denops未起動時に呼ぶと失敗する。:DppInstall/:DppUpdate/:DppMakeState/
+  -- 自動インストール/起動時check_filesの全呼び出し口はここを通す。
+  -- dpp#async_ext_action()/dpp#make_state() both talk to denops; calling
+  -- either before denops is up fails. Every entry point below
+  -- (:DppInstall/:DppUpdate/:DppMakeState/auto-install/startup check_files)
   -- routes through this guard.
+  local function dpp_require_denops_ready()
+    if vim.fn['denops#server#status']() == 'running' then
+      return true
+    end
+    vim.notify(
+      'dpp: denops server is not running yet. '
+        .. 'Wait for it to finish starting (see DenopsReady) and retry.',
+      vim.log.levels.WARN
+    )
+    return false
+  end
+
   local function dpp_run_installer(action, params)
-    if vim.fn['denops#server#status']() ~= 'running' then
-      vim.notify(
-        'dpp: denops server is not running yet. '
-          .. 'Wait for it to finish starting (see DenopsReady) and retry.',
-        vim.log.levels.WARN
-      )
+    if not dpp_require_denops_ready() then
       return
     end
     -- 注: Luaの空テーブル{}はvim.fn境界で空リスト[]に変換され、dpp側の
@@ -165,6 +174,41 @@ else
     dpp_run_installer('update', params)
   end, { nargs = '*', desc = 'Update dpp plugins (all, or the given plugin names)' })
 
+  -- 手動でstateを強制再生成するコマンド(dpp移行設計書の手動再生成手順の実体、#466)。
+  -- check_files()の差分有無に関わらず無条件でmake_state()を呼ぶ。
+  -- Manually force-regenerates state (the concrete command behind the dpp
+  -- migration design doc's documented manual-regen procedure, #466).
+  -- Unconditionally calls make_state() regardless of check_files() diffs.
+  vim.api.nvim_create_user_command('DppMakeState', function()
+    if not dpp_require_denops_ready() then
+      return
+    end
+    vim.fn['dpp#make_state'](dpp_base, dpp_config_path)
+  end, { desc = 'Manually regenerate dpp state (dpp#make_state)' })
+
+  -- check_files()で差分を検知した時だけmake_state()を呼ぶ共通処理。
+  -- BufWritePost(nvim内でTOML/config.tsを編集した直後)と起動時DenopsReady
+  -- (worktree+PRマージ→pullでTOMLが変わるがnvim内では編集しない運用の穴を
+  -- 埋める、#466)の双方から呼ぶことで二重実装を避ける。
+  -- Shared check-and-regenerate: calls make_state() only when check_files()
+  -- reports a diff. Called from both BufWritePost (editing TOML/config.ts
+  -- inside nvim) and startup DenopsReady (covers the worktree+PR-merge→pull
+  -- flow where TOML changes without ever being edited inside nvim, #466) to
+  -- avoid duplicating the same logic twice.
+  local function dpp_check_files_and_make_state()
+    if #vim.fn['dpp#check_files']() == 0 then
+      return
+    end
+    vim.notify(
+      'dpp: config files changed since the last state build. Regenerating state...',
+      vim.log.levels.INFO
+    )
+    -- Pass the same explicit args as the initial DenopsReady make_state —
+    -- argless make_state depends on dpp defaults and may target the wrong
+    -- base/config. 初回生成時と同じ引数を明示して同一のstateを再生成する。
+    vim.fn['dpp#make_state'](dpp_base, dpp_config_path)
+  end
+
   if vim.fn['dpp#min#load_state'](dpp_base) ~= 0 then
     -- state未生成(初回起動 or state破棄後): denops起動後にmake_state()で
     -- state(startup.vim/state.vim)を生成する。make_state成功後もrepos/が
@@ -178,11 +222,23 @@ else
     })
   else
     -- state生成済み(通常起動): make_state()は走らずDpp:makeStatePostも
-    -- 発火しないため、repos/欠損はここでdenops起動後に一度だけチェックする。
+    -- 発火しないため、repos/欠損とcheck_filesの差分はここでdenops起動後に
+    -- 一度だけチェックする。VimEnter直後ではなくDenopsReady後にしているのは、
+    -- dpp#make_state()がdenops経由(dpp#denops#_notify)のため。denops起動前に
+    -- 呼ぶと失敗する。
+    -- Startup with state already present: make_state() doesn't run and
+    -- Dpp:makeStatePost never fires, so check repos/ and check_files() diffs
+    -- here, once, after denops comes up. This runs on DenopsReady rather
+    -- than VimEnter/an immediate defer because dpp#make_state() talks to
+    -- denops (dpp#denops#_notify) — calling it before denops is running
+    -- fails.
     vim.api.nvim_create_autocmd('User', {
       pattern = 'DenopsReady',
       once = true,
-      callback = dpp_auto_install_if_missing,
+      callback = function()
+        dpp_check_files_and_make_state()
+        dpp_auto_install_if_missing()
+      end,
     })
   end
 
@@ -212,14 +268,7 @@ else
   -- TOML/config.ts編集時にstateを自動再生成する(check_files)
   vim.api.nvim_create_autocmd('BufWritePost', {
     pattern = { '*.toml', '*.lua', '*.vim', '*.ts' },
-    callback = function()
-      if #vim.fn['dpp#check_files']() > 0 then
-        -- Pass the same explicit args as the initial DenopsReady make_state —
-        -- argless make_state depends on dpp defaults and may target the wrong
-        -- base/config. 初回生成時と同じ引数を明示して同一のstateを再生成する。
-        vim.fn['dpp#make_state'](dpp_base, dpp_config_path)
-      end
-    end,
+    callback = dpp_check_files_and_make_state,
   })
 end
 --End dpp Scripts-----------------------------

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -94,11 +94,13 @@ else
 
   -- dpp#async_ext_action()/dpp#make_state()はいずれもdenops経由で動くため、
   -- denops未起動時に呼ぶと失敗する。:DppInstall/:DppUpdate/:DppMakeState/
-  -- 自動インストール/起動時check_filesの全呼び出し口はここを通す。
+  -- 自動インストール/check_files(BufWritePost・起動時DenopsReadyの両方)の
+  -- 全呼び出し口はここを通す。
   -- dpp#async_ext_action()/dpp#make_state() both talk to denops; calling
   -- either before denops is up fails. Every entry point below
-  -- (:DppInstall/:DppUpdate/:DppMakeState/auto-install/startup check_files)
-  -- routes through this guard.
+  -- (:DppInstall/:DppUpdate/:DppMakeState/auto-install/check_files — both
+  -- the BufWritePost and startup DenopsReady paths) routes through this
+  -- guard.
   local function dpp_require_denops_ready()
     if vim.fn['denops#server#status']() == 'running' then
       return true
@@ -197,6 +199,14 @@ else
   -- avoid duplicating the same logic twice.
   local function dpp_check_files_and_make_state()
     if #vim.fn['dpp#check_files']() == 0 then
+      return
+    end
+    -- BufWritePost経由だと起動直後の早すぎるタイミングで発火しうるため、
+    -- 起動時DenopsReady経由(常に通過済み)と同じくここでもガードする。
+    -- The BufWritePost path can fire very early during startup, before
+    -- denops is up — guard here too, same as the startup DenopsReady path
+    -- (which always passes this check already).
+    if not dpp_require_denops_ready() then
       return
     end
     vim.notify(

--- a/.mise.toml
+++ b/.mise.toml
@@ -122,6 +122,25 @@ repo_root="$(pwd)"
 nvim --headless -u ~/.config/nvim/init.lua -l "$repo_root/.config/nvim/scripts/install_treesitter_parsers.lua" "$repo_root"
 """
 
+[tasks."nvim:state"]
+description = "dpp state(startup.vim/state.vim)をheadlessで強制再生成する(pull後・nix:switch後の明示反映用、#466)"
+# check_files()の差分有無に関わらず無条件でdpp#make_state()を呼ぶ、:DppMakeStateのheadless版。
+# nvim:ts-installと同様に~/.config/nvim/init.luaをそのままheadless nvimへ渡し、通常のdpp/denops
+# bootstrapを経由させる。DenopsReady後にmake_state()を呼び、Dpp:makeStatePostでqall。denopsが
+# 上がらない/make_stateが完走しない事故はtimer_startの120秒cquit(exit 1)で打ち切る。
+# Unconditionally calls dpp#make_state() regardless of check_files() diffs — the headless
+# equivalent of :DppMakeState. Like nvim:ts-install, loads ~/.config/nvim/init.lua as-is so the
+# normal dpp/denops bootstrap runs. Calls make_state() once DenopsReady fires, then qalls on
+# Dpp:makeStatePost. A 120s timer_start cquit (exit 1) guards against denops never starting or
+# make_state never completing.
+run = """
+set -euo pipefail
+nvim --headless -u ~/.config/nvim/init.lua \
+  -c "lua vim.api.nvim_create_autocmd('User', { pattern = 'DenopsReady', once = true, callback = function() vim.fn['dpp#make_state'](vim.env.HOME .. '/.cache/dpp', vim.fn.stdpath('config') .. '/dpp/config.ts') end })" \
+  -c "lua vim.api.nvim_create_autocmd('User', { pattern = 'Dpp:makeStatePost', once = true, callback = function() vim.cmd('qall') end })" \
+  -c "lua vim.fn.timer_start(120000, function() vim.cmd('cquit 1') end)"
+"""
+
 # =============================================================================
 # Utility Tasks
 # =============================================================================

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -60,6 +60,17 @@ mise タスクではないが、あわせて使うグローバルタスク(`.con
 
 ---
 
+## Neovim Tasks
+
+| Task | Description | Equivalent Command |
+|------|-------------|---------------------|
+| `mise run nvim:ts-install` | `treesitter_parsers.lua` のリストに従い nvim-treesitter のパーサをインストール(冪等) | headless nvim 経由で `ts.install()` |
+| `mise run nvim:state` | dpp state(`startup.vim`/`state.vim`)を headless で強制再生成(`check_files()` の差分有無を問わない)。pull後・`nix:switch` 後の明示反映用([#466](https://github.com/music-brain88/dotfiles/issues/466)) | headless nvim 経由で `dpp#make_state()` |
+
+state 鮮度管理の4経路(BufWritePost / 起動時 check_files / `:DppMakeState` / `mise run nvim:state`)の使い分けは [neovim-config.md](neovim-config.md#plugin-management-dpp) を参照。
+
+---
+
 ## Utility Tasks
 
 | Task | Description | Equivalent Command |

--- a/docs/reference/neovim-config.md
+++ b/docs/reference/neovim-config.md
@@ -133,6 +133,19 @@ CopilotChat.nvimの後継。[ACP (Agent Client Protocol)](https://github.com/oli
 
 denops/ddc/ddu本体・UI層などの基盤層プラグインはTOMLで`rev`を固定しており、dpp-protocol-gitがそのrev指定を尊重するため`:DppUpdate`を無条件に実行してもバージョンは動かない。ただし基盤層プラグインの更新自体は`:DppUpdate`に頼らず、**意図的なrev bump PR**を経由するのが原則([Epic #447](https://github.com/music-brain88/dotfiles/issues/447) Decision Log D2)。`:DppUpdate`は非基盤層プラグイン(rev未指定)の追従更新に使う。
 
+### state鮮度管理(明示的な再生成、[#466](https://github.com/music-brain88/dotfiles/issues/466))
+
+dpp.vimは起動時に`state.vim`/`startup.vim`を読み込むだけで、dein時代のようなmtime自動チェックは一切行わない。鮮度チェックは`dpp#check_files()`(`state.vim`のmtimeと、`config.ts`が`checkFiles`に登録した全TOML + `config.ts`自身のmtimeを比較)を**自分で呼ぶ**必要がある。差分があれば`dpp#make_state()`で再生成する。本リポジトリでは以下4つの経路で再生成のタイミングをカバーしている:
+
+| 経路 | 発火タイミング | 用途 |
+|------|----------------|------|
+| `BufWritePost` autocmd | `*.toml`/`*.lua`/`*.vim`/`*.ts`保存直後 | nvim内でTOML/config.tsを直接編集した場合 |
+| 起動時`DenopsReady` autocmd | 通常起動でstate読み込み成功後、denops起動完了時 | worktree + PRマージ→pullでTOMLが変わる(nvim内では編集しない)本リポジトリの主力フロー |
+| `:DppMakeState`コマンド | 手動実行時 | `check_files()`の差分有無に関わらず強制再生成したい時 |
+| `mise run nvim:state` | 手動実行時(headless) | `nix:switch`後やpull後、nvimを開かずCLIから明示的に反映したい時 |
+
+起動時経路をVimEnter直後ではなく`DenopsReady`後にしているのは、`dpp#make_state()`がdenops経由(`dpp#denops#_notify`)のため、denops起動前に呼ぶと失敗するから。`BufWritePost`とこの起動時経路は同じ`dpp_check_files_and_make_state()`(`init.lua`内のローカル関数)を共有しており、二重実装を避けている。
+
 ---
 
 ## ⌨️ Keybindings


### PR DESCRIPTION
## 概要

Closes #466

dpp.vim は起動時に `state.vim`/`startup.vim` を読み込むだけで、dein 時代のような mtime 自動チェックを一切行わない。鮮度チェックは `dpp#check_files()` を自分で呼ぶ必要があるが、既存実装は `BufWritePost`(nvim 内でのファイル保存)のみだった。本リポジトリは worktree + PR マージ → pull で設定が変わる(nvim 内で TOML を編集しない)運用が主力のため、この経路だけでは差分が検知されず、mason 残留(#461)と同種の「消したはずの設定が生きている」事故が dpp でも再発しうる状態だった。

## 変更内容

1. **起動時 check_files**(`.config/nvim/init.lua`)
   - state 読み込み成功時(既存の else 分岐)の `DenopsReady` autocmd を拡張し、denops 起動後に `dpp#check_files()` → 差分があれば `dpp#make_state()` + `vim.notify` で通知するようにした
   - `BufWritePost` ハンドラと共通の `dpp_check_files_and_make_state()` ローカル関数に括り出し、二重実装を避けた
   - **設計判断**: Issue には「VimEnter(または起動直後の defer)」とあったが、`dpp#make_state()` は denops 経由(`dpp#denops#_notify`)のため denops 起動前に呼ぶと失敗する。そのため VimEnter ではなく `DenopsReady` 後に実行する設計にした
2. **`:DppMakeState` コマンド**(`.config/nvim/init.lua`)
   - 手動再生成用のユーザーコマンドを追加。既存 `dpp_run_installer` の denops 起動ガードを `dpp_require_denops_ready()` として共通化し、両方から使うようにした
   - `check_files()` の差分有無に関わらず無条件で `dpp#make_state()` を呼ぶ(dpp移行設計書の手動再生成手順の実体)
3. **mise タスク `nvim:state`**(`.mise.toml`)
   - headless で state を強制再生成するタスクを追加(既存 `nvim:ts-install` のスタイルを踏襲)
   - `DenopsReady` で `dpp#make_state()` 実行 → `Dpp:makeStatePost` で `qall`、`timer_start` で 120 秒後 `cquit 1` のタイムアウト付き
   - 用途: PR マージ後の pull / `nix:switch` 後に明示的に state を反映する
4. **docs**
   - `docs/reference/mise-tasks.md` に新設の `## Neovim Tasks` セクションを追加し、`nvim:state` の行を追加(`nvim:ts-install` が未文書化だったのでついでに追記)
   - `docs/reference/neovim-config.md` の dpp セクションに state 鮮度管理の4経路(BufWritePost / 起動時 check_files / `:DppMakeState` / `mise run nvim:state`)の使い分け表を追記

## 検証

**禁止事項の遵守**: 実 HOME・実 `~/.cache/dpp` には一切触れていない。`$SCRATCH` を `mktemp -d` で作り、`$SCRATCH/.config/nvim` をこの worktree の `.config/nvim` へ、`$SCRATCH/.cache/dpp/repos` を実環境のクローン済みプラグイン(`/home/archie/.cache/dpp/repos`、読み取り専用参照)へシンボリックリンクした隔離ハーネスで全シナリオを検証した。実行後 `~/.cache/dpp/nvim/state.vim` の mtime が変化していないことも確認済み。

| # | シナリオ | 結果 |
|---|---------|------|
| 1 | 初回起動(state 未生成) | `make_state` 完走、`state.vim`/`startup.vim` 生成を確認 |
| 2 | 2回目起動(差分なし) | `check_files()` は発火するが `make_state` は走らない(`state.vim` の mtime 不変を確認) |
| 3 | worktree 内 TOML(`mini/mini.toml`)を `touch` → 3回目起動 | 起動時 `check_files` が symlink 越しに mtime 差分を正しく検知(`dpp#check_files()` が touch したファイルの絶対パスを1件返すことを直接確認)、自動で `make_state` が走り `state.vim` の mtime が更新された(**out-of-store symlink 経由の getftime が実ファイル準拠で機能することを実証**) |
| 4 | `:DppMakeState` を headless で実行 | 差分なしでも無条件に `state.vim` を再生成できることを確認 |
| 5 | `mise run nvim:state` をハーネス env 付きで worktree cwd から実行 | `$SCRATCH` 側の state が再生成されることを確認(exit 0、タイムアウトなし) |

## 気づき・懸念点

- **nvim-notify によるヘッドレス時の notify 不可視化**: このリポジトリには `rcarriga/nvim-notify`(`style.toml`)が入っており、state が存在する通常起動(state 読み込み → プラグイン読み込み → denops 起動、の順)では `vim.notify` が早期にプラグイン側実装へ差し替わる。ヘッドレスモードには UI がないため、差し替え後の `vim.notify` 呼び出しはトースト描画されず stdout にも出ない。そのため検証シナリオ3の「通知が出ること」は stdout 上では直接確認できなかったが、`dpp#check_files()` の戻り値を直接ファイルへ書き出す形で差分検知そのものを実証し、`state.vim` の mtime 変化で `make_state` の実行を確認する形で機能面を担保した。実際の対話セッション(nvim-notify 有効時)ではトースト通知として、nvim-notify 無効時はデフォルトの cmdline echo として表示されるはずで、コード上は `vim.notify(...)` を正しく呼んでいる。
- **`mise run nvim:state` を state 未生成の完全新規環境で実行した場合の二重呼び出し**: `nvim:state` タスクは `DenopsReady` に独自の無条件 `make_state` ハンドラを追加するが、state が完全に未生成の場合は `init.lua` 側の初回ブートストラップ用ハンドラ(これも無条件で `make_state` を呼ぶ)と同一イベントで両方発火し、`dpp#make_state()` が短時間に2回呼ばれる。Issue の想定用途(「PR マージ後の pull / `nix:switch` 後」)は state が既に存在する場面が前提のため実害は薄いと判断し、対策は入れていない。気になる場合は state 未生成時は普通に nvim を一度起動する運用でカバーできる。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>