### PR TITLE
fix(waybar): 存在しなかったweather.shを実装し天気モジュールを初めて動かす

### DIFF
--- a/.config/waybar/scripts/weather.sh
+++ b/.config/waybar/scripts/weather.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Waybar 計器モジュール custom/weather (#563)
+# 左島(現実世界の窓)に現在の天気を表示する。wttr.in から観測値を1リクエストで取得し、
+# return-type: json 形式で1行出力して終了する(常駐しない — interval 1800 で再実行)。
+# Waybar gauge module custom/weather (#563): shows current conditions on the left
+# island (the window to the real world). Fetches one reading from wttr.in in a
+# single request, emits one return-type: json line, and exits (not resident —
+# waybar reruns it via interval 1800).
+
+set -euo pipefail
+
+# 場所未指定 = wttr.in の IP ジオロケーション任せ。固定したい時は
+# WAYBAR_WEATHER_LOCATION(例: Tokyo)で上書きする。
+# Empty location = wttr.in's IP geolocation; override with
+# WAYBAR_WEATHER_LOCATION (e.g. "Tokyo") to pin a place.
+location="${WAYBAR_WEATHER_LOCATION:-}"
+
+# 全項目を1リクエストで取り | で分解する: 天気アイコン|気温|天況|体感|湿度|風|場所
+# One request for every field, split on "|": icon|temp|condition|feels|humidity|wind|place
+if ! reading="$(curl -sf --max-time 10 "https://wttr.in/${location}?format=%c|%t|%C|%f|%h|%w|%l")"; then
+  # 取得失敗は「表示するものがない」扱い(text が空だとモジュール非表示)。
+  # exec-if の ping を通過した後の一時的な失敗もここで握る。
+  # A failed fetch means "nothing to display" (empty text hides the module),
+  # covering transient errors that slip past the exec-if ping.
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
+
+IFS='|' read -r icon temp cond feels humidity wind place <<<"$reading"
+
+# wttr.in の絵文字アイコンは余白(パディング用スペース)を含むので除去する
+# The emoji icon from wttr.in carries padding spaces — strip them.
+icon="${icon// /}"
+
+# alt は config 側の format-alt "{alt}: {}"(右クリック)で場所名として使われる
+# alt feeds the config's format-alt "{alt}: {}" (right-click) as the place name.
+jq -cn \
+  --arg text "${icon} ${temp}" \
+  --arg alt "${place}" \
+  --arg tooltip "${place}: ${cond} ${temp} (体感 ${feels}) 湿度 ${humidity} 風 ${wind}" \
+  '{text: $text, alt: $alt, tooltip: $tooltip}'


### PR DESCRIPTION
## [optional body]
`custom/weather` は設定だけ存在してスクリプト実体が無い「絵に描いた計器」だった(#563)。exec-if の `ping wttr.in` は通るため、エラーも出ず無言で空表示が続いていた。

- wttr.in から `%c|%t|%C|%f|%h|%w|%l`(アイコン/気温/天況/体感/湿度/風/場所)を1リクエストで取得し、`jq -cn` で return-type: json の1行を出力して終了する(常駐せず interval 1800 で再実行)
- 表示は「🌦️ +23°C」、右クリック(format-alt)で場所名付き、ツールチップに天況・体感・湿度・風
- 取得失敗時は text 空で exit 0(モジュール非表示に落ちるだけで waybar は無傷)
- 場所は `WAYBAR_WEATHER_LOCATION` で固定可能。未指定は IP ジオロケーション
- 実装スタイルは bring_status.sh に合わせた(bash / `set -euo pipefail` / `jq -cn` / バイリンガルコメント)

動作確認済み: 成功系(実データでJSON出力)・失敗系(不正な場所指定で空text/exit 0)。新規ファイルのみのため #561 と競合しない。マージ後は `nix:switch` で `.config/waybar` ディレクトリリンク経由で配備される。

## [optional footer(s)]
Closes #563
Refs: #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)