### PR TITLE
feat(herdr): herdr-browser プラグイン導入の前提を整備する

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -41,6 +41,17 @@ panel_bg = "#1e2127" # WezTerm background と揃えた値 (据え置き、詳細
 [terminal]
 default_shell = "fish"
 
+# Kitty graphics protocol (実験的機能、herdr >= 0.7.4)。herdr-browser 等の
+# 画像描画プラグインに必要。WezTerm 側も enable_kitty_graphics = true が必要
+# (wezterm.lua 側で設定済み)。Alacritty は非対応のためフォールバックでは描画されない。
+# Kitty graphics protocol (experimental, herdr >= 0.7.4). Required by plugins
+# that render images, such as herdr-browser. Also needs WezTerm's
+# enable_kitty_graphics = true (set in wezterm.lua). Alacritty doesn't support
+# it, so the fallback terminal won't render these panes. See
+# docs/reference/herdr-browser.md.
+[experimental]
+kitty_graphics = true
+
 [ui]
 # 移行前にローカルで設定済みだった値を引き継ぎ / carried over from the pre-migration local config
 agent_panel_sort = "spaces"

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -51,6 +51,15 @@ config.window_background_opacity = 0.8
 config.enable_tab_bar = false
 config.window_padding = { left = 0, right = 0, top = 0, bottom = 0 }
 
+-- Kitty graphics protocol (WezTerm はデフォルト OFF)。herdr 側の experimental
+-- kitty_graphics と対で有効化が必要 (herdr-browser プラグイン等が利用)。
+-- Alacritty は非対応のため、フォールバック側では描画されない。
+-- Kitty graphics protocol (off by default in WezTerm). Must be enabled
+-- alongside herdr's experimental kitty_graphics setting (used by plugins such
+-- as herdr-browser). Alacritty doesn't support it, so the fallback terminal
+-- won't render these panes. See docs/reference/herdr-browser.md.
+config.enable_kitty_graphics = true
+
 -- ---------------------------------------------------------------------------
 -- シェル / Shell (herdr は既存セッションへ自動アタッチするため分岐不要)
 -- ---------------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@
 - [reference/fontconfig.md](./reference/fontconfig.md) - フォント設定
 - [reference/color-palette.md](./reference/color-palette.md) - カラーパレット基準表 (onedark)
 - [reference/tool-management-map.md](./reference/tool-management-map.md) - ツール管轄マップ(どのツールをどの層が管理するか)
+- [reference/herdr-browser.md](./reference/herdr-browser.md) - herdr-browser プラグインの概要・要件・インストール手順
 
 ---
 

