### PR TITLE
feat(mise): hypr:pm-update タスク — Hyprland更新後のhyprpm再ビルドをPATH罠対策込みで包む

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -250,3 +250,20 @@ gpg --quick-set-expire "$fpr" 2y '*'
 mise run gpg:export
 echo "Expiry extended. Re-register public.asc on GitHub, then run 'mise run gpg:import' on other machines."
 """
+
+# =============================================================================
+# Hyprland プラグイン管理 / Hyprland plugin management
+# =============================================================================
+
+[tasks."hypr:pm-update"]
+description = "Rebuild hyprpm-managed plugins after a Hyprland upgrade (forces the Arch toolchain over Nix)"
+run = """
+set -euo pipefail
+# Nix profile の cmake/pkg-config は純粋性パッチで /usr を探索できず、
+# システムの OpenGL/GLES3 が見つからずビルドに失敗する(#554)。
+# /usr/bin を先頭に置いて Arch のツールチェーンを強制する。
+# The Nix-profile cmake/pkg-config are patched not to search /usr, so system
+# OpenGL/GLES3 is never found (#554); prepend /usr/bin to force the Arch toolchain.
+# sudo プロンプトが出るため対話ターミナルで実行すること / run from an interactive terminal (needs a sudo prompt)
+PATH="/usr/bin:$PATH" hyprpm update
+"""


### PR DESCRIPTION
## [optional body]
Hyprland が pacman で更新されるたびに、hyprpm 管理プラグイン(hyprtasking、#549/#551)は `hyprpm update` での再ビルドが必要(ABI 完全一致必須)。ただし素の `hyprpm update` は Nix profile の cmake/pkg-config(純粋性パッチで `/usr` を探索しない)を拾い、システムの OpenGL/GLES3 が見つからずビルドに失敗する — #551 導入時に実測した罠。

`PATH="/usr/bin:$PATH" hyprpm update` を `mise run hypr:pm-update` として固定化する(`mise gpg:*` と同じ「運用手順のタスク化」パターン)。

- `mise tasks` での認識確認済み
- sudo プロンプトが出るため対話ターミナルでの実行前提(コメントに明記)

## [optional footer(s)]
Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)