### PR TITLE
fix(waybar): window-rewriteの ^/$ アンカーを全ルールから除去しマッチ可能にする

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -52,9 +52,9 @@
         "window-rewrite-default": "\u25aa", // U+25AA BLACK SMALL SQUARE (not a Nerd Font glyph)
         "format-window-separator": " ",
         // 辞書は window-rules.conf で運用中のアプリを網羅する(#548)。漏れると ▪ に落ちて中身が判別できない。
-        // wofi はレイヤーシェルでワークスペースに現れないため対象外
+        // wofi はレイヤーシェル(WSに現れない)、Emacs / neovide は不使用(エディタは端末内 neovim)のため対象外
         // Cover the apps managed in window-rules.conf (#548); anything missing falls back to an unreadable ▪.
-        // wofi is a layer-shell surface that never appears as a workspace window, hence excluded.
+        // Excluded: wofi (layer-shell, never a workspace window) and Emacs/neovide (unused; editing happens in terminal neovim).
         // マッチ方式: ルール全体を正規表現(icase)として "class<実class>" に regex_search する。
         // class< の内側に ^ / $ を書くと構造的に絶対マッチしない(#556 で全ルール沈黙から復旧)。
         // 山括弧 < > 自体が完全一致アンカーとして機能し、大文字小文字は icase で無視される。
@@ -72,8 +72,6 @@
             "class<discord>": "\uf1ff", // nf-fa-discord
             "class<obsidian>": "\ue6bb", // nf-custom-obsidian
             "class<claude-desktop>": "\udb85\udf19", // nf-md-robot_happy
-            "class<Emacs>": "\ue632", // nf-custom-emacs
-            "class<neovide>": "\ue6ae", // nf-custom-neovim
             "class<vivaldi-stable>": "\uf0ac", // nf-fa-globe (Nerd Fonts に Vivaldi グリフ無し / no Vivaldi brand glyph)
             "class<steam>": "\uf1b6", // nf-fa-steam
             "class<steam_app.*>": "\uf11b", // nf-fa-gamepad (Steam games)

--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -55,35 +55,41 @@
         // wofi はレイヤーシェルでワークスペースに現れないため対象外
         // Cover the apps managed in window-rules.conf (#548); anything missing falls back to an unreadable ▪.
         // wofi is a layer-shell surface that never appears as a workspace window, hence excluded.
