### PR TITLE
feat(herdr): device-auth 承認 URL を herdr-browser pane に直行させる $BROWSER ラッパーを追加する

### DIFF
--- a/.config/herdr/scripts/device_auth_browser.sh
+++ b/.config/herdr/scripts/device_auth_browser.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# device_auth_browser.sh — $BROWSER wrapper for the device-auth approval flow
+#
+# aws sso login --profile / gh auth login -w / gcloud auth login 等が開く承認 URL
+# を、herdr 内では GUI ブラウザではなく herdr-browser (official.browser) プラグイン
+# の pane に直行させる。herdr 外・SSH・プラグイン未導入時は従来の GUI ブラウザへ
+# フォールバックする。$BROWSER はスペース区切りの引数付き指定を解釈しないツールが
+# あるため、単一実行ファイルのラッパーにしてある(Issue #523)。
+#
+# Routes device-auth approval URLs (aws sso login --profile, gh auth login -w,
+# gcloud auth login, etc.) into a herdr-browser (official.browser) plugin pane
+# instead of a GUI browser when running inside herdr. Falls back to the normal
+# GUI browser outside herdr, over SSH, or when the plugin isn't installed. Kept
+# as a single executable (not "cmd --flag") because some tools that honor
+# $BROWSER don't split on spaces (Issue #523).
+#
+# 参照 / see: docs/reference/herdr-browser.md
+set -euo pipefail
+
+PLUGIN_ID="official.browser"
+ENTRYPOINT="browser"
+
+url="${1:-}"
+if [ -z "$url" ]; then
+  echo "usage: $(basename "$0") <url>" >&2
+  exit 1
+fi
+
+# GUI ブラウザへフォールバックする / fall back to the desktop GUI browser
+fallback_gui() {
+  if command -v xdg-open >/dev/null 2>&1; then
+    exec xdg-open "$url"
+  fi
+  if command -v open >/dev/null 2>&1; then
+    exec open "$url"
+  fi
+  echo "device_auth_browser: no GUI browser opener (xdg-open/open) found for $url" >&2
+  exit 1
+}
+
+# herdr 環境判定: HERDR_ENV=1 か、herdr サーバのソケットに到達可能か
+# Detect herdr: either HERDR_ENV=1, or the herdr server socket answers.
+in_herdr=0
+if [ "${HERDR_ENV:-}" = "1" ]; then
+  in_herdr=1
+elif command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  server_status="$(herdr status server --json 2>/dev/null || true)"
+  if [ "$(printf '%s' "$server_status" | jq -r '.status // empty' 2>/dev/null || true)" = "running" ]; then
+    in_herdr=1
+  fi
+fi
+
+if [ "$in_herdr" -ne 1 ]; then
+  fallback_gui
+fi
+
+# herdr-browser プラグインの前提コマンド (herdr/jq/bun) が揃っているか確認
+# Confirm the herdr-browser plugin's prerequisite commands are available.
+if ! command -v herdr >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 || ! command -v bun >/dev/null 2>&1; then
+  fallback_gui
+fi
+
+# プラグイン導入済み判定 + plugin_root 解決 (ハードコード禁止、#523 実装案どおり)
+# Confirm the plugin is installed and resolve plugin_root — never hardcode it.
+plugin_list_json="$(herdr plugin list --plugin "$PLUGIN_ID" --json 2>/dev/null || true)"
+plugin_root="$(printf '%s' "$plugin_list_json" |
+  jq -r --arg id "$PLUGIN_ID" '.result.plugins[]? | select(.id == $id) | .plugin_root // empty' 2>/dev/null || true)"
+
+if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/src/cli.ts" ]; then
+  fallback_gui
+fi
+
+cli="$plugin_root/src/cli.ts"
+
+# 既存 view (可視 pane に紐づくもの) の有無で分岐する
+# Branch on whether a view (backed by a visible pane) already exists.
+views_json="$(bun run "$cli" views 2>/dev/null || true)"
+has_view="$(printf '%s' "$views_json" | jq -r '(.views // []) | length > 0' 2>/dev/null || echo false)"
+
+if [ "$has_view" = "true" ]; then
+  # 既存 view を ensureView() が自動選択して navigate する (open に --view は無い)
+  # ensureView() auto-selects the existing view and navigates it (open has no --view flag)
+  bun run "$cli" open "$url" >/dev/null 2>&1 || fallback_gui
+else
+  # view が無ければ pane を新規に開きつつ初期 URL を渡す (README 記載の --env)
+  # No view yet: open a fresh pane with the initial URL in one step (documented --env)
+  herdr plugin pane open \
+    --plugin "$PLUGIN_ID" \
+    --entrypoint "$ENTRYPOINT" \
+    --placement overlay \
+    --focus \
+    --env "HERDR_BROWSER_INITIAL_URL=$url" \
+    >/dev/null 2>&1 || fallback_gui
+fi

