### PR TITLE
feat(flake): GitHub Copilot CLI を 1.0.78 に更新する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
           (final: prev: {
             github-copilot-cli = prev.github-copilot-cli.overrideAttrs (old:
               let
-                copilotVersion = "1.0.65";
+                copilotVersion = "1.0.78";
               in
               {
                 version = copilotVersion;
@@ -38,7 +38,7 @@
                 # and native binaries live in the platform-specific release asset.
                 src = prev.fetchzip {
                   url = "https://github.com/github/copilot-cli/releases/download/v${copilotVersion}/github-copilot-${copilotVersion}-linux-x64.tgz";
-                  hash = "sha256-4Af5u4K5xg76RCLu3jHY1+IxWMosu7d8fmwJy0zgwB4=";
+                  hash = "sha256-2tQ3dIamXBErYElEd8dgY+Iz5OgGY7WvcdnoDIB0hWM=";
                 };
                 # nixpkgs 側の derivation が npm tarball 前提の sourceRoot = "package" を
                 # 設定するようになったが、GitHub Release アセットはルート直下にファイルを
@@ -64,6 +64,20 @@
                   "libpng16.so.16"
                   "libpipewire-0.3.so.0"
                   "libei.so.1"
+                  # v1.0.78 で追加された webview 機能 (@webviewjs/webview) 用の GTK/WebKit
+                  # スタック。CLI 利用では webview 機能を使わないため無視する。
+                  # GTK/WebKit stack for the webview feature (@webviewjs/webview) added
+                  # in v1.0.78. Unused in CLI usage, so ignore it.
+                  "libwebkit2gtk-4.1.so.0"
+                  "libgtk-3.so.0"
+                  "libgdk-3.so.0"
+                  "libcairo.so.2"
+                  "libgdk_pixbuf-2.0.so.0"
+                  "libsoup-3.0.so.0"
+                  "libjavascriptcoregtk-4.1.so.0"
+                  "libwayland-client.so.0"
+                  "libdbus-1.so.3"
+                  "libxdo.so.3"
                 ];
                 # npm version may not match internal binary version string
                 doInstallCheck = false;


### PR DESCRIPTION
## 概要
- overlay でピン留めしている `copilotVersion` を `1.0.65` → `1.0.78` に更新
- `fetchzip` の `hash` を新 tarball のものに更新
- v1.0.78 で追加された webview 機能 (`@webviewjs/webview`) 用の GTK/WebKit 系共有ライブラリが `autoPatchelfHook` で解決できずビルドが失敗したため、`autoPatchelfIgnoreMissingDeps` に既存方針(CLI 利用では不要な GUI/メディア機能用ライブラリを無視する)を踏襲して追記

## 背景
nixpkgs の `github-copilot-cli` が遅い(1.0.61)ため、公式リリースの tarball を直接ピン留めしている。upstream は 2026-08-03 に安定版 v1.0.78 をリリース済み。

## 確認内容
- `mise run nix:check`(`nix flake check`)成功
- `nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.homeConfigurations.archie.pkgs.github-copilot-cli'` でビルド成功
- ビルド結果の `bin/copilot --version` を直接実行し、`GitHub Copilot CLI 1.0.78.` を確認

## 補足(webview機能の無視について)
v1.0.78 で `github-copilot-cli` パッケージ内に `@webviewjs/webview` というネイティブモジュールが同梱されるようになった。GitHub Copilot CLI 本体のドキュメント上の詳細は未確認だが、パッケージ構成から見て今後のGUI連携(ブラウザベースのUI表示等)向けの機能と推測される。CLI 用途では使用しないため、既存の `autoPatchelfIgnoreMissingDeps` の方針(スクリーンキャプチャ/入力系ライブラリの無視)を踏襲し、GTK/WebKit スタックの共有ライブラリ(`libwebkit2gtk-4.1.so.0` 等10個)を無視リストに追加した。`buildInputs` に追加してフル解決する代替案もあったが、closure サイズが大きく増える割に CLI 用途でのメリットがないため見送った(司令塔と協議のうえA案を採用)。

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)