### PR TITLE
feat(waybar): 左島に現実世界の計器 — 月相・日の出入りと祝日カウントダウンを追加する

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -15,7 +15,13 @@
   // 中央集約(#559 案A): 「読む」情報(workspaces計器盤)は視野中心、「見る」情報(時計・日付)は左端へ
   // Centralized layout (#559 plan A): information you READ (workspaces gauge) sits at the
   // visual center; information you GLANCE at (clock, date) goes to the far-left zone.
-  "modules-left": ["clock", "clock#date", "custom/weather"],
+  "modules-left": [
+    //"clock#date",
+    "clock",
+    "custom/weather",
+    "custom/sun_moon",
+    "custom/holiday",
+  ],
   "modules-center": [
     "hyprland/workspaces",
     "hyprland/submap",
@@ -175,6 +181,17 @@
     "tooltip": false,
   },
 
+  // 祝日カウントダウン(#562): holidays-jp API を日次キャッシュ。ネットワーク断は
+  // スクリプト側が古いキャッシュ/非表示で吸収するので exec-if は持たない
+  // Holiday countdown (#562): holidays-jp API with a daily cache. The script itself
+  // absorbs network failures (stale cache / hidden), so no exec-if gate here.
+  "custom/holiday": {
+    "format": "{}",
+    "return-type": "json",
+    "interval": 3600,
+    "exec": "~/.config/waybar/scripts/holiday.sh",
+  },
+
   "custom/weather": {
     "format": "{}",
     "format-alt": "{alt}: {}",
@@ -182,6 +199,16 @@
     "interval": 1800,
     "return-type": "json",
     "exec": "~/.config/waybar/scripts/weather.sh",
+    "exec-if": "ping wttr.in -c1",
+  },
+
+  // 月相+日の出入り(#562): weather.sh と同じ wttr.in インフラに乗る空の計器
+  // Moon phase + sunrise/sunset (#562): a sky gauge riding the same wttr.in infra as weather.sh.
+  "custom/sun_moon": {
+    "format": "{}",
+    "return-type": "json",
+    "interval": 1800,
+    "exec": "~/.config/waybar/scripts/sun_moon.sh",
     "exec-if": "ping wttr.in -c1",
   },
 

--- a/.config/waybar/scripts/holiday.sh
+++ b/.config/waybar/scripts/holiday.sh
@@ -29,12 +29,20 @@ if [ ! -s "$cache_file" ]; then
   exit 0
 fi
 
-# 今日以降で最初の祝日を1件取り出す(ISO日付なので文字列比較でそのまま並ぶ)
+# 今日以降で最初の祝日を1件取り出す(ISO日付なので文字列比較でそのまま並ぶ)。
+# 壊れたキャッシュはパース失敗で set -e ごと死なないよう捨てて非表示に落とす
+# (次回実行が再取得する)。bring_status.sh と同じ防御パターン。
 # Pick the first holiday on/after today (ISO dates sort lexicographically).
-next="$(jq -r --arg today "$today" '
+# A corrupt cache must not kill the script via set -e: drop it and hide the
+# module (the next run re-fetches). Same defensive pattern as bring_status.sh.
+if ! next="$(jq -r --arg today "$today" '
   to_entries | map(select(.key >= $today)) | sort_by(.key) | first
   | if . == null then "" else "\(.key)|\(.value)" end
-' "$cache_file")"
+' "$cache_file" 2>/dev/null)"; then
+  rm -f "$cache_file"
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
 
 # データの終端(来年分が未公開の年末など)に達したら非表示
 # Past the end of the dataset (e.g. year-end before next year is published) -> hide.