--- a/.config/herdr/scripts/device_auth_browser.sh
+++ b/.config/herdr/scripts/device_auth_browser.sh
@@ -38,12 +38,27 @@ fallback_gui() {
   exit 1
 }
 
-# herdr 環境判定: HERDR_ENV=1 か、herdr サーバのソケットに到達可能か
-# Detect herdr: either HERDR_ENV=1, or the herdr server socket answers.
+# SSH セッション判定: ソケット到達性だけで herdr 内と誤判定しないためのガード。
+# 同一ホストに SSH で入った別セッションでも herdr のソケットには到達できてしまう
+# ため、SSH 由来のセッションは HERDR_ENV=1 (herdr --remote 等で明示的に立って
+# いる場合) でない限り、無条件に GUI へフォールバックさせる。
+# SSH detection: guards against a false "inside herdr" from socket reachability
+# alone. A plain SSH session into the same host can still reach the local herdr
+# socket, so an SSH-originated session must always fall back to the GUI browser
+# unless HERDR_ENV=1 is explicitly set (e.g. via herdr --remote).
+is_ssh=0
+if [ -n "${SSH_CONNECTION:-}" ] || [ -n "${SSH_TTY:-}" ]; then
+  is_ssh=1
+fi
+
+# herdr 環境判定: HERDR_ENV=1 か、(SSH 経由でない場合に限り) herdr サーバの
+# ソケットに到達可能か
+# Detect herdr: either HERDR_ENV=1, or — only outside SSH — the herdr server
+# socket answers.
 in_herdr=0
 if [ "${HERDR_ENV:-}" = "1" ]; then
   in_herdr=1
-elif command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+elif [ "$is_ssh" -eq 0 ] && command -v herdr >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
   server_status="$(herdr status server --json 2>/dev/null || true)"
   if [ "$(printf '%s' "$server_status" | jq -r '.status // empty' 2>/dev/null || true)" = "running" ]; then
     in_herdr=1

--- a/docs/reference/herdr-browser.md
+++ b/docs/reference/herdr-browser.md
@@ -42,6 +42,35 @@ herdr の pane 内に実ブラウザ (Chromium) を描画し、Chrome DevTools P
 3. `herdr plugin install ogulcancelik/herdr-browser --yes` — プラグイン本体をインストールする
 4. WezTerm 上で browser pane を開き、描画を実機確認する (例: `herdr plugin pane open --plugin official.browser --entrypoint browser --placement split --direction right --focus`)
 