+        // マッチ方式: ルール全体を正規表現(icase)として "class<実class>" に regex_search する。
+        // class< の内側に ^ / $ を書くと構造的に絶対マッチしない(#556 で全ルール沈黙から復旧)。
+        // 山括弧 < > 自体が完全一致アンカーとして機能し、大文字小文字は icase で無視される。
+        // Rules are regex_search'd (icase) against "class<actual>". Never put ^ / $ inside
+        // the angle brackets — they can never match there (#556); the < > delimiters
+        // already act as exact-match anchors, and casing is ignored via icase.
         "window-rewrite": {
-            "class<^firefox$>": "\uf269", // nf-fa-firefox
-            "class<^code$>": "\udb82\ude1e", // nf-md-microsoft_visual_studio_code
-            "class<^kitty$>": "\uf120", // nf-fa-terminal
-            "class<^Alacritty$>": "\uf120", // nf-fa-terminal
-            "class<^org\\.wezfurlong\\.wezterm$>": "\uf120", // nf-fa-terminal
-            "class<^[Ss]potify$>": "\uf1bc", // nf-fa-spotify (window-rules に spotify/Spotify 両表記あり / both casings appear)
-            "class<^slack$>": "\uf198", // nf-fa-slack
-            "class<^discord$>": "\uf1ff", // nf-fa-discord
-            "class<^obsidian$>": "\ue6bb", // nf-custom-obsidian
-            "class<^claude-desktop$>": "\udb85\udf19", // nf-md-robot_happy
-            "class<^Emacs$>": "\ue632", // nf-custom-emacs
-            "class<^neovide$>": "\ue6ae", // nf-custom-neovim
-            "class<^[Vv]ivaldi-stable$>": "\uf0ac", // nf-fa-globe (Nerd Fonts に Vivaldi グリフ無し。実機 class は小文字 / no brand glyph; live class is lowercase)
-            "class<^steam$>": "\uf1b6", // nf-fa-steam
-            "class<^steam_app.*>": "\uf11b", // nf-fa-gamepad (Steam games)
-            "class<^lutris$>": "\uf11b", // nf-fa-gamepad
-            "class<^mpv$>": "\uf008", // nf-fa-film
-            "class<^vlc$>": "\udb81\udd7c", // nf-md-vlc
-            "class<^imv$>": "\uf03e", // nf-fa-image
-            "class<^pavucontrol$>": "\uf1de", // nf-fa-sliders
-            "class<^blueman-manager$>": "\uf293", // nf-fa-bluetooth
-            "class<^nm-connection-editor$>": "\uf1eb", // nf-fa-wifi
-            "class<^file-roller$>": "\uf187", // nf-fa-archive
-            "class<^eog$>": "\uf03e", // nf-fa-image
-            "class<^nwg-look$>": "\uf1fc", // nf-fa-paint_brush
-            "class<^qt5ct$>": "\uf1fc", // nf-fa-paint_brush
-            "class<^org\\.kde\\.polkit-kde-authentication-agent-1$>": "\uf132", // nf-fa-shield
-            "class<^org\\.kde\\.dolphin$>": "\uf07b" // nf-fa-folder
+            "class<firefox>": "\uf269", // nf-fa-firefox
+            "class<code>": "\udb82\ude1e", // nf-md-microsoft_visual_studio_code
+            "class<kitty>": "\uf120", // nf-fa-terminal
+            "class<Alacritty>": "\uf120", // nf-fa-terminal
+            "class<org\\.wezfurlong\\.wezterm>": "\uf120", // nf-fa-terminal
+            "class<spotify>": "\uf1bc", // nf-fa-spotify
+            "class<slack>": "\uf198", // nf-fa-slack
+            "class<discord>": "\uf1ff", // nf-fa-discord
+            "class<obsidian>": "\ue6bb", // nf-custom-obsidian
+            "class<claude-desktop>": "\udb85\udf19", // nf-md-robot_happy
+            "class<Emacs>": "\ue632", // nf-custom-emacs
+            "class<neovide>": "\ue6ae", // nf-custom-neovim
+            "class<vivaldi-stable>": "\uf0ac", // nf-fa-globe (Nerd Fonts に Vivaldi グリフ無し / no Vivaldi brand glyph)
+            "class<steam>": "\uf1b6", // nf-fa-steam
+            "class<steam_app.*>": "\uf11b", // nf-fa-gamepad (Steam games)
+            "class<lutris>": "\uf11b", // nf-fa-gamepad
+            "class<mpv>": "\uf008", // nf-fa-film
+            "class<vlc>": "\udb81\udd7c", // nf-md-vlc
+            "class<imv>": "\uf03e", // nf-fa-image
+            "class<pavucontrol>": "\uf1de", // nf-fa-sliders
+            "class<blueman-manager>": "\uf293", // nf-fa-bluetooth
+            "class<nm-connection-editor>": "\uf1eb", // nf-fa-wifi
+            "class<file-roller>": "\uf187", // nf-fa-archive
+            "class<eog>": "\uf03e", // nf-fa-image
+            "class<nwg-look>": "\uf1fc", // nf-fa-paint_brush
+            "class<qt5ct>": "\uf1fc", // nf-fa-paint_brush
+            "class<org\\.kde\\.polkit-kde-authentication-agent-1>": "\uf132", // nf-fa-shield
+            "class<org\\.kde\\.dolphin>": "\uf07b" // nf-fa-folder
         },
         "persistent-workspaces": {
             "*": [1, 2, 3]


### PR DESCRIPTION
## [optional body]
#550 で拡充した window-rewrite のアイコンが1つも表示されない報告を調査したところ、**全20ルールが構造的にマッチ不能**だったことが判明(#556)。

waybar は `src/util/regex_collection.cpp` でルール文字列全体を `std::regex`(icase)としてコンパイルし、`class<実際のclass>` という文字列に `regex_search` する。`class<` リテラルの後に `^`(入力先頭アンカー)が来るパターンは絶対にマッチしない — つまり `class<^firefox$>` 形式だった従来の6エントリも、#550 で追加した14エントリも、一度も動いたことがなかった(全ウィンドウが `▪` フォールバック)。

対処(waybar 0.15.0 と同一セマンティクスの C++ テストで実証済み):
- 全キーから `^` / `$` を除去 — `< >` デリミタ自体が完全一致アンカーとして機能するため誤爆しない(`class<firefox>` は `class<firefox-dev>` にマッチしない)
- icase コンパイルのため不要だった `[Ss]potify` / `[Vv]ivaldi-stable` を素の小文字に簡素化
- マッチ方式のセマンティクス(アンカー禁止・デリミタ=実質アンカー・icase)をコメントに明文化して再発防止

## [optional footer(s)]
Closes #556
関連: #548 / #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)