### PR TITLE
fix(herdr): device_auth_browser の plugin 判定を plugin_id に直し GUI 誤フォールバックを解消する

### DIFF
--- a/.config/herdr/scripts/device_auth_browser.sh
+++ b/.config/herdr/scripts/device_auth_browser.sh
@@ -79,7 +79,7 @@ fi
 # Confirm the plugin is installed and resolve plugin_root — never hardcode it.
 plugin_list_json="$(herdr plugin list --plugin "$PLUGIN_ID" --json 2>/dev/null || true)"
 plugin_root="$(printf '%s' "$plugin_list_json" |
-  jq -r --arg id "$PLUGIN_ID" '.result.plugins[]? | select(.id == $id) | .plugin_root // empty' 2>/dev/null || true)"
+  jq -r --arg id "$PLUGIN_ID" '.result.plugins[]? | select(.plugin_id == $id) | .plugin_root // empty' 2>/dev/null || true)"
 
 if [ -z "$plugin_root" ] || [ ! -f "$plugin_root/src/cli.ts" ]; then
   fallback_gui


### PR DESCRIPTION
## [optional body]

#525 で導入した `$BROWSER` ラッパー `device_auth_browser.sh` のプラグイン導入判定を修正する。

- `herdr plugin list --json` の plugin オブジェクトには `id` フィールドが存在せず `plugin_id` が正のため、`select(.id == $id)` は決してマッチせず `plugin_root` が空になり、プラグイン導入済みでも常に `fallback_gui` へ落ちていた
- jq フィルタを `select(.plugin_id == $id)` に修正する(1行)
- あわせて repo 側スクリプトの git mode を `100644` → `100755` にする。nix 配布側は `executable = true` のため実害はないが、`$BROWSER` に repo パスを直接向けてテストする際、実行ビットが無いと Python `webbrowser` が黙って次の候補へフォールバックする罠を潰す

## 実機確認 (2026-07-31、修正済みラッパーで実施済み)

- [x] view 無し → `herdr plugin pane open --env HERDR_BROWSER_INITIAL_URL=<url>` で overlay pane 新規作成 + 初期 URL 表示
- [x] view 有り → `cli.ts open <url>` (`ensureView()`) がクエリ付き OIDC URL でも既存 pane に navigate
- [x] `aws sso login --profile <profile>` end-to-end: 承認 URL が pane 直行 → IdP サインイン → OAuth callback → `Successfully logged into Start URL` まで pane 内で完結
- [x] `bash -n` / `nix run nixpkgs#shellcheck` 警告なし

## [optional footer(s)]

Closes #531
Refs: #523 (実装案), #525 (導入 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