--- a/.config/waybar/scripts/holiday.sh
+++ b/.config/waybar/scripts/holiday.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Waybar 計器モジュール custom/holiday (#562)
+# 左島(現実世界の窓)に次の祝日カウントダウンを表示する。holidays-jp API の年次データを
+# 日次キャッシュし、今日以降で最初の祝日を1件選んで return-type: json を1行出力する。
+# Waybar gauge module custom/holiday (#562): countdown to the next Japanese national
+# holiday on the left island. Caches the holidays-jp API data daily, picks the first
+# holiday on/after today, and emits one return-type: json line.
+
+set -euo pipefail
+
+api_url="https://holidays-jp.github.io/api/v1/date.json"
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/waybar"
+cache_file="${cache_dir}/holidays_jp.json"
+mkdir -p "$cache_dir"
+
+today="$(date +%Y-%m-%d)"
+
+# キャッシュの鮮度は mtime の日付で判定(日次更新)。取得失敗時は古いキャッシュで続行する
+# Cache freshness = mtime date (daily refresh). On fetch failure keep serving the old cache.
+if [ ! -s "$cache_file" ] || [ "$(date -r "$cache_file" +%Y-%m-%d)" != "$today" ]; then
+  curl -sf --max-time 10 "$api_url" -o "${cache_file}.tmp" && mv "${cache_file}.tmp" "$cache_file" || true
+fi
+
+# キャッシュも無い(初回起動でオフライン等) → 非表示
+# No cache at all (first run while offline, etc.) -> hide the module.
+if [ ! -s "$cache_file" ]; then
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
+
+# 今日以降で最初の祝日を1件取り出す(ISO日付なので文字列比較でそのまま並ぶ)
+# Pick the first holiday on/after today (ISO dates sort lexicographically).
+next="$(jq -r --arg today "$today" '
+  to_entries | map(select(.key >= $today)) | sort_by(.key) | first
+  | if . == null then "" else "\(.key)|\(.value)" end
+' "$cache_file")"
+
+# データの終端(来年分が未公開の年末など)に達したら非表示
+# Past the end of the dataset (e.g. year-end before next year is published) -> hide.
+if [ -z "$next" ]; then
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
+
+IFS='|' read -r hdate hname <<<"$next"
+days_until=$(( ($(date -d "$hdate" +%s) - $(date -d "$today" +%s)) / 86400 ))
+
+# ツールチップ用の日付(例: 8/11(火))
+# Human date for the tooltip (e.g. 8/11(火)).
+hdate_human="$(LC_TIME=ja_JP.UTF-8 date -d "$hdate" "+%-m/%-d(%a)")"
+
+# バーに出す1行の文言を決める。days=0 は今日が祝日。
+# Decide the one-line text for the bar. days=0 means today IS the holiday.
+format_countdown() {
+  local days="$1" name="$2"
+  case "$days" in
+    0)  echo "今日は 🎌 ${name} 🎌" ;;
+    1)  echo "明日は 🎌 ${name} 🎌" ;;
+    *)  echo "${days}日後は 🎌 ${name} 🎌" ;;
+  esac
+}
+
+text="$(format_countdown "$days_until" "$hname")"
+
+jq -cn \
+  --arg text "$text" \
+  --arg tooltip "次の祝日: ${hdate_human} ${hname}" \
+  '{text: $text, tooltip: $tooltip}'

--- a/.config/waybar/scripts/holiday.sh
+++ b/.config/waybar/scripts/holiday.sh
@@ -19,7 +19,14 @@ today="$(date +%Y-%m-%d)"
 # キャッシュの鮮度は mtime の日付で判定(日次更新)。取得失敗時は古いキャッシュで続行する
 # Cache freshness = mtime date (daily refresh). On fetch failure keep serving the old cache.
 if [ ! -s "$cache_file" ] || [ "$(date -r "$cache_file" +%Y-%m-%d)" != "$today" ]; then
-  curl -sf --max-time 10 "$api_url" -o "${cache_file}.tmp" && mv "${cache_file}.tmp" "$cache_file" || true
+  # 取得成功時のみ tmp を本採用(アトミック更新)、失敗時は部分書き込みの tmp を掃除
+  # Adopt the tmp file only on a successful fetch (atomic update); clean up the
+  # partially written tmp on failure.
+  if curl -sf --max-time 10 "$api_url" -o "${cache_file}.tmp"; then
+    mv -f "${cache_file}.tmp" "$cache_file"
+  else
+    rm -f "${cache_file}.tmp"
+  fi
 fi
 
 # キャッシュも無い(初回起動でオフライン等) → 非表示

