### PR TITLE
fix(skills): /wt — context 使用率(💭 n%)が pane 幅で切り詰められて読めない場合の対処を SOP に追記する

### DIFF
--- a/.config/claude/skills/wt/SKILL.md
+++ b/.config/claude/skills/wt/SKILL.md
@@ -198,6 +198,7 @@ herdr agent prompt <agent-name> "<追加指示のテキスト>"
 - **MUST**: 実行前に対象の agent 名を必ず確認する(宛先を誤ると、無関係なエージェントに指示が届いてしまう。`agent prompt` はテキストを引数としてそのまま送るだけで、確認や取り消しは挟まらない)
 - **MUST**: 送信前に `herdr agent read` で対象 pane の状態を確認する。AskUserQuestion 等のメニューが表示中は `agent prompt` を使わない(chat 入力欄への送信になるため、ハイライトされている選択肢を誤確定させる罠がある。`send-text` + Enter でこの誤確定による実害が実際に出ており(詳細: Troubleshooting「AskUserQuestion メニュー表示中の誤確定事故」参照)、`agent prompt` も同じくメニュー表示中の pane に送信する以上、予防的に避ける)。メニューの選択肢確定自体は従来どおり `herdr pane send-keys <pane-id> Enter` で行う(pane-id は `herdr agent get <agent-name>` で都度引く。詳細: Troubleshooting「pane-id は非永続」参照)
 - **MUST**: レビュー差し戻し等、委任後に追加の作業ラウンドを送る前に、`herdr agent get <agent-name>` で pane-id を引いたうえで `herdr pane read <pane-id> --source visible` を実行し、末尾行の pane 下部ステータスラインで context 使用率(💭 n%)を確認する。50% を超えている場合は追加ラウンドを送らず、(a) 司令塔が直接対応する、(b) 新 worker へ引き継ぐ(引き継ぎブリーフ = 元ブリーフ + ここまでの成果物参照(PR URL / コミット)+ 残作業のみ)、のいずれかを選ぶ。ユーザーより先に司令塔が検知すべきシグナルであり、閾値超過を検知したら対応方針とあわせてユーザーに報告する(詳細: Troubleshooting「レビュー差し戻しラウンドによる worker context の逼迫」参照)
+- **MUST**: pane 幅が狭くステータスラインが `…` で切り詰められ 💭 の値が読めない場合、herdr CLI に幅非依存で context 使用率を取得できる経路は無い(実機調査済み。詳細: Troubleshooting「ステータスライン切り詰めで 💭 が読めない」参照)。読めない場合は使用率を推測で埋めず、保守的に (a) 直接対応 または (b) 引き継ぎ 側へ倒す
 - **MAY**: `--wait` / `--until <STATUS>`(繰り返し指定可)/ `--timeout <MS>` を併用すると、送信と応答待ちを1コマンドに畳められる(詳細: Troubleshooting「send-keys Enter が chat 入力を submit できないことがある」参照)
 
 #### (2) 上り=イベント
