### PR TITLE
chore(nvim): dein掃除と起動時間計測 — 移行の完了確認

### DIFF
--- a/nix/modules/neovim.nix
+++ b/nix/modules/neovim.nix
@@ -133,18 +133,6 @@ in
     ];
   };
 
-  # Install dein.vim (Neovim plugin manager used in existing config)
-  # The existing TOML-based plugin configuration will continue to work
-  home.file.".cache/dein" = {
-    source = pkgs.fetchFromGitHub {
-      owner = "Shougo";
-      repo = "dein.vim";
-      rev = "3.1";
-      sha256 = "sha256-qKhuqDMkjvz7i79kHidiA0tlEl/ktPK5J8CfN74SzAM=";
-    };
-    recursive = true;
-  };
-
   # Note: Python environment is managed in dev-tools.nix to avoid conflicts
 
   # Environment variables for Neovim
@@ -153,11 +141,9 @@ in
     NVIM_PYTHON3_HOST_PROG = "${pkgs.python3.withPackages (ps: [ ps.pynvim ])}/bin/python3";
 
     # dpp.vim store paths, exposed for init.lua (via vim.env) to read.
-    # NOTE: dpp is installed but NOT wired into init.lua yet — dein remains
-    #       the active plugin manager. Wiring is PR-2 (see #445/#471).
+    # dpp is the active plugin manager, wired into init.lua (PR-2, see #445/#471/#472).
     # dpp.vim の store パス。init.lua 側が vim.env 経由で読める命名にしている。
-    # 注: dpp は導入のみでまだ init.lua には配線していない — アクティブなプラグイン
-    #     マネージャは引き続き dein。配線は PR-2(#445/#471 参照)で行う。
+    # dpp がアクティブなプラグインマネージャとして init.lua に配線済み(PR-2、#445/#471/#472 参照)。
     NVIM_DPP_VIM = "${dppVim}";
     NVIM_DENOPS_VIM = "${denopsVim}";
     NVIM_DPP_EXT_INSTALLER = "${dppExtInstaller}";
@@ -167,6 +153,5 @@ in
   };
 
   # Note: Existing Neovim configuration in .config/nvim/ is symlinked via home.nix
-  # The TOML-based dein.vim setup remains unchanged for now
-  # This provides a path for gradual migration to Nix-managed plugins if desired
+  # The TOML-based plugin configuration (dpp.vim) is managed there.
 }


### PR DESCRIPTION
## 概要
dpp 移行(PR-1 #471 / PR-2 #472)完了後の掃除。`nix/modules/neovim.nix` に残っていた dein.vim 導入コードと、PR-2 マージ前を前提とした stale コメントを現状に合わせて修正する。

## 変更内容
- `home.file ".cache/dein"` ブロック(dein.vim を Nix 経由で `~/.cache/dein` へコピーする方式)を削除
- `NVIM_DPP_*` 環境変数のコメントを、「dpp は導入のみで init.lua には未配線」(PR-2 前提)から「dpp が配線済みでアクティブ」に修正
- モジュール末尾の「TOML ベースの dein.vim 設定は当面そのまま」というコメントを、dpp.vim ベースである現状に修正
- `.config/nvim/*.toml` 内の dein 言及(lsp_settings.toml:5, ddc_settings.toml:32 ほか)はコメントのみで、並行 Issue #475 が同ファイル群を再構成中のため今回は触っていない

## `~/.cache/dein` のクリア手順(未実施)
本 PR のマージ後、ライブ環境で以下を実施すること(司令塔がマージ世話の段階で実施 — 本エージェントはライブ環境厳禁のため未実施):

```sh
mise run nix:switch   # 本PRの変更を適用(home.file ".cache/dein" が消える)
rm -rf ~/.cache/dein   # dein.vim 本体・プラグインrepos・stateキャッシュを削除
```

## 起動時間計測
`XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `XDG_STATE_HOME` / `XDG_DATA_HOME` / `HOME` の5変数すべてを scratch ディレクトリへ向けた完全隔離環境(headless)で計測。ライブ環境(`~/.cache/dein`, `~/.cache/dpp`, `~/.config/nvim` 等)には一切触れていない(計測前後で mtime に変化がないことを確認済み)。

手順: 各構成につき初回起動でプラグインインストール・state 生成を済ませたうえで(計測対象外のウォームアップ)、`nvim --headless --startuptime FILE +qa` を5回実行し中央値を取得。

| 構成 | 対象コミット | 5回の計測値(msec) | 中央値(msec) |
|---|---|---|---|
| dein(移行前ベースライン) | `54a0d80`(#476 — dpp共存導入、init.lua は dein のまま最後のコミット) | 87.172 / 87.795 / 88.160 / 91.578 / 177.009 | **88.160** |
| dpp(本 worktree = 移行後) | `chore/dein_cleanup`(本ブランチ) | 94.907 / 95.625 / 97.018 / 97.422 / 117.680 | **97.018** |

- dein 側は本来「移行前(main)」を想定していたが、main は既に dpp 化済みのため、dein がアクティブだった最後のコミット(`54a0d80`)を `git archive` でスクラッチに展開し、同様に隔離 headless 環境でプラグインをインストールして計測した(リポジトリ本体・現worktreeには変更なし)。
- 両構成とも各初回のみ外れ値(dein: 177ms, dpp: 118ms)が出ている。ディスクキャッシュのコールドスタートと見られ、中央値には影響していない。
- この計測では dein の方がわずかに速い(88ms vs 97ms)という結果になった。dpp 側は denops サーバ起動を伴うアーキテクチャのぶん headless 起動でもわずかにオーバーヘッドが乗っている可能性がある。移行の主目的はメンテナンス性(TOML純宣言化・非同期installer運用・state鮮度管理の明示化)であり、起動速度の大幅改善が目的ではなかった点を踏まえると許容範囲と考えるが、体感差についてはライブ環境での最終比較を司令塔側でも確認いただきたい。

## 確認事項
- `mise run nix:check`(`nix flake check`): 通過(`all checks passed!`)
- `.config/nvim/init.lua` に dein の bootstrap コード(git clone / mtime依存処理)は残っていないことを確認済み(dpp化はPR-2で完了済み)

## 相談・気づき
- 隔離検証の当初手順で `HOME` のみ上書きし `XDG_CACHE_HOME` 等を見落とした結果、1回目の試行で dpp の state 参照が実 `~/.cache/dpp` を読みに行きかけた(書き込みは発生せず、事故には至っていない)。司令塔から HOME + XDG 5変数すべての明示指定が必要との指摘を受けて手順を修正した(#495 で踏まれた罠と同種)。

Closes #474