--- a/.config/waybar/scripts/sun_moon.sh
+++ b/.config/waybar/scripts/sun_moon.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Waybar 計器モジュール custom/sun_moon (#562)
+# 左島(現実世界の窓)に月相と日の出/日の入りを表示する。weather.sh と同じく wttr.in
+# から1リクエストで取得し、return-type: json を1行出力して終了する(interval 再実行)。
+# Waybar gauge module custom/sun_moon (#562): moon phase plus sunrise/sunset on the
+# left island (the window to the real world). Like weather.sh, one wttr.in request,
+# one return-type: json line, then exit (waybar reruns via interval).
+
+set -euo pipefail
+
+# weather.sh と同じ場所解決を使う(空 = IP ジオロケーション)
+# Same place resolution as weather.sh (empty = IP geolocation).
+location="${WAYBAR_WEATHER_LOCATION:-}"
+
+# 月相絵文字|月齢|夜明け|日の出|日の入り|日暮れ を1リクエストで取る
+# One request for moon-phase emoji|moon day|dawn|sunrise|sunset|dusk.
+if ! reading="$(curl -sf --max-time 10 "https://wttr.in/${location}?format=%m|%M|%D|%S|%s|%d")"; then
+  # 取得失敗は「表示するものがない」扱い(weather.sh と同じ振る舞い)
+  # A failed fetch means "nothing to display" (same behavior as weather.sh).
+  jq -cn '{text: "", tooltip: ""}'
+  exit 0
+fi
+
+IFS='|' read -r moon moonday dawn sunrise sunset dusk <<<"$reading"
+moon="${moon// /}"
+
+# wttr.in の時刻は HH:MM:SS — バー上は分までで充分なので秒を落とす
+# wttr.in returns HH:MM:SS; minutes are enough on the bar, drop the seconds.
+sunrise="${sunrise%:*}"
+sunset="${sunset%:*}"
+dawn="${dawn%:*}"
+dusk="${dusk%:*}"
+
+jq -cn \
+  --arg text "${moon} 🌅${sunrise} 🌇${sunset}" \
+  --arg tooltip "月齢 ${moonday} / 夜明け ${dawn} → 日の出 ${sunrise} / 日の入り ${sunset} → 日暮れ ${dusk}" \
+  '{text: $text, tooltip: $tooltip}'

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -102,6 +102,8 @@ window#waybar.hidden {
 #pulseaudio,
 #custom-media,
 #custom-weather,
+#custom-sun_moon,
+#custom-holiday,
 #custom-power,
 #tray,
 #mode,


### PR DESCRIPTION
## [optional body]
三島構成(#561)の左島「現実世界の窓」を、空と暦の計器で拡充する。

### custom/sun_moon(空の計器)
- wttr.in から `%m|%M|%D|%S|%s|%d`(月相絵文字/月齢/夜明け/日の出/日の入り/日暮れ)を1リクエストで取得
- バー表示は「🌖 🌅04:48 🌇18:43」、ツールチップに月齢と薄明の時系列
- weather.sh と同じインフラ(interval 1800 / exec-if ping / 失敗時は空textで非表示)

### custom/holiday(暦の計器)
- holidays-jp API(https://holidays-jp.github.io/)を日次キャッシュし、今日以降の直近祝日を1件選出
- 文言は当日/明日/N日後の case 分岐:「今日は 🎌 山の日 🎌」「明日は 🎌 山の日 🎌」「8日後は 🎌 山の日 🎌」— 全分岐を同一骨格の文体に揃え、島幅の揺れを数字の桁だけに抑える
- オフライン時は古いキャッシュで続行、キャッシュ皆無・データ終端(翌年分未公開の年末)は自動非表示
- exec-if は持たない(ネットワーク断はスクリプト側で吸収する設計のため)

### その他
- 左島の並びは 時計→天気→空→祝日 に整理、`clock#date` は一旦コメントアウト(定義は温存)
- 六曜(custom/rokuyo)は本Issueのスコープから切り出し、別リポジトリの自作Rust CLI として実装予定(#562 のコメント参照)。CLI完成後にwaybar統合を改めてIssue化する

実機確認済み(スクリプト単体の成功系/失敗系 + nix:switch → SIGUSR2 でバー表示)。

## [optional footer(s)]
Closes #562
Refs: #561, #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)