### PR TITLE
fix(gpg): SSHセッションからpinentryが到達不能な問題を恒久対策する

### DIFF
--- a/.config/bash/bashrc
+++ b/.config/bash/bashrc
@@ -18,6 +18,11 @@ if [ "$(uname -s)" = 'Linux' ]; then
     eval "$(ssh-agent -s)"
   fi
   export GPG_TTY=$(tty)
+  # SSH session: refresh gpg-agent's cached tty so pinentry can reach us
+  # SSHセッション時はgpg-agentが保持するttyを更新する
+  if [ -n "$SSH_CONNECTION" ]; then
+    gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
+  fi
 fi
 
 # Launch Nix-managed fish shell

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -12,6 +12,17 @@ set -x LC_CTYPE en_US.UTF-8
 set -x EDITOR nvim
 set -x VISUAL nvim
 
+# GPG: tell gpg-agent which tty to use for pinentry (interactive shells only)
+# gpg-agentにこのシェルのttyを伝える(pinentry用、対話シェルのみ)
+if status is-interactive; and isatty stdin
+  set -gx GPG_TTY (tty)
+  # SSH session: refresh gpg-agent's cached tty so pinentry can reach us
+  # SSHセッション時はgpg-agentが保持するttyを更新する
+  if set -q SSH_CONNECTION
+    gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
+  end
+end
+
 # Aliases
 alias vim 'nvim'
 alias rm 'rm -i'

--- a/.config/fish/functions/gpg-unlock.fish
+++ b/.config/fish/functions/gpg-unlock.fish
@@ -1,0 +1,3 @@
+function gpg-unlock --description "Warm gpg-agent passphrase cache via a fresh pty (for Tailscale SSH) / ptyを挟んでGPGキャッシュを温める"
+  script -qec 'export GPG_TTY=$(tty); gpg-connect-agent updatestartuptty /bye; echo unlock | gpg --clearsign -o /dev/null' /dev/null
+end

--- a/.config/pinentry/preexec
+++ b/.config/pinentry/preexec
@@ -1,0 +1,9 @@
+# Force pinentry to curses/tty. Arch's /usr/bin/pinentry wrapper sources this
+# hook before backend selection; without it, stale XDG_SESSION_TYPE=wayland in
+# gpg-agent's environment selects pinentry-gnome3, which is unreachable from
+# SSH sessions (Permission denied / Timeout).
+# pinentryをcurses/ttyへ誘導する。gpg-agent環境に残るXDG_SESSION_TYPE=wayland
+# がgnome3バックエンドを選び続け、SSHセッションから到達不能になるため。
+# 恒久対策: music-brain88/dotfiles#533
+unset DISPLAY
+export XDG_SESSION_TYPE=tty

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -19,6 +19,9 @@
   # GnuPG config symlink (gpg-agent cache TTL)
   home.file.".gnupg/gpg-agent.conf".source = ../../.config/gnupg/gpg-agent.conf;
 
+  # pinentry preexec hook (forces curses/tty backend; see #533)
+  xdg.configFile."pinentry/preexec".source = ../../.config/pinentry/preexec;
+
   # GnuPG expects a private home directory.
   # GnuPGは ~/.gnupg がprivateじゃないと警告する
   home.activation.ensureGnuPGHomePermissions = config.lib.dag.entryAfter [ "writeBoundary" ] ''

--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -14,6 +14,7 @@
   # Fish config symlinks (matching deploy.sh)
   home.file.".config/fish/config.fish".source = ../../.config/fish/config.fish;
   home.file.".config/fish/functions/fish_user_key_bindings.fish".source = ../../.config/fish/functions/fish_user_key_bindings.fish;
+  home.file.".config/fish/functions/gpg-unlock.fish".source = ../../.config/fish/functions/gpg-unlock.fish;
   home.file.".config/fish/completions" = {
     source = ../../.config/fish/completions;
     recursive = true;


### PR DESCRIPTION
## 概要

Issue #533 の根本原因3層のうち (a)(b) を恒久対策し、(c) を運用対処の関数として追加する。

- gpg-agent が起動時の tty/DISPLAY を保持し続ける
- Arch の pinentry ラッパーが gpg-agent 環境に残る `XDG_SESSION_TYPE=wayland` で pinentry-gnome3 を選び、SSH セッションから到達不能になる(Permission denied / Timeout)
- Tailscale SSH(tailscaled が root で直接処理)の pty からは pinentry-curses が開けない

## 変更内容

1. **pinentry preexec フックの repo 取り込み**: `.config/pinentry/preexec`(新規)で無条件に curses/tty へ誘導。`nix/modules/git.nix` に `xdg.configFile."pinentry/preexec"` symlink を追加。ホームに手置きしていた暫定対処の昇格。
2. **fish**: `.config/fish/config.fish` に対話シェルのみで動く `GPG_TTY` 設定と、SSH セッション時(`SSH_CONNECTION`)の `gpg-connect-agent updatestartuptty` を追加。
3. **bash**: `.config/bash/bashrc` の既存 `GPG_TTY` 設定の近くに、SSH セッション時のみ `gpg-connect-agent updatestartuptty` を追加(fish とのパリティ)。
4. **gpg-unlock 関数**: `.config/fish/functions/gpg-unlock.fish`(新規)。Tailscale SSH の pty から直接 pinentry-curses が開けないケース向けに、`script(1)` で通常の pty を1枚挟んでパスフレーズ入力 → agent キャッシュを温める。`nix/modules/shell.nix` に symlink を追加。

## 動作確認

- `mise run nix:check` が通ることを確認
- Issue #533 のコメントに記録された動作確認済み手順(preexec フックの curses 誘導、script ワンライナー)をそのまま関数化・repo 化した

## マージ後のデプロイ手順

1. `rm ~/.config/pinentry/preexec`(手置きの暫定ファイルを退かす — home-manager が既存実ファイルと衝突するため)
2. `mise run nix:switch`
3. 既存シェルには GPG_TTY 等が反映されない(新しい fish から有効)

Closes #533