### PR TITLE
feat(hypr): hyprtasking導入 — ワークスペースのライブサムネイル俯瞰(overview)を追加する

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -9,6 +9,9 @@ source = ~/.config/hypr/startup.conf
 source = ~/.config/hypr/keybinds.conf
 source = ~/.config/hypr/window-rules.conf
 source = ~/.config/hypr/themes/mocha.conf
+# プラグイン設定はテーマ変数($base 等)を参照できるよう themes より後に読み込む
+# Load after themes so plugin config can reference theme variables ($base etc.)
+source = ~/.config/hypr/plugins.conf
 
 
 ################

--- a/.config/hypr/keybinds.conf
+++ b/.config/hypr/keybinds.conf
@@ -94,6 +94,11 @@ bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
 
 ### ワークスペース操作 ###
+# hyprtasking overview のトグル (#549)。README 推奨の SUPER+Tab / SUPER+Space は
+# 直前WS戻り / wofi で使用済みのため grave(バッククォート)を採用
+# Toggle the hyprtasking overview (#549); Tab/Space suggested upstream are already taken
+bind = $mainMod, grave, hyprtasking:toggle, cursor
+
 # ワークスペースへの移動
 bind = $mainMod, 1, workspace, 1
 bind = $mainMod, 2, workspace, 2

--- a/.config/hypr/plugins.conf
+++ b/.config/hypr/plugins.conf
@@ -12,23 +12,23 @@
 # Usage: SUPER+grave toggles (keybinds.conf); right-click enters a workspace, left-drag moves windows.
 # 全オプション / all options: https://github.com/raybbian/hyprtasking#config-options
 plugin {
-    hyprtasking {
-        layout = grid
+  hyprtasking {
+    layout = grid
 
-        # 2列x3行の6面グリッド: 作業台 ws1-3 + 詰め所 ws4-6 の主戦場がちょうど収まる
-        # 2x3 grid fits the six daily workspaces (workbench ws1-3 + depot ws4-6)
-        grid {
-            rows = 3
-            cols = 2
-        }
-
-        bg_color = $crust
-        gap_size = 10
-        border_size = 6
-
-        jump {
-            # 俯瞰中にラベルキーで一発でワープできる
-            enabled = true
-        }
+    # 2列x3行の6面グリッド: 作業台 ws1-3 + 詰め所 ws4-6 の主戦場がちょうど収まる
+    # 2x3 grid fits the six daily workspaces (workbench ws1-3 + depot ws4-6)
+    grid {
+      rows = 3
+      cols = 2
     }
+
+    bg_color = $crust
+    gap_size = 10
+    border_size = 6
+
+    jump {
+      # 俯瞰中にラベルキーで一発でワープできる
+      enabled = true
+    }
+  }
 }

--- a/.config/hypr/plugins.conf
+++ b/.config/hypr/plugins.conf
@@ -1,0 +1,34 @@
+######################
+### PLUGINS (#549) ###
+######################
+# hyprtasking: ワークスペース俯瞰(overview)。hyprexpo が upstream で unmaintained
+# として削除されたため、後継としてこちらを採用。プラグイン本体は hyprpm 管理
+# (dotfiles 管理外)で、Hyprland 更新のたびに `hyprpm update` で要再ビルド(ABI 完全一致必須)。
+# hyprtasking: workspace overview. Adopted as the successor to hyprexpo, which was
+# dropped upstream as unmaintained. The plugin binary is managed by hyprpm (outside
+# dotfiles); rebuild with `hyprpm update` after every Hyprland upgrade (exact ABI match).
+#
+# 操作: SUPER+grave でトグル(keybinds.conf)、右クリックでそのWSに入る、左ドラッグで窓を別WSへ引っ越し
+# Usage: SUPER+grave toggles (keybinds.conf); right-click enters a workspace, left-drag moves windows.
+# 全オプション / all options: https://github.com/raybbian/hyprtasking#config-options
+plugin {
+    hyprtasking {
+        layout = grid
+
+        # 2列x3行の6面グリッド: 作業台 ws1-3 + 詰め所 ws4-6 の主戦場がちょうど収まる
+        # 2x3 grid fits the six daily workspaces (workbench ws1-3 + depot ws4-6)
+        grid {
+            rows = 3
+            cols = 2
+        }
+
+        bg_color = $crust
+        gap_size = 10
+        border_size = 6
+
+        jump {
+            # 俯瞰中にラベルキーで一発でワープできる
+            enabled = true
+        }
+    }
+}

--- a/.config/hypr/startup.conf
+++ b/.config/hypr/startup.conf
@@ -26,6 +26,8 @@ exec-once = mako
 # polkit
 exec-once = /usr/lib/polkit-kde-authentication-agent-1
 
-# hyprpm 管理プラグイン(hyprtasking #549)の自動ロード。-n はロード結果を通知で知らせる
-# autoload hyprpm-managed plugins (hyprtasking, #549); -n reports results via notification
+# hyprpm 管理プラグイン(hyprtasking #549)の自動ロード。
+# -n は成功時にも通知を出すフラグ(警告・エラーは -n の有無に関係なく常に通知される)
+# autoload hyprpm-managed plugins (hyprtasking, #549); -n adds a success notification
+# (warnings/errors always notify regardless of the flag)
 exec-once = hyprpm reload -n

--- a/.config/hypr/startup.conf
+++ b/.config/hypr/startup.conf
@@ -25,3 +25,7 @@ exec-once = mako
 
 # polkit
 exec-once = /usr/lib/polkit-kde-authentication-agent-1
+
+# hyprpm 管理プラグイン(hyprtasking #549)の自動ロード。-n はロード結果を通知で知らせる
+# autoload hyprpm-managed plugins (hyprtasking, #549); -n reports results via notification
+exec-once = hyprpm reload -n


### PR DESCRIPTION
## [optional body]
全ワークスペースをライブサムネイルのグリッドで一望できる overview を Hyprland に導入する。当初候補の hyprexpo は upstream(hyprwm/hyprland-plugins)で unmaintained として削除済みのため、後継の [hyprtasking](https://github.com/raybbian/hyprtasking) を採用(hyprpm.toml に v0.56.0 ピンあり、ローカルの Hyprland コミットと一致確認済み)。

プラグイン本体は hyprpm 管理(dotfiles 管理外)で、本PRは設定のみ:

- **plugins.conf(新規)**: `plugin:hyprtasking` 設定。テーマ変数を参照できるよう `themes/mocha.conf` より後に source する
  - 2列x3行の6面グリッド — 作業台 ws1-3 + 詰め所 ws4-6 の主戦場がちょうど収まる
  - `bg_color = $crust`(Catppuccin Mocha の最暗色でサムネイルを際立たせる)
  - `jump { enabled = true }` — 俯瞰中にラベルキー(1-9,0,a-z)で一発ワープ
  - `warp_on_move_window` は未設定(既定値)。効果があるのは `hyprtasking:movewindow` ディスパッチャ使用時のみで、本PRではバインドしていないため
- **keybinds.conf**: `SUPER+grave` で overview トグル。README 推奨の `SUPER+Tab` / `SUPER+Space` は直前WS戻り / wofi で使用済みのため不採用
- **startup.conf**: `exec-once = hyprpm reload -n` で再起動後もプラグインを自動ロード

運用note: pacman で Hyprland が更新されるたびに `hyprpm update` での再ビルドが必要(ABI 完全一致必須)。

## [optional footer(s)]
Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)