### PR TITLE
fix(fish): mise activate を化石バイナリ直書きから PATH 解決に変更する

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -84,4 +84,4 @@ starship init fish | source
 # set -gx VOLTA_HOME "$HOME/.volta"
 # set -gx PATH "$VOLTA_HOME/bin" $PATH
 
-~/.local/bin/mise activate fish | source
+mise activate fish | source

--- a/docs/explanation/shell-boot-flow.md
+++ b/docs/explanation/shell-boot-flow.md
@@ -159,7 +159,7 @@ if type -q bat; alias cat 'bat'; end
 starship init fish | source
 
 # バージョン管理
-~/.local/bin/mise activate fish | source
+mise activate fish | source
 ```
 
 ---


### PR DESCRIPTION
## 概要
`.config/fish/config.fish:87` の mise activate 行が、Nix 管理外の化石バイナリ `~/.local/bin/mise` を絶対パスで直書きしていた問題を修正する。`starship init fish | source` と同じ流儀で PATH 解決に揃えた。

Closes #584

## 変更内容
- `.config/fish/config.fish:87`: `~/.local/bin/mise activate fish | source` → `mise activate fish | source`
- `docs/explanation/shell-boot-flow.md:162`: 同じ抜粋を同期更新

## 確認したこと
- `fish -n .config/fish/config.fish` が通ることを確認
- `grep -rn 'local/bin/mise' .config docs nix home.nix` が 0 件になったことを確認
- `~/.nix-profile/bin/mise activate fish` の出力が正常に生成されることを確認済み(ライブ環境は読み取りのみ、変更なし)

## merge 後の手順(ユーザー作業)
1. `mise run nix:switch`
2. `rm ~/.local/bin/mise`(Nix 管理外の化石を掃除。`docs/how-to/install-unmanaged-tools.md` の手順どおり)
3. `which mise` が `~/.nix-profile/bin/mise` を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjAqwd6QyYQGho1NHm8FAU
