### PR TITLE
fix(fish): ~/.local/bin を config.fish で PATH に明示追加する

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -37,6 +37,11 @@ set -x PATH $HOME/.cargo/bin $PATH
 # set pulimi path
 set -x PATH $HOME/.pulumi/bin $PATH
 
+# set ~/.local/bin path (native installer 管理ツール: claude 等 / native-installer tools such as claude)
+# 以前は化石 mise の activate が副作用で入れていた。fish_add_path は冪等なので入れ子シェルでも重複しない (#593)
+# Formerly injected as a side effect of the fossil mise activate; fish_add_path is idempotent across nested shells (#593)
+fish_add_path --path $HOME/.local/bin
+
 
 # set exa alias
 if type -q test eza

--- a/docs/explanation/shell-boot-flow.md
+++ b/docs/explanation/shell-boot-flow.md
@@ -83,7 +83,7 @@ Fish で作業
 ┌─────────────────────────────────────────────────────────┐
 │  config.fish                                            │
 │  ├── ロケール設定 (LANG, LC_CTYPE)                       │
-│  ├── PATH 設定 (cargo, go, pyenv, etc.)                 │
+│  ├── PATH 設定 (~/.local/bin, cargo, go, etc.)          │
 │  ├── エイリアス設定 (vim, rm, ls, cat, ps)              │
 │  ├── プロンプト設定 (starship)                          │
 │  └── ツール有効化 (mise)                                │
@@ -149,6 +149,7 @@ alias rm 'rm -i'
 
 # PATH 設定
 set -x PATH $HOME/.cargo/bin $PATH
+fish_add_path --path $HOME/.local/bin   # claude 等 native installer 管理ツール
 set -x GOPATH $HOME/go
 
 # モダン CLI ツール

--- a/nix/modules/tmux.nix
+++ b/nix/modules/tmux.nix
@@ -15,7 +15,7 @@
   home.file.".tmux.conf".source = ../../.config/tmux/tmux.conf;
 
   # Claude Code popup launcher (per-directory persistent session)
-  # ~/.local/bin is already on PATH; tmux.conf binds it to prefix + C.
+  # ~/.local/bin is put on PATH by config.fish (fish_add_path, #593); tmux.conf binds it to prefix + C.
   home.file.".local/bin/tmux-claude-popup" = {
     source = ../../.config/tmux/scripts/tmux-claude-popup;
     executable = true;


### PR DESCRIPTION
## 概要
`claude` コマンドが新しいシェルで見つからなくなった問題の修正。`~/.local/bin`(native installer が claude の symlink を置く場所)がリポジトリのどこにも PATH 宣言されておらず、化石 mise(`~/.local/bin/mise`)の `activate` が「自分のバイナリの置き場を PATH に prepend する」副作用で載っていただけだった。#585 で Nix 版 mise(`~/.nix-profile/bin`、既に PATH 内)に切り替えた瞬間に注入が消えた。

Closes #593

## 変更内容
- `.config/fish/config.fish`: PATH 設定ブロックに `fish_add_path --path $HOME/.local/bin` を追加(冪等なので入れ子シェルで重複しない)
- `nix/modules/tmux.nix`: 「`~/.local/bin` is already on PATH」コメントを実態(config.fish で追加)に合わせて修正
- `docs/explanation/shell-boot-flow.md`: PATH 設定の説明と config.fish 抜粋に `~/.local/bin` を追記

## 設計判断
- 宣言の置き場は A(`home.sessionPath`、Nix 側)と B(config.fish)を比較し、B を採用。shell-boot-flow.md の「PATH 設定は config.fish で管理」方針との整合を優先した(比較は #593 の修正案を参照)
- 位置は従来どおり prepend。`~/.local/bin` を末尾に回して「化石が Nix 版を隠せない」構造にする案は挙動変更を伴うため本 PR には含めない(別 Issue 候補)

## 確認したこと
- `fish -n .config/fish/config.fish` 通過
- config.fish を 2 回 source しても `$PATH` 内の `~/.local/bin` は 1 つ(冪等性)
- `mise run nix:switch` 後、新しい fish および 2 段ネストした fish で `which claude` → `~/.local/bin/claude`、`claude --version` → 2.1.267
- switch 前に起動した既存 pane は残留 env のまま(`exec fish` で復旧)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjkLhrX116RbXk6TD7bdML
