### PR TITLE
feat(waybar): 三島構成でworkspaces計器盤を視野中心に固定し左端の視認性を根本改善する

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -1,273 +1,289 @@
 {
-    "layer": "top",
-    "position": "top",
-    "height": 38,
-    "spacing": 4,
-    "margin-top": 6,
-    "margin-bottom": 0,
-    "modules-left": [
-        "hyprland/workspaces",
-        "hyprland/submap",
-        "hyprland/window",
-        "custom/bring"
-    ],
-    "modules-center": [
-        "clock",
-        "custom/weather"
-    ],
-    "modules-right": [
-        "custom/media",
-        "hyprland/language",
-        "pulseaudio",
-        "pulseaudio#microphone",
-        "network",
-        "cpu",
-        "memory",
-        "temperature",
-        "backlight",
-        "battery",
-        "custom/power",
-        "tray"
-    ],
+  "layer": "top",
+  "position": "top",
+  "height": 38,
+  "spacing": 4,
+  "margin-top": 6,
+  "margin-bottom": 0,
+  // 三島構成(#559): 中央島(workspaces計器盤)が常に視野中心にいるので、左右の島は
+  // 端まで戻してよい。6pxはmargin-topと揃えた「浮き」の名残り。島スタイルはstyle.css側。
+  // Three-island layout (#559): with the center island (workspaces gauge) pinned at the
+  // visual center, the side islands can sit at the screen edges again. 6px matches
+  // margin-top for the floating look; island styling lives in style.css.
+  "margin-left": 6,
+  "margin-right": 6,
+  // 中央集約(#559 案A): 「読む」情報(workspaces計器盤)は視野中心、「見る」情報(時計・日付)は左端へ
+  // Centralized layout (#559 plan A): information you READ (workspaces gauge) sits at the
+  // visual center; information you GLANCE at (clock, date) goes to the far-left zone.
+  "modules-left": ["clock", "clock#date", "custom/weather"],
+  "modules-center": [
+    "hyprland/workspaces",
+    "hyprland/submap",
+    "hyprland/window",
+    "custom/bring",
+  ],
+  "modules-right": [
+    "custom/media",
+    "hyprland/language",
+    "pulseaudio",
+    "pulseaudio#microphone",
+    "cpu",
+    "memory",
+    "network",
+    "temperature",
+    "backlight",
+    "battery",
+    "custom/power",
+    "tray",
+  ],
 
-    // 3層構造(window-rules.conf 冒頭コメント参照)をバー上でも宣言する
-    // Mirror the three-layer workspace design (see window-rules.conf header) in the bar:
-    //   作業台 ws1〜3 = 数字アイコン(persistent-workspacesで常時表示) / Workbench: numeral icons, always shown
-    //   詰め所 ws4〜  = 共通アイコン(default) / Depot: shared "default" icon
-    //   引き出し special = show-special + special-visible-only で開いている時だけ表示 / Drawer: shown only while open
-    "hyprland/workspaces": {
-        "format": "{icon}{windows}",
-        "on-click": "activate",
-        // Icons below are written as literal \uXXXX JSON escapes, not raw PUA glyphs pasted
-        // directly -- raw glyphs silently collapsed to empty strings in this file before
-        // (caught in PR #366 review). Look up glyph names at nerdfonts.com/cheat-sheet.
-        "format-icons": {
-            "1": "1",
-            "2": "2",
-            "3": "3",
-            "urgent": "\uf071", // nf-fa-exclamation_triangle
-            "special": "\uf052", // nf-fa-eject (drawer: shown only while open)
-            "default": "\uf01c" // nf-fa-inbox (depot)
-        },
-        "window-rewrite-default": "\u25aa", // U+25AA BLACK SMALL SQUARE (not a Nerd Font glyph)
-        "format-window-separator": " ",
-        // 辞書は window-rules.conf で運用中のアプリを網羅する(#548)。漏れると ▪ に落ちて中身が判別できない。
-        // wofi はレイヤーシェル(WSに現れない)、Emacs / neovide は不使用(エディタは端末内 neovim)のため対象外
-        // Cover the apps managed in window-rules.conf (#548); anything missing falls back to an unreadable ▪.
-        // Excluded: wofi (layer-shell, never a workspace window) and Emacs/neovide (unused; editing happens in terminal neovim).
-        // マッチ方式: ルール全体を正規表現(icase)として "class<実class>" に regex_search する。
-        // class< の内側に ^ / $ を書くと構造的に絶対マッチしない(#556 で全ルール沈黙から復旧)。
-        // 山括弧 < > 自体が完全一致アンカーとして機能し、大文字小文字は icase で無視される。
-        // Rules are regex_search'd (icase) against "class<actual>". Never put ^ / $ inside
-        // the angle brackets — they can never match there (#556); the < > delimiters
-        // already act as exact-match anchors, and casing is ignored via icase.
-        "window-rewrite": {
-            "class<firefox>": "\uf269", // nf-fa-firefox
-            "class<code>": "\udb82\ude1e", // nf-md-microsoft_visual_studio_code
-            "class<kitty>": "\uf120", // nf-fa-terminal
-            "class<Alacritty>": "\uf120", // nf-fa-terminal
-            "class<org\\.wezfurlong\\.wezterm>": "\uf120", // nf-fa-terminal
-            "class<spotify>": "\uf1bc", // nf-fa-spotify
-            "class<slack>": "\uf198", // nf-fa-slack
-            "class<discord>": "\uf1ff", // nf-fa-discord
-            "class<obsidian>": "\ue6bb", // nf-custom-obsidian
-            "class<claude-desktop>": "\udb85\udf19", // nf-md-robot_happy
-            "class<vivaldi-stable>": "\uf0ac", // nf-fa-globe (Nerd Fonts に Vivaldi グリフ無し / no Vivaldi brand glyph)
-            "class<steam>": "\uf1b6", // nf-fa-steam
-            "class<steam_app.*>": "\uf11b", // nf-fa-gamepad (Steam games)
-            "class<lutris>": "\uf11b", // nf-fa-gamepad
-            "class<mpv>": "\uf008", // nf-fa-film
-            "class<vlc>": "\udb81\udd7c", // nf-md-vlc
-            "class<imv>": "\uf03e", // nf-fa-image
-            "class<pavucontrol>": "\uf1de", // nf-fa-sliders
-            "class<blueman-manager>": "\uf293", // nf-fa-bluetooth
-            "class<nm-connection-editor>": "\uf1eb", // nf-fa-wifi
-            "class<file-roller>": "\uf187", // nf-fa-archive
-            "class<eog>": "\uf03e", // nf-fa-image
-            "class<nwg-look>": "\uf1fc", // nf-fa-paint_brush
-            "class<qt5ct>": "\uf1fc", // nf-fa-paint_brush
-            "class<org\\.kde\\.polkit-kde-authentication-agent-1>": "\uf132", // nf-fa-shield
-            "class<org\\.kde\\.dolphin>": "\uf07b" // nf-fa-folder
-        },
-        "persistent-workspaces": {
-            "*": [1, 2, 3]
-        },
-        "show-special": true,
-        "special-visible-only": true,
-        "sort-by": "number",
-        "on-scroll-up": "hyprctl dispatch workspace e+1",
-        "on-scroll-down": "hyprctl dispatch workspace e-1"
+  // 3層構造(window-rules.conf 冒頭コメント参照)をバー上でも宣言する
+  // Mirror the three-layer workspace design (see window-rules.conf header) in the bar:
+  //   作業台 ws1〜3 = 数字アイコン(persistent-workspacesで常時表示) / Workbench: numeral icons, always shown
+  //   詰め所 ws4〜  = 共通アイコン(default) / Depot: shared "default" icon
+  //   引き出し special = show-special + special-visible-only で開いている時だけ表示 / Drawer: shown only while open
+  "hyprland/workspaces": {
+    "format": "{icon}{windows}",
+    "on-click": "activate",
+    // Icons below are written as literal \uXXXX JSON escapes, not raw PUA glyphs pasted
+    // directly -- raw glyphs silently collapsed to empty strings in this file before
+    // (caught in PR #366 review). Look up glyph names at nerdfonts.com/cheat-sheet.
+    "format-icons": {
+      "1": "1",
+      "2": "2",
+      "3": "3",
+      "urgent": "\uf071", // nf-fa-exclamation_triangle
+      "special": "\uf052", // nf-fa-eject (drawer: shown only while open)
+      "default": "\uf01c", // nf-fa-inbox (depot)
     },
-
-    "hyprland/window": {
-        "format": " {}",
-        "max-length": 50,
-        "separate-outputs": true
+    "window-rewrite-default": "\u25aa", // U+25AA BLACK SMALL SQUARE (not a Nerd Font glyph)
+    "format-window-separator": " ",
+    // 辞書は window-rules.conf で運用中のアプリを網羅する(#548)。漏れると ▪ に落ちて中身が判別できない。
+    // wofi はレイヤーシェル(WSに現れない)、Emacs / neovide は不使用(エディタは端末内 neovim)のため対象外
+    // Cover the apps managed in window-rules.conf (#548); anything missing falls back to an unreadable ▪.
+    // Excluded: wofi (layer-shell, never a workspace window) and Emacs/neovide (unused; editing happens in terminal neovim).
+    // マッチ方式: ルール全体を正規表現(icase)として "class<実class>" に regex_search する。
+    // class< の内側に ^ / $ を書くと構造的に絶対マッチしない(#556 で全ルール沈黙から復旧)。
+    // 山括弧 < > 自体が完全一致アンカーとして機能し、大文字小文字は icase で無視される。
+    // Rules are regex_search'd (icase) against "class<actual>". Never put ^ / $ inside
+    // the angle brackets — they can never match there (#556); the < > delimiters
+    // already act as exact-match anchors, and casing is ignored via icase.
+    "window-rewrite": {
+      "class<firefox>": "\uf269", // nf-fa-firefox
+      "class<code>": "\udb82\ude1e", // nf-md-microsoft_visual_studio_code
+      "class<kitty>": "\uf120", // nf-fa-terminal
+      "class<Alacritty>": "\uf120", // nf-fa-terminal
+      "class<org\\.wezfurlong\\.wezterm>": "\uf120", // nf-fa-terminal
+      "class<spotify>": "\uf1bc", // nf-fa-spotify
+      "class<slack>": "\uf198", // nf-fa-slack
+      "class<discord>": "\uf1ff", // nf-fa-discord
+      "class<obsidian>": "\ue6bb", // nf-custom-obsidian
+      "class<claude-desktop>": "\udb85\udf19", // nf-md-robot_happy
+      "class<vivaldi-stable>": "\uf0ac", // nf-fa-globe (Nerd Fonts に Vivaldi グリフ無し / no Vivaldi brand glyph)
+      "class<steam>": "\uf1b6", // nf-fa-steam
+      "class<steam_app.*>": "\uf11b", // nf-fa-gamepad (Steam games)
+      "class<lutris>": "\uf11b", // nf-fa-gamepad
+      "class<mpv>": "\uf008", // nf-fa-film
+      "class<vlc>": "\udb81\udd7c", // nf-md-vlc
+      "class<imv>": "\uf03e", // nf-fa-image
+      "class<pavucontrol>": "\uf1de", // nf-fa-sliders
+      "class<blueman-manager>": "\uf293", // nf-fa-bluetooth
+      "class<nm-connection-editor>": "\uf1eb", // nf-fa-wifi
+      "class<file-roller>": "\uf187", // nf-fa-archive
+      "class<eog>": "\uf03e", // nf-fa-image
+      "class<nwg-look>": "\uf1fc", // nf-fa-paint_brush
+      "class<qt5ct>": "\uf1fc", // nf-fa-paint_brush
+      "class<org\\.kde\\.polkit-kde-authentication-agent-1>": "\uf132", // nf-fa-shield
+      "class<org\\.kde\\.dolphin>": "\uf07b", // nf-fa-folder
     },
-
-    // Bring 型の計器盤(#422): bring_window.sh(Super+Y)で借りている参照ウィンドウを表示。
-    // 常駐スクリプトが Hyprland socket2 を購読して随時1行出力する(interval なし)。
-    // 操作はここに持たせない — 表示のみ(操作系は Super+Y / Super+Shift+Y のまま)。
-    // Bring-style gauge (#422): shows the reference window borrowed via Super+Y.
-    // The long-running script subscribes to Hyprland socket2 and streams JSON lines
-    // (no interval). Display only; control stays on the Super+Y keybinds.
-    "custom/bring": {
-        "format": "{}",
-        "return-type": "json",
-        "max-length": 45,
-        "exec": "~/.config/waybar/scripts/bring_status.sh",
-        "escape": true
+    "persistent-workspaces": {
+      "*": [1, 2, 3],
     },
+    "show-special": true,
+    "special-visible-only": true,
+    "sort-by": "number",
+    "on-scroll-up": "hyprctl dispatch workspace e+1",
+    "on-scroll-down": "hyprctl dispatch workspace e-1",
+  },
 
-    "hyprland/language": {
-        "format": " {}",
-        "format-en": "US",
-        "format-ja": "JP",
-        "keyboard-name": "at-translated-set-2-keyboard"
+  "hyprland/window": {
+    "format": " {}",
+    "max-length": 50,
+    "separate-outputs": true,
+  },
+
+  // Bring 型の計器盤(#422): bring_window.sh(Super+Y)で借りている参照ウィンドウを表示。
+  // 常駐スクリプトが Hyprland socket2 を購読して随時1行出力する(interval なし)。
+  // 操作はここに持たせない — 表示のみ(操作系は Super+Y / Super+Shift+Y のまま)。
+  // Bring-style gauge (#422): shows the reference window borrowed via Super+Y.
+  // The long-running script subscribes to Hyprland socket2 and streams JSON lines
+  // (no interval). Display only; control stays on the Super+Y keybinds.
+  "custom/bring": {
+    "format": "{}",
+    "return-type": "json",
+    "max-length": 45,
+    "exec": "~/.config/waybar/scripts/bring_status.sh",
+    "escape": true,
+  },
+
+  "hyprland/language": {
+    "format": " {}",
+    "format-en": "US",
+    "format-ja": "JP",
+    "keyboard-name": "at-translated-set-2-keyboard",
+  },
+
+  "hyprland/submap": {
+    "format": "✌️ {}",
+    "max-length": 8,
+    "tooltip": false,
+  },
+
+  "clock": {
+    "format": " {:%H:%M}",
+    "format-alt": " {:%Y-%m-%d}",
+    "tooltip-format": "<tt><small>{calendar}</small></tt>",
+    "calendar": {
+      "mode": "year",
+      "mode-mon-col": 3,
+      "weeks-pos": "right",
+      "on-scroll": 1,
+      "on-click-right": "mode",
+      "format": {
+        "months": "<span color='#ffead3'><b>{}</b></span>",
+        "days": "<span color='#ecc6d9'><b>{}</b></span>",
+        "weeks": "<span color='#99ffdd'><b>W{}</b></span>",
+        "weekdays": "<span color='#ffcc66'><b>{}</b></span>",
+        "today": "<span color='#ff6699'><b><u>{}</u></b></span>",
+      },
     },
-
-    "hyprland/submap": {
-        "format": "✌️ {}",
-        "max-length": 8,
-        "tooltip": false
+    "actions": {
+      "on-click-right": "mode",
+      "on-click-forward": "tz_up",
+      "on-click-backward": "tz_down",
+      "on-scroll-up": "shift_up",
+      "on-scroll-down": "shift_down",
     },
+  },
 
-    "clock": {
-        "format": " {:%H:%M}",
-        "format-alt": " {:%Y-%m-%d}",
-        "tooltip-format": "<tt><small>{calendar}</small></tt>",
-        "calendar": {
-            "mode"          : "year",
-            "mode-mon-col"  : 3,
-            "weeks-pos"     : "right",
-            "on-scroll"     : 1,
-            "on-click-right": "mode",
-            "format": {
-                "months":     "<span color='#ffead3'><b>{}</b></span>",
-                "days":       "<span color='#ecc6d9'><b>{}</b></span>",
-                "weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
-                "weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
-                "today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
-            }
-        },
-        "actions": {
-            "on-click-right": "mode",
-            "on-click-forward": "tz_up",
-            "on-click-backward": "tz_down",
-            "on-scroll-up": "shift_up",
-            "on-scroll-down": "shift_down"
-        }
+  // 日付の常時表示(#559派生): ホバーカレンダー・クリック切替は本体clockに任せ、こちらは見るだけの計器
+  // Always-visible date (offshoot of #559): hover calendar / click toggle stay on the main
+  // clock; this instance is a glance-only gauge. CSSは #clock.date として本体のスタイルを継承する
+  "clock#date": {
+    "format": " {:%m/%d (%a)}", // nf-fa-calendar
+    "locale": "ja_JP.UTF-8", // 曜日を「(日)」表記にする / Japanese weekday names
+    "tooltip": false,
+  },
+
+  "custom/weather": {
+    "format": "{}",
+    "format-alt": "{alt}: {}",
+    "format-alt-click": "click-right",
+    "interval": 1800,
+    "return-type": "json",
+    "exec": "~/.config/waybar/scripts/weather.sh",
+    "exec-if": "ping wttr.in -c1",
+  },
+
+  "custom/media": {
+    "format": "{icon} {}",
+    "return-type": "json",
+    "max-length": 40,
+    "format-icons": {
+      "spotify": "",
+      "default": "🎜",
     },
+    "escape": true,
+    "exec": "~/.config/waybar/scripts/mediaplayer.py 2> /dev/null",
+    "on-click": "playerctl play-pause",
+  },
 
-    "custom/weather": {
-        "format": "{}",
-        "format-alt": "{alt}: {}",
-        "format-alt-click": "click-right",
-        "interval": 1800,
-        "return-type": "json",
-        "exec": "~/.config/waybar/scripts/weather.sh",
-        "exec-if": "ping wttr.in -c1"
+  "cpu": {
+    "format": " {usage}%",
+    "tooltip": true,
+    "interval": 1,
+  },
+
+  "memory": {
+    "format": " {}%",
+    "interval": 1,
+  },
+
+  "temperature": {
+    "critical-threshold": 80,
+    "format": "{icon} {temperatureC}°C",
+    "format-icons": ["", "", ""],
+  },
+
+  "backlight": {
+    "format": "{icon} {percent}%",
+    "format-icons": ["", "", "", "", "", "", "", "", ""],
+    "on-scroll-up": "brightnessctl set +5%",
+    "on-scroll-down": "brightnessctl set 5%-",
+  },
+
+  "battery": {
+    "states": {
+      "good": 95,
+      "warning": 30,
+      "critical": 15,
     },
+    "format": "{icon} {capacity}%",
+    "format-charging": " {capacity}%",
+    "format-plugged": " {capacity}%",
+    "format-alt": "{icon} {time}",
+    "format-icons": ["", "", "", "", ""],
+  },
 
-    "custom/media": {
-        "format": "{icon} {}",
-        "return-type": "json",
-        "max-length": 40,
-        "format-icons": {
-            "spotify": "",
-            "default": "🎜"
-        },
-        "escape": true,
-        "exec": "~/.config/waybar/scripts/mediaplayer.py 2> /dev/null",
-        "on-click": "playerctl play-pause"
+  "network": {
+    "format-wifi": " {essid} ({signalStrength}%)",
+    "format-ethernet": " {ipaddr}/{cidr}",
+    "tooltip-format": " {ifname} via {gwaddr}",
+    "format-linked": " {ifname} (No IP)",
+    "format-disconnected": "⚠ Disconnected",
+    "format-alt": "{ifname}: {ipaddr}/{cidr}",
+    "on-click-right": "nm-connection-editor",
+  },
+
+  "pulseaudio": {
+    "format": "{icon} {volume}%",
+    "format-bluetooth": "{icon} {volume}% {format_source}",
+    "format-bluetooth-muted": " {icon} {format_source}",
+    "format-muted": " {format_source}",
+    "format-source": " {volume}%",
+    "format-source-muted": "",
+    "format-icons": {
+      "headphone": "",
+      "hands-free": "",
+      "headset": "",
+      "phone": "",
+      "portable": "",
+      "car": "",
+      "default": ["", "", ""],
     },
+    "on-click": "pavucontrol",
+  },
 
-    "cpu": {
-        "format": " {usage}%",
-        "tooltip": true,
-        "interval": 1
-    },
+  "pulseaudio#microphone": {
+    "format": "{format_source}",
+    "format-source": " {volume}%",
+    "format-source-muted": "",
+    "on-click": "pavucontrol",
+    "on-scroll-up": "pamixer --default-source -i 5",
+    "on-scroll-down": "pamixer --default-source -d 5",
+    "scroll-step": 5,
+  },
 
-    "memory": {
-        "format": " {}%",
-        "interval": 1
-    },
+  "custom/power": {
+    "format": "⏻",
+    "on-click": "wlogout",
+    "tooltip": false,
+  },
 
-    "temperature": {
-        "critical-threshold": 80,
-        "format": "{icon} {temperatureC}°C",
-        "format-icons": ["", "", ""]
-    },
-
-    "backlight": {
-        "format": "{icon} {percent}%",
-        "format-icons": ["", "", "", "", "", "", "", "", ""],
-        "on-scroll-up": "brightnessctl set +5%",
-        "on-scroll-down": "brightnessctl set 5%-"
-    },
-
-    "battery": {
-        "states": {
-            "good": 95,
-            "warning": 30,
-            "critical": 15
-        },
-        "format": "{icon} {capacity}%",
-        "format-charging": " {capacity}%",
-        "format-plugged": " {capacity}%",
-        "format-alt": "{icon} {time}",
-        "format-icons": ["", "", "", "", ""]
-    },
-
-    "network": {
-        "format-wifi": " {essid} ({signalStrength}%)",
-        "format-ethernet": " {ipaddr}/{cidr}",
-        "tooltip-format": " {ifname} via {gwaddr}",
-        "format-linked": " {ifname} (No IP)",
-        "format-disconnected": "⚠ Disconnected",
-        "format-alt": "{ifname}: {ipaddr}/{cidr}",
-        "on-click-right": "nm-connection-editor"
-    },
-
-    "pulseaudio": {
-        "format": "{icon} {volume}%",
-        "format-bluetooth": "{icon} {volume}% {format_source}",
-        "format-bluetooth-muted": " {icon} {format_source}",
-        "format-muted": " {format_source}",
-        "format-source": " {volume}%",
-        "format-source-muted": "",
-        "format-icons": {
-            "headphone": "",
-            "hands-free": "",
-            "headset": "",
-            "phone": "",
-            "portable": "",
-            "car": "",
-            "default": ["", "", ""]
-        },
-        "on-click": "pavucontrol"
-    },
-
-    "pulseaudio#microphone": {
-        "format": "{format_source}",
-        "format-source": " {volume}%",
-        "format-source-muted": "",
-        "on-click": "pavucontrol",
-        "on-scroll-up": "pamixer --default-source -i 5",
-        "on-scroll-down": "pamixer --default-source -d 5",
-        "scroll-step": 5
-    },
-
-    "custom/power": {
-        "format": "⏻",
-        "on-click": "wlogout",
-        "tooltip": false
-    },
-
-    "tray": {
-        // trayだけはフォント非連動なのでfont-size拡大(#558)に合わせて個別に上げる
-        // Tray icons don't scale with font-size, so bump separately alongside #558.
-        "icon-size": 24,
-        "spacing": 10
-    }
+  "tray": {
+    // trayだけはフォント非連動なのでfont-size拡大(#558)に合わせて個別に上げる
+    // Tray icons don't scale with font-size, so bump separately alongside #558.
+    "icon-size": 24,
+    "spacing": 10,
+  },
 }

--- a/.config/waybar/scripts/weather.sh
+++ b/.config/waybar/scripts/weather.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Waybar 計器モジュール custom/weather (#563)
+# 左島(現実世界の窓)に現在の天気を表示する。wttr.in から観測値を1リクエストで取得し、
+# return-type: json 形式で1行出力して終了する(常駐しない — interval 1800 で再実行)。
+# Waybar gauge module custom/weather (#563): shows current conditions on the left
+# island (the window to the real world). Fetches one reading from wttr.in in a
+# single request, emits one return-type: json line, and exits (not resident —
+# waybar reruns it via interval 1800).
+
+set -euo pipefail
+
+# 場所未指定 = wttr.in の IP ジオロケーション任せ。固定したい時は
+# WAYBAR_WEATHER_LOCATION(例: Tokyo)で上書きする。
+# Empty location = wttr.in's IP geolocation; override with
+# WAYBAR_WEATHER_LOCATION (e.g. "Tokyo") to pin a place.
+location="${WAYBAR_WEATHER_LOCATION:-}"
+
+# 全項目を1リクエストで取り | で分解する: 天気アイコン|気温|天況|体感|湿度|風|場所
+# One request for every field, split on "|": icon|temp|condition|feels|humidity|wind|place
+if ! reading="$(curl -sf --max-time 10 "https://wttr.in/${location}?format=%c|%t|%C|%f|%h|%w|%l")"; then
+  # 取得失敗は「表示するものがない」扱い(text が空だとモジュール非表示)。
+  # exec-if の ping を通過した後の一時的な失敗もここで握る。
+  # A failed fetch means "nothing to display" (empty text hides the module),
+  # covering transient errors that slip past the exec-if ping.
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
+
+IFS='|' read -r icon temp cond feels humidity wind place <<<"$reading"
+
+# wttr.in の絵文字アイコンは余白(パディング用スペース)を含むので除去する
+# The emoji icon from wttr.in carries padding spaces — strip them.
+icon="${icon// /}"
+
+# alt は config 側の format-alt "{alt}: {}"(右クリック)で場所名として使われる
+# alt feeds the config's format-alt "{alt}: {}" (right-click) as the place name.
+jq -cn \
+  --arg text "${icon} ${temp}" \
+  --arg alt "${place}" \
+  --arg tooltip "${place}: ${cond} ${temp} (体感 ${feels}) 湿度 ${humidity} 風 ${wind}" \
+  '{text: $text, alt: $alt, tooltip: $tooltip}'

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -10,12 +10,22 @@
     transition-duration: 0.5s;
 }
 
+/* 三島構成(#559): バー本体は透明な土台にして、left/center/rightの各ゾーンを
+   独立した島にする。島の間は壁紙がそのまま見える */
+/* Three-island layout (#559): the bar window is a transparent stage; each of the
+   left/center/right zones becomes its own island, with wallpaper visible between them. */
 window#waybar {
-    background-color: rgba(21, 18, 27, 0.95);
-    border-bottom: 2px solid rgba(100, 114, 125, 0.5);
+    background: transparent;
     color: #cdd6f4;
-    transition-property: background-color;
-    transition-duration: .5s;
+}
+
+.modules-left,
+.modules-center,
+.modules-right {
+    background-color: rgba(21, 18, 27, 0.95);
+    border: 2px solid rgba(100, 114, 125, 0.5);
+    border-radius: 12px;
+    padding: 0 8px;
 }
 
 window#waybar.hidden {


### PR DESCRIPTION
## [optional body]
#559 の当初案は「案A: workspaces中央寄せ」「案B: バー島化」の二択だったが、実機で両方試した結果、その合成のさらに先の**三島構成**に着地した。

- バー本体(`window#waybar`)は透明な土台にし、`.modules-left` / `.modules-center` / `.modules-right` の3ゾーンをそれぞれ独立した島(背景+全周ボーダー+角丸12px)にする。島の間は壁紙が見える
- **中央島**: workspaces(3層構造の計器盤) + submap + window + bring。「読む」情報を視野中心に固定
- **左島**: clock + `clock#date`(新設) + weather。「見る」だけの現実世界の情報を端に明け渡す
- **右島**: メディア・音量・ネットワーク・システム系のマシン世界
- `clock#date`: `ja_JP.UTF-8` で「 08/03 (日)」を常時表示。ホバーの年間カレンダーとクリック切替は本体clockに残し、こちらは表示専用
- 左右margin: 島が独立したため400px→6px(margin-topと揃えた浮きの名残)に戻した

### weather.sh の新規実装(#563)
左島の `custom/weather` は設定だけ存在してスクリプト実体が無い「絵に描いた計器」だった。wttr.in から `%c|%t|%C|%f|%h|%w|%l` を1リクエストで取得し `jq -cn` で return-type: json を出力する weather.sh を実装(bring_status.sh の流儀に準拠)。表示は「🌦️ +23°C」、ツールチップに天況・体感・湿度・風。取得失敗時は text 空 / exit 0 でモジュール非表示に落ちるだけ。場所は `WAYBAR_WEATHER_LOCATION` で固定可(未指定はIPジオロケーション)。動作確認済み(成功系・失敗系)。

「左端が見にくい」を、左端に読む情報を置かないことで解決する設計。実機確認済み(nix:switch → SIGUSR2、waybar生存・パース警告なし)。

`config.jsonc` はフォーマッタによる2スペース化・末尾カンマ付与を含む(リポジトリ規約の2スペースに準拠、waybarのjsoncppは末尾カンマ許容を実機確認済み)。

## [optional footer(s)]
Closes #559
Closes #563
Refs: #558, #560, #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)