### PR TITLE
build(nix): herdr を 0.7.3 → 0.7.5 に更新する

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs-herdr": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## [optional body]
- 専用 input `nixpkgs-herdr` の lock のみ更新 (rev e7a3ca8 2026-07-11 → 624af66 2026-07-26)
- これにより herdr が 0.7.3 → 0.7.5 に上がる
- flake.nix のコメント方針どおり、メインの nixpkgs pin は据え置き (バイナリキャッシュ維持)
- `mise run nix:check` ローカル通過済み、新 pin での `herdr.version` が 0.7.5 であることを eval で確認済み
- マージ後の反映: `mise run nix:switch` → `herdr --version` で確認

Closes #517

## [optional footer(s)]
- Issue: https://github.com/music-brain88/dotfiles/issues/517

🤖 Generated with [Claude Code](https://claude.com/claude-code)