### PR TITLE
docs(reference): スキル配置の2層構造(tool-neutral / Claude専用)を directory-structure に明記

### DIFF
--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -102,7 +102,7 @@ dotfiles/
 スキルは配線経路によって2層に分かれる:
 
 - **tool-neutral 層**(`skills/`): エージェント横断の共有 SOP(例: `learn`、`session-log`、`distill`)。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方へのマウントに解決され、単一ソースからドリフトしない(Issue #404)
-- **Claude 専用層**(`claude/skills/`): harness 固有の運用スキル(例: `wt`、`wtclean`、`herdr`)。`.claude` 全体の recursive マウント(`home.nix` の `".claude"` エントリ)でそのまま配布され、個別の上書きエントリを持たない
+- **Claude 専用層**(`claude/skills/`): harness 固有の運用スキル(例: `wt`、`wtclean`、`herdr`)。これらは `.claude` 全体の recursive マウント(`home.nix` の `".claude"` エントリ)でそのまま配布され、tool-neutral 層のような個別スキル単位の上書きマウントは持たない(個別の `.claude/skills/<name>` エントリが `home.nix` に存在するのは、あくまで tool-neutral 層の共有スキルを上書きするためのもの)
 
 新しいスキルを追加する際は「特定 harness(Claude Code)の機能に依存するか」で配置を判断する — 依存しなければ tool-neutral 層、依存すれば Claude 専用層に置く。
 

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -99,6 +99,13 @@ dotfiles/
 
 ### AI Assistant Skills
 
+スキルは配線経路によって2層に分かれる:
+
+- **tool-neutral 層**(`skills/`): エージェント横断の共有 SOP(例: `learn`、`session-log`、`distill`)。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方へのマウントに解決され、単一ソースからドリフトしない(Issue #404)
+- **Claude 専用層**(`claude/skills/`): harness 固有の運用スキル(例: `wt`、`wtclean`、`herdr`)。`.claude` 全体の recursive マウント(`home.nix` の `".claude"` エントリ)でそのまま配布され、個別の上書きエントリを持たない
+
+新しいスキルを追加する際は「特定 harness(Claude Code)の機能に依存するか」で配置を判断する — 依存しなければ tool-neutral 層、依存すれば Claude 専用層に置く。
+
 | Directory | Description |
 |-----------|-------------|
 | `skills/` | ツール中立な共有スキル層。各サブディレクトリに `SKILL.md`(frontmatter は `name`/`description` のみ)。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方にマウントし、単一ソースからのドリフトを構造的に防ぐ(Issue #404)。スキルの一覧は `.config/skills/` 配下が正(列挙は追加のたびに腐るためここには書かない) |


### PR DESCRIPTION
## 背景

Issue #509 より。/wtclean の供養(知見回収)で、#505 起票時にスキル配置の実態を誤解していたことが発覚。

- **tool-neutral 層**: `.config/skills/` — `learn`/`session-log`/`distill` など。`home.nix` で `.claude/skills/<name>` と `.copilot/skills/<name>` の両方にマウントされ、単一ソースからドリフトしない(Issue #404)
- **Claude 専用層**: `.config/claude/skills/` — `wt`/`wtclean`/`herdr` など。`.claude` 全体の recursive マウントでそのまま配布される

この区別が未文書化で、スキル起票・配置判断を誤るミスが再発しうる状態だった。

## 変更内容

`docs/reference/directory-structure.md` の `AI Assistant Skills` セクションに以下を追記:

- 各層の役割(tool-neutral はエージェント横断の共有 SOP、Claude 専用は harness 固有の運用スキル)
- 配線経路の違い(home.nix の両ミラー配線 vs `.claude` recursive マウント)
- 新規スキル追加時の配置判断基準(特定 harness の機能に依存するか)

既存の Directory/Description テーブルは変更していない(追記のみ)。

## 裏取り

`home.nix` の実際の配線コードを確認し、Issue の記述と実態が一致していることを確認済み:
- `.claude/skills/<name>` と `.copilot/skills/<name>` の個別エントリ(両ミラー配線、`recursive = true`)
- `.claude` 全体の recursive マウント(`".claude" = { source = ./.config/claude; recursive = true; }`)、個別スキルの上書きエントリなし
- `.config/claude/skills/` 配下の実体(`herdr`/`wt`/`wtclean`)と `.config/skills/` 配下の実体(`context`/`create-issue`/`daily`/`distill`/`formal`/`herdr-chat`/`learn`/`pr`/`qbq`/`release-note`/`session-log`)を実ディレクトリで確認

## 確認事項

- [x] `git diff` で既存セクションに意図しない変更がないことを確認済み

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)