### PR TITLE
feat(waybar): バー高さとフォントサイズを拡大して視認性を上げる

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -1,7 +1,7 @@
 {
     "layer": "top",
     "position": "top",
-    "height": 30,
+    "height": 38,
     "spacing": 4,
     "margin-top": 6,
     "margin-bottom": 0,
@@ -265,7 +265,9 @@
     },
 
     "tray": {
-        "icon-size": 21,
+        // trayだけはフォント非連動なのでfont-size拡大(#558)に合わせて個別に上げる
+        // Tray icons don't scale with font-size, so bump separately alongside #558.
+        "icon-size": 24,
         "spacing": 10
     }
 }

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -2,7 +2,9 @@
     border: none;
     border-radius: 0;
     font-family: "JetBrainsMono Nerd Font", "Noto Sans CJK JP";
-    font-size: 13px;
+    /* AW3821DW(37.5in/111ppi・scale 1.0)では13pxは物理約3mmで判読困難だった(#558) */
+    /* 13px was ~3mm physical on the AW3821DW (37.5in/111ppi, scale 1.0) — too small to read (#558) */
+    font-size: 16px;
     min-height: 0;
     transition-property: background-color;
     transition-duration: 0.5s;


### PR DESCRIPTION
## [optional body]
AW3821DW(37.5in / 3840x1600 / 約111ppi・scale 1.0)では font-size 13px は物理約3mmとなり、特に左端のworkspacesアイコンが判読困難だった。まず手軽なサイズ調整で視認性を上げる。

- `style.css`: `font-size` 13px → 16px(workspacesアイコンはNerd Fontグリフのため全て連動して拡大)
- `config.jsonc`: `height` 30 → 38
- `config.jsonc`: `tray` の `icon-size` 21 → 24(trayのみビットマップでフォント非連動のため個別指定)

実機確認済み(nix:switch → SIGUSR2リロード)。体感「やや大きめ」の声もあるため、運用しつつ 15px 等への微調整の余地は残す。左端が視野中心から遠い問題の根本対策(中央寄せ/島化)は #559 で扱う。

## [optional footer(s)]
Closes #558
Refs: #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)