### PR TITLE
feat(mise): SOPS age 鍵管理タスクを追加する

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -291,7 +291,7 @@ bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
 item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
 umask 077
 mkdir -p "$(dirname "$keyfile")"
-bw get attachment keys.txt --itemid "$item_id" --output "$keyfile"
+bw get attachment "keys.txt" --itemid "$item_id" --output "$keyfile"
 chmod 600 "$keyfile"
 echo "Restored. Public key:"
 age-keygen -y "$keyfile"
@@ -308,11 +308,11 @@ item=${AGE_BW_ITEM:-sops-age-key}
 # Self-unlock when the vault is locked — no shell-specific export needed
 bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
 item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
-# 同名の既存添付は置き換える / Replace an existing attachment of the same name
-old=$(bw get item "$item" | jq -r '.attachments[]? | select(.fileName=="keys.txt") | .id')
-if [ -n "$old" ]; then
+# 同名の既存添付は全て削除して置き換える (重複添付にも耐性を持たせる)
+# Replace all existing attachments of the same name — robust against duplicates
+for old in $(bw get item "$item" | jq -r '.attachments[]? | select(.fileName=="keys.txt") | .id'); do
   bw delete attachment "$old" --itemid "$item_id"
-fi
+done
 bw create attachment --file "$keyfile" --itemid "$item_id" > /dev/null
 bw sync > /dev/null
 echo "age key attached to Bitwarden item '$item'."

