### PR TITLE
fix(nvim): ddc sourcesリストのcmdline-historyを実ソース名cmdline_historyに修正

### DIFF
--- a/.config/nvim/ddc_settings.toml
+++ b/.config/nvim/ddc_settings.toml
@@ -19,7 +19,7 @@ inoremap <A-]> <Plug>(copilot-next)
 hook_source = '''
   let g:copilot_no_maps = v:true
   call ddc#custom#patch_global('ui', 'native')
-  call ddc#custom#patch_global('sources', ['lsp' ,'around', 'file', 'copilot', 'vsnip', 'cmdline', 'cmdline-history'])
+  call ddc#custom#patch_global('sources', ['lsp' ,'around', 'file', 'copilot', 'vsnip', 'cmdline', 'cmdline_history'])
   call ddc#custom#patch_global('sourceOptions', #{   _:#{   matchers: ['matcher_fuzzy'],   sorters: ['sorter_fuzzy'], },   copilot: #{     mark: ' Copilot',     matchers: [],     minAutoCompleteLength: 0,     isVolatile: v:true,   },   around:#{   mark: ' Text',  },   lsp:#{   mark: ' LSP',   dup: 'keep',   keywordPattern: '\k+',   forceCompletionPattern: '\.\w*|:\w*',  },   file: #{   mark: ' File',   isVolatile: v:true,   forceCompletionPattern: '\S/\S*',  },   vsnip: #{   mark: ' Snippet',   dup: v:true,   },   cmdline: #{   mark: ' Cmdline',   },   cmdline_history: #{   mark: ' Cmdline History',  }, })
 
 " Customize settings for specific filetypes


### PR DESCRIPTION
## 概要
`ddc_settings.toml` の ddc グローバル `sources` リストが `'cmdline-history'`(ハイフン)を指定しているが、ddc-source-cmdline-history が実際に登録するソース名は `cmdline_history`(アンダースコア、`denops/@ddc-sources/cmdline_history/main.ts` で確認済み)。同ファイル内の `sourceOptions` キーは既に `cmdline_history` で、`sources` リストの1箇所だけが不一致だった。

Closes #495

## 変更内容
- `ddc_settings.toml`: `sources` リスト内の `'cmdline-history'` → `'cmdline_history'`(1箇所のみ)
- plugin repo 宣言 `Shougo/ddc-source-cmdline-history`(76行目、リポジトリ名由来のハイフン)は変更していない

## 検証
実 HOME (`~/.cache/dpp`, `~/.config/nvim`) を汚さないよう、`$SCRATCH/isohome` に `HOME` / `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `XDG_STATE_HOME` / `XDG_DATA_HOME` を全て向けた隔離環境を作り、headless nvim で検証した。

途中、`HOME` のみの上書きでは `XDG_CONFIG_HOME`/`XDG_CACHE_HOME` がグローバル環境変数(実ホームを指す)で先勝ちし、`vim.fn.stdpath('config')` が実 `~/.config/nvim` に解決されてしまい隔離が漏れていたことに気づいた。5つの XDG 系変数を全て明示的に上書きしてから再検証している。

### 検証1: state生成(headless、DenopsReady後にdpp#make_state())
成功。生成された `state.vim` の `ddc.vim` の `hook_source` に焼き込まれた `sources` リストで `cmdline_history`(アンダースコア)を確認。

### 検証2: 動作検証(通常起動 → 8秒後に `doautocmd InsertEnter` → 20秒後に状態をJSON書き出し)
```json
{"rtp_has_ddc_source_cmdline_history": true, "sourced": true}
```
`:messages` に `[ddc] Not found source: cmdline-history` は **0件**(修正前は出続けていた)。`ddc-source-cmdline-history` が runtimepath に入り `dpp#get('ddc-source-cmdline-history').sourced` が `true` になることを確認。

## マージ後の作業(重要)
この修正は**設定ファイルの変更のみ**で、実 state (`~/.cache/dpp/nvim/state.vim` / `startup.vim`)には反映されない。マージ後、実環境で state 再生成が必要(`mise run nvim:state`、#466)。

## 制約範囲
`ddc_settings.toml` の1行のみ変更。他のファイルは触っていない。