+## device-auth 承認フロー
+
+`aws sso login --profile <x>` / `gh auth login -w` / `gcloud auth login` 等の device-auth 系 CLI は、承認用の URL を `$BROWSER` 環境変数 (aws cli v2 は Python `webbrowser` 経由、gh / gcloud も同様) 経由で開く。運用方針「terminal が主・ブラウザは副」に沿って、この承認 1 クリックのためだけに GUI ブラウザが開く摩擦を消すため、`$BROWSER` を herdr-browser の pane へ直行させるラッパースクリプトに差し替えている ([Issue #523](https://github.com/music-brain88/dotfiles/issues/523))。
+
+- ラッパー本体: [`.config/herdr/scripts/device_auth_browser.sh`](../../.config/herdr/scripts/device_auth_browser.sh)
+- `nix/modules/herdr.nix` が `~/.local/bin/device_auth_browser` へ symlink 配置し、`home.nix` の `sessionVariables.BROWSER` からそのパスを指す
+- `$BROWSER` はスペース区切りで引数付き指定を解釈しないツールがあるため、単一実行ファイルのラッパーにしてある(`herdr plugin pane open ...` のような複数引数コマンドを直接 `$BROWSER` には書けない)
+
+### 挙動
+
+1. **herdr 環境判定**: `HERDR_ENV=1`、または `herdr status server --json` でサーバソケットに到達可能なら herdr 内とみなす。どちらでもなければ (herdr 外・SSH 接続先など) 従来の GUI ブラウザ (`xdg-open` 等) へフォールバックする
+2. **プラグイン導入済み判定**: `herdr` / `jq` / `bun` が揃っているか、`herdr plugin list --plugin official.browser --json` の結果から `plugin_root` を解決できるかを確認する。`plugin_root` はハードコードせず毎回 CLI から解決する。いずれか欠けていれば GUI へフォールバックする
+3. **pane への navigate**: プラグインの CLI (`bun run <plugin_root>/src/cli.ts views`) で既存 view (可視 pane に紐づくもの) の有無を確認する
+   - 既存 view があれば `bun run <plugin_root>/src/cli.ts open <url>` を実行する(`ensureView()` が既存 view を自動選択して navigate する。`--view` フラグは `connect` 専用で `open` には無い)
+   - 既存 view が無ければ `herdr plugin pane open --plugin official.browser --entrypoint browser --placement overlay --focus --env HERDR_BROWSER_INITIAL_URL=<url>` で新規 pane を overlay 配置(承認だけの一時利用に向く transient/popup 的配置)で開き、初期 URL を渡す
+   - navigate 自体が失敗した場合も GUI ブラウザへフォールバックする
+
+2 回目以降の承認は、pane 専用の Chrome プロファイル (`~/.local/state/herdr/plugins/official.browser/chrome-profiles/`、0700) に SSO セッションが残るためワンクリックで完了する想定。新規ログインでパスワード入力が必要になるケース(セッション切れの初回など)は、pane 内のブラウザで直接入力するかどうかは別途検討事項として残っている。
+
+### 実機確認手順 (マージ後)
+
+このラッパーの実装自体はコードレビューのみで完結しており、実際の承認フローの動作確認にはユーザーの認証情報が必要なため、マージ・`mise run nix:switch` によるライブ反映後にユーザー自身が以下を確認する。
+
+1. `mise run nix:switch` で `$BROWSER` 差し替えと symlink を反映する
+2. herdr-browser プラグインが未導入なら [マージ後のインストール手順](#マージ後のインストール手順) を先に実行する
+3. herdr 内 (WezTerm) のシェルから `aws sso login --profile <x>` を実行し、承認 URL が herdr-browser の pane (overlay) 内で開くこと・承認クリックがそのまま完結することを確認する
+4. `gh auth login -w` でも同様に pane 内で承認が完結することを確認する
+5. herdr 外 (例: 素の Alacritty や SSH 接続先) から同じコマンドを実行し、従来どおり GUI ブラウザ (Firefox 等) が開くことを確認する
+
 ## 運用上の注意
 
 - **CDP はローカル限定**: CDP エンドポイントはそのブラウザビューへの完全な制御権を持つ。ループバック (127.0.0.1) に限定し、ネットワークに公開しないこと (プラグイン README にも明記されている運用上の要件)
@@ -52,5 +81,6 @@ herdr の pane 内に実ブラウザ (Chromium) を描画し、Chrome DevTools P
 ## 関連
 
 - [Issue #520](https://github.com/music-brain88/dotfiles/issues/520) - 導入の背景とセキュリティレビュー結果
+- [Issue #523](https://github.com/music-brain88/dotfiles/issues/523) - device-auth 承認フローの $BROWSER ラッパー
 - [reference/nix-modules.md](./nix-modules.md) - Nixモジュール構成 (bun は dev-tools.nix)
 - [explanation/architecture.md](../explanation/architecture.md) - Nix + Symlink ハイブリッドの設計思想

--- a/docs/reference/herdr-browser.md
+++ b/docs/reference/herdr-browser.md
@@ -52,7 +52,7 @@ herdr の pane 内に実ブラウザ (Chromium) を描画し、Chrome DevTools P
 
 ### 挙動
 
-1. **herdr 環境判定**: `HERDR_ENV=1`、または `herdr status server --json` でサーバソケットに到達可能なら herdr 内とみなす。どちらでもなければ (herdr 外・SSH 接続先など) 従来の GUI ブラウザ (`xdg-open` 等) へフォールバックする
+1. **herdr 環境判定**: `HERDR_ENV=1` なら herdr 内とみなす。`HERDR_ENV` が立っていない場合は、SSH セッション (`SSH_CONNECTION` または `SSH_TTY` が set) でないことを条件に `herdr status server --json` でサーバソケットへの到達性を追加確認する。同一ホストへの SSH セッションはソケットには到達できてしまうため、`HERDR_ENV=1` でない限り必ず GUI ブラウザ (`xdg-open` 等) へフォールバックする
 2. **プラグイン導入済み判定**: `herdr` / `jq` / `bun` が揃っているか、`herdr plugin list --plugin official.browser --json` の結果から `plugin_root` を解決できるかを確認する。`plugin_root` はハードコードせず毎回 CLI から解決する。いずれか欠けていれば GUI へフォールバックする
 3. **pane への navigate**: プラグインの CLI (`bun run <plugin_root>/src/cli.ts views`) で既存 view (可視 pane に紐づくもの) の有無を確認する
    - 既存 view があれば `bun run <plugin_root>/src/cli.ts open <url>` を実行する(`ensureView()` が既存 view を自動選択して navigate する。`--view` フラグは `connect` 専用で `open` には無い)

--- a/home.nix
+++ b/home.nix
@@ -33,7 +33,12 @@
   home.sessionVariables = {
     EDITOR = "nvim";
     VISUAL = "nvim";
-    BROWSER = "firefox";
+    # device-auth 系 CLI (aws sso login / gh auth login -w / gcloud auth login 等) の
+    # 承認 URL を herdr-browser pane に直行させるラッパー。herdr 外では内部で GUI
+    # ブラウザ (xdg-open 等) にフォールバックする (Issue #523)。
+    # Routes device-auth approval URLs into a herdr-browser pane; falls back to the
+    # GUI browser internally outside herdr (Issue #523).
+    BROWSER = "${config.home.homeDirectory}/.local/bin/device_auth_browser";
     TERMINAL = "wezterm";
     # SSL certificates (use system certs instead of Nix store)
     SSL_CERT_DIR = "/etc/ssl/certs";

--- a/nix/modules/herdr.nix
+++ b/nix/modules/herdr.nix
@@ -10,4 +10,11 @@
 
   # herdr config symlink (keybind は旧 tmux 設定互換 / tmux-compatible keybindings)
   home.file.".config/herdr/config.toml".source = ../../.config/herdr/config.toml;
+
+  # device-auth 承認 URL を herdr-browser pane に直行させる $BROWSER ラッパー (Issue #523)
+  # $BROWSER wrapper that routes device-auth approval URLs into a herdr-browser pane (Issue #523)
+  home.file.".local/bin/device_auth_browser" = {
+    source = ../../.config/herdr/scripts/device_auth_browser.sh;
+    executable = true;
+  };
 }


### PR DESCRIPTION
## 概要
- `aws sso login --profile` / `gh auth login -w` / `gcloud auth login` 等の device-auth 系 CLI が開く承認 URL を、GUI ブラウザではなく herdr-browser (`official.browser`) プラグインの pane に直行させる `$BROWSER` ラッパースクリプトを追加する
- `home.nix` の `sessionVariables.BROWSER` を配線し、`nix/modules/herdr.nix` で `~/.local/bin/device_auth_browser` へ symlink 配置する
- `docs/reference/herdr-browser.md` に「device-auth 承認フロー」節を追記する

Closes #523

## 実装

- `.config/herdr/scripts/device_auth_browser.sh`
  1. **herdr 環境判定**: `HERDR_ENV=1`、または `herdr status server --json` でソケット到達性を確認。どちらでもなければ GUI ブラウザ (`xdg-open` 等) へフォールバック
  2. **プラグイン導入済み判定**: `herdr`/`jq`/`bun` の存在と、`herdr plugin list --plugin official.browser --json` から `plugin_root` を解決できるかを確認 (ハードコードしない)。欠けていれば GUI へフォールバック
  3. **pane への navigate**: `bun run <plugin_root>/src/cli.ts views` で既存 view (可視 pane に紐づくもの) の有無を確認し、
     - あれば `bun run <plugin_root>/src/cli.ts open <url>` (`ensureView()` が既存 view を自動選択)
     - なければ `herdr plugin pane open --plugin official.browser --entrypoint browser --placement overlay --focus --env HERDR_BROWSER_INITIAL_URL=<url>` で新規 pane を開きつつ初期 URL を渡す
     - navigate 自体が失敗した場合も GUI へフォールバック
- `$BROWSER` はスペース区切りの引数付き指定を解釈しないツールがあるため、単一実行ファイルのラッパーにしてある

## Issue 記載の実装案からの変更点

実装前にプラグイン本体 (`ogulcancelik/herdr-browser`) の README と `src/cli.ts` を直接確認したところ、Issue 記載の実装案と実際の CLI 仕様に食い違いがあったため、司令塔 (`commander-dotfiles`) に相談のうえ以下のとおり変更した。

- Issue 案: 「既存 view があれば `bun run cli.ts open <url> --view <id>`」→ 実際には `open` に `--view` フラグは存在しない (`--view` は `connect` 専用)。`open <url>` は内部の `ensureView()` が既存 view (視認可能な pane に紐づくもの) を自動選択して navigate するため、`--view` を渡さず `open <url>` のみで既存 view への navigate が成立する
- 新規 pane を開く際は、README に明記された `herdr plugin pane open --env HERDR_BROWSER_INITIAL_URL=<url>` で初期 URL を pane 起動と同時に渡す方式を採用した(pane open 後に別途 `cli.ts open` を叩く必要がない)
- pane の配置は `overlay` を採用した。README で「transient, popup-like browser surface」として推奨されており、承認 1 クリックで完結する device-auth の用途に合致するため

## 実機確認 (マージ後にユーザーが実施)

このラッパーの実装はコードレビューと `bash -n` / shellcheck (herdr-browser プラグイン未導入のためここでは `nix run nixpkgs#shellcheck` 経由、警告なし) のみで完結しており、実際の承認フローの動作確認にはユーザーの認証情報が必要なため作業者側では実施していない。マージ後、`mise run nix:switch` によるライブ反映後にユーザーが以下を確認する。

1. `mise run nix:switch` で `$BROWSER` 差し替えと symlink を反映する
2. herdr-browser プラグインが未導入なら [マージ後のインストール手順](https://github.com/music-brain88/dotfiles/blob/main/docs/reference/herdr-browser.md#マージ後のインストール手順) を先に実行する
3. herdr 内 (WezTerm) のシェルから `aws sso login --profile <x>` を実行し、承認 URL が herdr-browser の pane (overlay) 内で開くこと・承認クリックがそのまま完結することを確認する
4. `gh auth login -w` でも同様に pane 内で承認が完結することを確認する
5. herdr 外 (例: 素の Alacritty や SSH 接続先) から同じコマンドを実行し、従来どおり GUI ブラウザ (Firefox 等) が開くことを確認する

## テストプラン

- [x] `bash -n .config/herdr/scripts/device_auth_browser.sh`
- [x] `nix run nixpkgs#shellcheck -- .config/herdr/scripts/device_auth_browser.sh` (警告なし)
- [x] `nix-instantiate --parse` で `home.nix` / `nix/modules/herdr.nix` の構文確認
- [ ] (マージ後、ユーザー実施) `aws sso login` / `gh auth login -w` が pane 内で完結すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)