--- a/.mise.toml
+++ b/.mise.toml
@@ -252,6 +252,73 @@ echo "Expiry extended. Re-register public.asc on GitHub, then run 'mise run gpg:
 """
 
 # =============================================================================
+# SOPS age 鍵管理 / SOPS age key management (hexhive Secrets)
+# =============================================================================
+
+[tasks."age:keygen"]
+description = "Generate the SOPS age keypair at ~/.config/sops/age/keys.txt (refuses to overwrite)"
+run = """
+set -euo pipefail
+keyfile="$HOME/.config/sops/age/keys.txt"
+# 既存鍵の上書きは拒否 — ローテーションは意図的な手作業に限る
+# Never overwrite an existing key — rotation must be a deliberate manual act
+[ ! -f "$keyfile" ] || { echo "Key already exists at $keyfile — refusing to overwrite." >&2; exit 1; }
+umask 077
+mkdir -p "$(dirname "$keyfile")"
+age-keygen -o "$keyfile"
+echo "Public key (paste into .sops.yaml recipients):"
+age-keygen -y "$keyfile"
+echo "Next: create a Bitwarden secure note '${AGE_BW_ITEM:-sops-age-key}', then run 'mise run age:bw:push'."
+"""
+
+[tasks."age:status"]
+description = "Show the public key derived from the local age key (for .sops.yaml updates)"
+run = """
+set -euo pipefail
+keyfile="$HOME/.config/sops/age/keys.txt"
+[ -f "$keyfile" ] || { echo "No key at $keyfile — run 'mise run age:keygen' (new) or 'mise run age:import' (restore)." >&2; exit 1; }
+age-keygen -y "$keyfile"
+"""
+
+[tasks."age:import"]
+description = "Restore the age key from Bitwarden to ~/.config/sops/age/keys.txt if absent (item: $AGE_BW_ITEM or 'sops-age-key')"
+run = """
+set -euo pipefail
+keyfile="$HOME/.config/sops/age/keys.txt"
+item=${AGE_BW_ITEM:-sops-age-key}
+[ ! -f "$keyfile" ] || { echo "Key already present at $keyfile — nothing to do."; exit 0; }
+bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
+item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
+umask 077
+mkdir -p "$(dirname "$keyfile")"
+bw get attachment keys.txt --itemid "$item_id" --output "$keyfile"
+chmod 600 "$keyfile"
+echo "Restored. Public key:"
+age-keygen -y "$keyfile"
+"""
+
+[tasks."age:bw:push"]
+description = "Upload ~/.config/sops/age/keys.txt to Bitwarden as an attachment (item: $AGE_BW_ITEM or 'sops-age-key')"
+run = """
+set -euo pipefail
+keyfile="$HOME/.config/sops/age/keys.txt"
+item=${AGE_BW_ITEM:-sops-age-key}
+[ -f "$keyfile" ] || { echo "No key at $keyfile — run 'mise run age:keygen' first." >&2; exit 1; }
+# ロック中ならこの場で解錠 (マスターパスワードを対話入力)。シェル側の export は不要
+# Self-unlock when the vault is locked — no shell-specific export needed
+bw unlock --check > /dev/null 2>&1 || export BW_SESSION=$(bw unlock --raw)
+item_id=$(bw get item "$item" | jq -r .id) || { echo "Item '$item' not found — create a secure note named '$item' in Bitwarden first." >&2; exit 1; }
+# 同名の既存添付は置き換える / Replace an existing attachment of the same name
+old=$(bw get item "$item" | jq -r '.attachments[]? | select(.fileName=="keys.txt") | .id')
+if [ -n "$old" ]; then
+  bw delete attachment "$old" --itemid "$item_id"
+fi
+bw create attachment --file "$keyfile" --itemid "$item_id" > /dev/null
+bw sync > /dev/null
+echo "age key attached to Bitwarden item '$item'."
+"""
+
+# =============================================================================
 # Hyprland プラグイン管理 / Hyprland plugin management
 # =============================================================================
 

--- a/docs/reference/mise-tasks.md
+++ b/docs/reference/mise-tasks.md
@@ -99,6 +99,19 @@ mise タスクではないが、あわせてよく使うコマンド:
 
 ---
 
+## SOPS age Tasks
+
+hexhive の Secrets(SOPS + age)で使う鍵の管理。秘密鍵の正本は Bitwarden、ローカルの置き場は `~/.config/sops/age/keys.txt`(sops が自動参照するパス)。GPG タスクと同じ「Bitwarden 添付 + fetch-if-absent」方式。
+
+| Task | Description |
+|------|-------------|
+| `mise run age:keygen` | age 鍵ペアを新規生成(既存鍵があれば拒否)+ 公開鍵を表示 |
+| `mise run age:status` | ローカル鍵から公開鍵を表示(`.sops.yaml` 更新用) |
+| `mise run age:import` | 新端末で Bitwarden から鍵を復元(ローカルにあれば何もしない) |
+| `mise run age:bw:push` | 鍵を Bitwarden アイテム(既定: `sops-age-key`)の添付としてアップロード |
+
+---
+
 ## Usage Examples
 
 ```bash


### PR DESCRIPTION
## [optional body]

hexhive の Secrets(SOPS + age)で使う鍵のライフサイクルを mise タスク化する。

| Task | Description |
|------|-------------|
| `age:keygen` | age 鍵ペアを新規生成(既存鍵があれば拒否)+ 公開鍵を表示 |
| `age:status` | ローカル鍵から公開鍵を表示(`.sops.yaml` 更新用) |
| `age:import` | 新端末で Bitwarden から鍵を復元(ローカルにあれば何もしない) |
| `age:bw:push` | 鍵を Bitwarden アイテム(既定: `sops-age-key`)の添付としてアップロード |

設計方針:

- 秘密鍵の正本は Bitwarden(クラスタ外)。クラスタを直す鍵がクラスタに住むと DR の循環が閉じるため
- 既存の `gpg:*` タスク(#437)と同じ「Bitwarden 添付 + fetch-if-absent」方式に統一
- ローカル置き場は `~/.config/sops/age/keys.txt`(sops が自動参照する既定パス)、`umask 077` + `chmod 600` で作成
- 鍵ローテーションは意図的な手作業に限るため、`age:keygen` は既存鍵の上書きを拒否する

依存ツール(`age` / `sops` / `bitwarden-cli` / `jq`)は導入済みのため nix 側の変更はなし(#573 で追加済み)。

## [optional footer(s)]

Refs: #573 (hexhive クラスタ運用ツール導入), #437 (gpg:* タスクの型)

🤖 Generated with [Claude Code](https://claude.com/claude-code)