--- a/docs/reference/herdr-browser.md
+++ b/docs/reference/herdr-browser.md
@@ -1,0 +1,56 @@
+# herdr-browser Plugin / herdr-browser プラグイン
+
+> **Diátaxis:** 📖 Reference
+
+herdr の pane 内に実ブラウザ (Chromium) を描画し、Chrome DevTools Protocol (CDP) 経由でエージェントに操作させつつ、司令塔や人間がその様子を目視できるようにするプラグイン。
+
+- リポジトリ: [ogulcancelik/herdr-browser](https://github.com/ogulcancelik/herdr-browser)
+- 作者は herdr 本体 ([herdrdev/herdr](https://github.com/herdrdev/herdr)) の作者本人であり、実質ファーストパーティ (`id = "official.browser"`)
+- 導入の背景・セキュリティレビュー結果は Issue [#520](https://github.com/music-brain88/dotfiles/issues/520) を参照
+
+---
+
+## 何をするものか
+
+- herdr の pane に headless Chromium を描画し、Kitty graphics protocol 経由でリアルタイム表示する
+- CDP エンドポイントを公開し、Browser Use / Playwright / Playwright MCP / Chrome DevTools MCP 等の自動化クライアントから操作できる
+- 表示中のペインはマウス・キーボード入力もそのまま Chromium に転送されるため、自動化を見ながら人間が途中で操作を奪うこともできる
+- 想定運用: 司令塔がエージェントのブラウザ操作を艦隊ビュー越しに監視する「窓」として使う
+
+## 要件
+
+| 項目 | 内容 |
+|------|------|
+| herdr | 0.7.4 以上 |
+| OS | Linux または macOS (Windows 未サポート) |
+| ランタイム | Bun |
+| ブラウザ | Google Chrome または Chromium |
+| ターミナル | Kitty graphics protocol 対応 (WezTerm, kitty, Ghostty 等) |
+
+このリポジトリでは Bun を `nix/modules/dev-tools.nix` に、WezTerm/herdr 側の Kitty graphics 有効化をそれぞれ `.config/wezterm/wezterm.lua` / `.config/herdr/config.toml` に設定済み。
+
+## プラグイン本体は Nix 管理外
+
+このリポジトリの多くのツールは Nix (Home Manager) で宣言的に管理されているが、herdr-browser プラグイン自体は `herdr plugin install` による**命令的インストール**であり、Nix の管理対象外。したがって `mise run nix:switch` では導入されず、下記のインストール手順を別途手動で実行する必要がある。
+
+## マージ後のインストール手順
+
+このリポジトリの変更 (bun 追加・kitty graphics 有効化) がマージ・反映された後、以下を順に実行する。
+
+1. `mise run nix:switch` — bun と Nix 側の設定変更を反映する
+2. `herdr server reload-config` — `.config/herdr/config.toml` の `[experimental] kitty_graphics = true` を反映する
+3. `herdr plugin install ogulcancelik/herdr-browser --yes` — プラグイン本体をインストールする
+4. WezTerm 上で browser pane を開き、描画を実機確認する (例: `herdr plugin pane open --plugin official.browser --entrypoint browser --placement split --direction right --focus`)
+
+## 運用上の注意
+
+- **CDP はローカル限定**: CDP エンドポイントはそのブラウザビューへの完全な制御権を持つ。ループバック (127.0.0.1) に限定し、ネットワークに公開しないこと (プラグイン README にも明記されている運用上の要件)
+- **WezTerm 専用**: Alacritty は画像プロトコル (Kitty graphics) 非対応であり、設計方針として今後も非搭載の予定。フォールバック側のターミナルとして使う場合、browser pane はそもそも描画されない。herdr-browser は WezTerm 上でのみ使用する
+- **WSL は未検証**: Windows 上の WezTerm (WSL2 経由) での動作は帯域面も含めて未検証。native Arch Linux 環境での検証を先に行うこと
+- **prompt injection のリスクは構造的に残る**: エージェントにブラウザを操作させる以上、Web 由来の prompt injection リスクはこのプラグイン固有の問題ではなく、claude-in-chrome 等の他のブラウザ自動化と同質のものとして残る
+
+## 関連
+
+- [Issue #520](https://github.com/music-brain88/dotfiles/issues/520) - 導入の背景とセキュリティレビュー結果
+- [reference/nix-modules.md](./nix-modules.md) - Nixモジュール構成 (bun は dev-tools.nix)
+- [explanation/architecture.md](../explanation/architecture.md) - Nix + Symlink ハイブリッドの設計思想

--- a/nix/modules/dev-tools.nix
+++ b/nix/modules/dev-tools.nix
@@ -61,6 +61,7 @@ in
     # Policy: Nix provides baseline runtimes only (unpinned = cached by Hydra);
     # per-project versions are pinned via mise (.mise.toml in each repo).
     nodejs # Node.js
+    bun # Bun runtime (herdr-browser プラグインの依存 / dependency of the herdr-browser plugin)
     python3 # Python
     go # Go language
     ruby # Ruby


### PR DESCRIPTION
## 概要

Issue #520 のうち、この PR で完結する前提整備部分を実装しました。herdr-browser プラグイン ([ogulcancelik/herdr-browser](https://github.com/ogulcancelik/herdr-browser)) 本体のインストールは `herdr plugin install` による命令的操作(Nix 管理外)のため、この PR のスコープ外です。

## 変更内容

- `nix/modules/dev-tools.nix`: bun を追加(herdr-browser プラグインのランタイム依存、nixpkgs 標準パッケージ)
- `.config/wezterm/wezterm.lua`: `config.enable_kitty_graphics = true` を追加(WezTerm はデフォルト OFF)
- `.config/herdr/config.toml`: `[experimental]` セクションに `kitty_graphics = true` を追加(herdr >= 0.7.4 の実験的機能フラグ)
- `docs/reference/herdr-browser.md`: 新規作成。プラグイン概要・要件・マージ後のインストール手順・運用注意(CDP はローカル限定、Alacritty では描画されない=WezTerm 専用、WSL 未検証)を記載
- `docs/README.md`: 上記ドキュメントを 📖 Reference の索引に追加

## ライブ反映はこの PR のスコープ外

以下はマージ後に別途実施します(この PR には含まれません):

1. `mise run nix:switch` — bun とここでの Nix/設定変更を反映
2. `herdr server reload-config` — kitty_graphics 設定を反映
3. `herdr plugin install ogulcancelik/herdr-browser --yes` — プラグイン本体のインストール
4. WezTerm 上での browser pane 描画確認(実機テスト)

手順の詳細は [docs/reference/herdr-browser.md](../blob/feat/herdr_browser_plugin/docs/reference/herdr-browser.md) を参照してください。

## 検証

- `mise run nix:check` (= `nix flake check`) を実行し完走、`all checks passed!` を確認(軽量版への縮退は不要でした)

## Test plan

- [x] `mise run nix:check` が通ることを確認済み
- [ ] マージ後: `mise run nix:switch` → `herdr server reload-config` → `herdr plugin install ogulcancelik/herdr-browser --yes` → WezTerm 上で browser pane の描画確認

Closes #520