### PR TITLE
feat(skills): /wtclean — 掃除完了後に収穫ステップ(蒸留 Hot lane)を追加

### DIFF
--- a/.config/claude/skills/wtclean/SKILL.md
+++ b/.config/claude/skills/wtclean/SKILL.md
@@ -125,8 +125,10 @@ git worktree prune
 ClaudeCodeSession ノートを Grep で検索する:
 
 ```bash
-grep -lE "#<PR番号>|pull/<PR番号>" /home/archie/Documents/Obsidian/Zettelkasten/ResearchNotes/ClaudeCodeSession-*.md
+grep -lE "#<PR番号>([^0-9]|$)|pull/<PR番号>([^0-9]|$)" /home/archie/Documents/Obsidian/Zettelkasten/ResearchNotes/ClaudeCodeSession-*.md
 ```
+
+(部分一致による誤検知を避けるため、PR番号の直後に数字が続かない境界を入れる。例: PR 53 を探すとき `#534` や `pull/534` を誤ってヒットさせない)
 
 ヒットしたノートの frontmatter `distilled_to:` が空のものを候補とする(実例: 「決定事項・成果物」節に
 `[PR #534](https://github.com/.../pull/534)` の形で PR リンクを残す運用が既に存在するため、この検索は成立する)。

--- a/.config/claude/skills/wtclean/SKILL.md
+++ b/.config/claude/skills/wtclean/SKILL.md
@@ -116,6 +116,32 @@ git worktree prune
 - **MUST**: スキップしたもの(理由付き: 未コミット変更あり、エージェント稼働中、open PR あり、など)を報告する
 - **MUST**: 回収した知見 / Issue 候補を報告する(worktree ごとに要約。該当なしなら「知見なし」)
 
+### 9. 収穫ステップ(蒸留パイプライン Hot lane)
+
+手順8の掃除完了報告の**後**に行う。蒸留パイプライン設計(vault ProjectNotes)の合意事項: 蒸留の実行トリガーは
+時刻ではなく**作業サイクルの完了**に置く。「マージ済み作業の後始末」である /wtclean は、その天然の完了の拍にあたる。
+
+削除した各 worktree について、対応する PR 番号(手順2で取得済み)を使い、ResearchNotes 配下の
+ClaudeCodeSession ノートを Grep で検索する:
+
+```bash
+grep -lE "#<PR番号>|pull/<PR番号>" /home/archie/Documents/Obsidian/Zettelkasten/ResearchNotes/ClaudeCodeSession-*.md
+```
+
+ヒットしたノートの frontmatter `distilled_to:` が空のものを候補とする(実例: 「決定事項・成果物」節に
+`[PR #534](https://github.com/.../pull/534)` の形で PR リンクを残す運用が既に存在するため、この検索は成立する)。
+
+**Constraints:**
+- **MUST**: 削除した各 worktree の PR 番号で `ResearchNotes/ClaudeCodeSession-*.md` を検索し、`distilled_to` が
+  空のノートを候補とする
+- **MUST**: 候補が複数あっても提案は1件のみに絞る(複数 worktree を掃除した場合など。最初に見つかったものでよい)
+- **MUST**: 候補が見つかったら `/distill <ノートパス>` による軽量蒸留を**提案**する
+- **MUST**: 提案は soft gate として行う。ユーザーが skip したら、それ以上食い下がらずそのまま終了する
+  (skip してもそのノートは蒸留キューに残るだけで害はない——罪悪感でループを殺さない、という設計意図をここに残す)
+- **MUST**: 対応する候補が1件も見つからない場合は何も言わずに終了する(ノイズを増やさない)
+- **MUST NOT**: この手順は手順1〜8(dry-run・安全チェック・削除・報告)の判定や結果に一切影響してはならない
+  (収穫ステップの成否に関わらず、掃除自体は手順8の時点で完了している)
+
 ## Examples
 
 ```


### PR DESCRIPTION
## 概要

蒸留パイプライン設計(vault ProjectNotes、2026-07-27合意)の Hot lane。蒸留の実行トリガーを時刻ではなく**作業サイクルの完了**に置く設計に基づき、「マージ済み作業の後始末」である `/wtclean` の掃除完了報告の後に収穫ステップを追加する。

## 変更内容

`.config/claude/skills/wtclean/SKILL.md` に手順9「収穫ステップ(蒸留パイプライン Hot lane)」を追加。

- 削除した各 worktree の PR 番号(手順2で取得済み)で `ResearchNotes/ClaudeCodeSession-*.md` を Grep 検索し、`distilled_to` が空の対応ノートを探す
- 見つかったら1件だけ `/distill <ノートパス>` による軽量蒸留を**提案**する(soft gate — skip 自由。skip してもノートはキューに残るだけで害はない、という設計意図を SOP に明記)
- 対応ノートが見つからない場合は何も言わず終了する(ノイズを増やさない)

検索方式(PR番号での Grep)は既存の ResearchNote 実例(`ClaudeCodeSession-20260801-GpgPinentrySshPermanentFix.md` の「決定事項・成果物」節に `[PR #534](...)` の形で PR リンクを残す運用)を確認した上で選定した。

既存フロー(手順1〜8: dry-run・安全チェック・削除・報告)には一切変更を加えていない(純粋な追記)。

Closes #507

## Test plan

- [x] `git diff` で既存部分に変更がないこと(純粋な追記のみ)を確認済み
- [x] 追記した Constraints の MUST/MUST NOT の整合性を見直し、意味が逆転していた箇所を修正済み
- [ ] 実運用(次回 `/wtclean` 実行時)で収穫ステップが期待通り動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)