@@ -363,7 +364,18 @@ herdr が使えない環境(worktree だけで完結させたい等)では、作
 作業者は【相談】送信後も司令塔からの回答を待つ間 `idle` に遷移するため、`herdr agent wait` の `idle` 発火だけでは完了と断定できない(#394)。判別・応答の手順は手順5「(2) 上り=イベント」の「相談 idle の判別」参照。
 
 ### レビュー差し戻しラウンドによる worker context の逼迫
-本業リポジトリの PR(2026-07-27)で、差し戻し2ラウンド後に worker が context 60% に到達し、ユーザーが先に検知した。差し戻しは元実装の全文脈を保持した worker に送るのが品質上望ましい一方、ラウンドごとに context は単調に増える。50% を目安に「直接対応 or 引き継ぎ」へ切り替える(上記手順5(1) の Constraint)。ステータスラインの使用率は `herdr agent get <agent-name>` で pane-id を引いてから `herdr pane read <pane-id> --source visible` を実行し、その末尾行で機械的に読める。
+本業リポジトリの PR(2026-07-27)で、差し戻し2ラウンド後に worker が context 60% に到達し、ユーザーが先に検知した。差し戻しは元実装の全文脈を保持した worker に送るのが品質上望ましい一方、ラウンドごとに context は単調に増える。50% を目安に「直接対応 or 引き継ぎ」へ切り替える(上記手順5(1) の Constraint)。ステータスラインの使用率は `herdr agent get <agent-name>` で pane-id を引いてから `herdr pane read <pane-id> --source visible` を実行し、その末尾行で機械的に読める(ただし pane 幅が狭いと切り詰められて読めないケースがある。詳細と代替手段は次項「ステータスライン切り詰めで 💭 が読めない」参照)。
+
+### ステータスライン切り詰めで 💭 が読めない
+2026-07-31、上記の運用で `herdr agent read <agent-name> --source visible` の末尾ステータスラインが pane 幅で切り詰められ(`⚡ Sonnet 5  xhigh …` までで省略)、💭 の値が読めないケースが発生した(#529)。ステータスラインの表示順で 💭 が右寄りにあるため、pane が狭いと機械的に読めない。
+
+調査の結果(実機確認済み)、herdr CLI に pane 幅非依存で context 使用率を取得できる経路は見つからなかった:
+- `herdr agent get <agent-name>` の JSON 出力(`agent`/`agent_status`/`cwd`/`pane_id`/`workspace_id` 等) に context 使用率相当のフィールドは無い
+- `herdr pane read <pane-id>` の `--source visible/recent/recent-unwrapped/detection` を総当たりしても、`recent-unwrapped`(改行の折り返し解除)や `--raw`、`--format text/ansi` を組み合わせても 💭 の省略記号(`…`)は変わらない。Claude Code 側の TUI がステータスラインを pane の列数に応じて描画時点で切り詰めており、pane 幅そのものを変えない限り herdr 側の出力オプションでは回避できない
+- `herdr api snapshot` にはペイン分割レイアウトの `ratio`(split の分割比率であり context 使用率とは無関係)はあるが、context/token/usage 相当のフィールドは無い
+- `herdr agent explain` は working/idle 等の検知根拠のみ、`herdr pane process-info` は前面プロセスの argv/cwd のみで、いずれも context 情報は含まない
+
+そのため、切り詰められて読めない場合は保守的に (a) 直接対応 または (b) 引き継ぎ 側へ倒す(上記手順5(1) の Constraint)。pane を広げれば読める可能性はあるが、他 worker の pane レイアウトを都合で変更するのは対話プロトコル上望ましくないため、標準手順としては採用しない。根本解決には statusline の表示順変更(💭 を左寄りにする等、`.config/claude/statusline` 系の変更)が必要だが、この skill のスコープを超えるため別途 Issue 化を検討する。
 
 ### commander-<repo名> の名前衝突
 同リポジトリの過去セッション pane が名前を保持していると `herdr agent rename` が

--- a/.config/claude/skills/wt/SKILL.md
+++ b/.config/claude/skills/wt/SKILL.md
@@ -367,7 +367,7 @@ herdr が使えない環境(worktree だけで完結させたい等)では、作
 本業リポジトリの PR(2026-07-27)で、差し戻し2ラウンド後に worker が context 60% に到達し、ユーザーが先に検知した。差し戻しは元実装の全文脈を保持した worker に送るのが品質上望ましい一方、ラウンドごとに context は単調に増える。50% を目安に「直接対応 or 引き継ぎ」へ切り替える(上記手順5(1) の Constraint)。ステータスラインの使用率は `herdr agent get <agent-name>` で pane-id を引いてから `herdr pane read <pane-id> --source visible` を実行し、その末尾行で機械的に読める(ただし pane 幅が狭いと切り詰められて読めないケースがある。詳細と代替手段は次項「ステータスライン切り詰めで 💭 が読めない」参照)。
 
 ### ステータスライン切り詰めで 💭 が読めない
-2026-07-31、上記の運用で `herdr agent read <agent-name> --source visible` の末尾ステータスラインが pane 幅で切り詰められ(`⚡ Sonnet 5  xhigh …` までで省略)、💭 の値が読めないケースが発生した(#529)。ステータスラインの表示順で 💭 が右寄りにあるため、pane が狭いと機械的に読めない。
+2026-07-31、上記の運用で `herdr pane read <pane-id> --source visible` の末尾ステータスラインが pane 幅で切り詰められ(`⚡ Sonnet 5  xhigh …` までで省略)、💭 の値が読めないケースが発生した(#529)。ステータスラインの表示順で 💭 が右寄りにあるため、pane が狭いと機械的に読めない。
 
 調査の結果(実機確認済み)、herdr CLI に pane 幅非依存で context 使用率を取得できる経路は見つからなかった:
 - `herdr agent get <agent-name>` の JSON 出力(`agent`/`agent_status`/`cwd`/`pane_id`/`workspace_id` 等) に context 使用率相当のフィールドは無い


### PR DESCRIPTION
## 概要
Issue #529 の対応。PR #527(Issue #512)で追加した「レビュー差し戻し前に `herdr pane read` でステータスラインの context 使用率(💭 n%)を確認する」Constraint が、pane 幅が狭いとステータスラインが `…` で切り詰められて読めないケースが実運用で発生した(実例: `⚡ Sonnet 5  xhigh …` までで省略)。

## 調査結果(実機確認)
現在並行稼働中の worker pane(`herdr agent list` で確認できる複数の worktree worker)を読み取り対象に、herdr CLI で pane 幅非依存の代替取得経路を調査したが、**どの経路でも context 使用率を機械的に取得できなかった**:

| 調査対象 | 結果 |
|---|---|
| `herdr agent get <agent-name>` の JSON 出力 | `agent`/`agent_status`/`cwd`/`pane_id`/`workspace_id` 等のみ。context 使用率相当のフィールドは無し |
| `herdr pane read <pane-id>` の `--source visible/recent/recent-unwrapped/detection` | 全 source・`--raw`・`--format text/ansi` を組み合わせても 💭 の省略記号(`…`)は変わらず。Claude Code 側 TUI が pane 列数に応じて描画時点でステータスラインを切り詰めているため、herdr 側の出力オプションでは回避不可(`recent-unwrapped` は改行の折り返し解除であって、TUI 側のトランケートとは別レイヤー) |
| `herdr api snapshot` | pane 分割レイアウトの `ratio` フィールドはあるが split の分割比率であり context 使用率とは無関係。context/token/usage 相当のキーは皆無 |
| `herdr agent explain` | working/idle 等の検知根拠のみ |
| `herdr pane process-info` | 前面プロセスの argv/cwd のみ |

根本解決には statusline の表示順変更(💭 を左寄りにする等、`.config/claude/statusline` 系の変更)が必要と判断したが、この skill(`/wt`)のスコープを超えるため本 PR では実装せず、司令塔(`commander-dotfiles`)へ相談 push 済み(別 Issue 化を提案)。

## 変更内容
`.config/claude/skills/wt/SKILL.md`:
- 手順5(1)「下り=指示」の Constraint に、切り詰めで読めない場合は保守的に直接対応/引き継ぎへ倒す旨を追記
- Troubleshooting に新規節「ステータスライン切り詰めで 💭 が読めない」を追加し、上記調査結果と対処方針を記録
- 既存 Troubleshooting「レビュー差し戻しラウンドによる worker context の逼迫」の該当文言に新節への参照を追記

Closes #529

## 確認したこと
- 実際に稼働中の他 worktree worker pane(読み取り系コマンドのみ使用、書き込み・送信・rename は未実施)に対して上記調査コマンドを実行し、結果を確認済み