### PR TITLE
fix(hypr): hyprlock認証失敗ラベルの未定義変数 $FAIL_MSG を $FAIL に修正する

### DIFF
--- a/.config/hypr/hyprlock.conf
+++ b/.config/hypr/hyprlock.conf
@@ -61,7 +61,7 @@ label {
 # 失敗メッセージの設定
 label {
     monitor = # すべてのモニターに適用
-    text = $FAIL_MSG # 認証失敗時のメッセージ
+    text = $FAIL # 認証失敗時のメッセージ
     color = rgb(204, 34, 34) # エラーメッセージの色
     font_size = 16 # フォントサイズ
     font_family = Noto Sans CJK JP # フォント


### PR DESCRIPTION
## 概要
hyprlockのロック画面で、認証失敗メッセージ用ラベルが常時 `_MSG` というゴミ文字を表示していた問題を修正する。

Closes #545

## 原因
- `.config/hypr/hyprlock.conf` の失敗ラベルが `text = $FAIL_MSG` になっていたが、`$FAIL_MSG` はhyprlockに存在しない変数
- hyprlockの `IWidget.cpp` は `replaceInString(in, "$FAIL", FAIL)` による部分文字列置換のため、`$FAIL` 部分だけが失敗テキスト(未失敗時は空文字)に置換され、残りの `_MSG` がリテラルとして描画されていた
- 結果、ロック直後(パスワード入力前)からUptime表示の真下に赤字で `_MSG` が常時表示されていた

## 変更内容
- `text = $FAIL_MSG` → `text = $FAIL`(1行修正)

## 期待される動作
- 認証失敗するまでは何も表示されない(失敗テキストが空のため)
- パスワードを間違えた時のみ、PAM由来の失敗理由(例: Authentication failed)が赤字で表示される

## 確認方法
- `mise run nix:switch` で反映後、`loginctl lock-session` でロックし、入力前に `_MSG` が表示されないこと・パスワード失敗時に失敗理由が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)